### PR TITLE
feat(budgets, categories): add plan vs actual budgets with configurable periods and user-defined categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { TransactionsProvider } from './context/TransactionsContext';
 import { AccountsProvider } from './context/AccountsContext';
 import { BudgetsProvider } from './context/BudgetsContext';
+import { CategoriesProvider } from './context/CategoriesContext';
 import { FilterPreferencesProvider } from './context/FilterPreferencesContext';
 import ProtectedRoute from './components/app/ProtectedRoute';
 import Home from './pages/Home';
@@ -13,33 +14,35 @@ function App() {
 	return (
 		<ThemeProvider>
 			<FilterPreferencesProvider>
-			<TransactionsProvider>
-				<AccountsProvider>
-					<BudgetsProvider>
-						<Router>
-							<Routes>
-								<Route path="/" element={<Home />} />
-								<Route
-									path="/dashboard"
-									element={
-										<ProtectedRoute>
-											<Dashboard />
-										</ProtectedRoute>
-									}
-								/>
-								<Route
-									path="/accounts/:accountId"
-									element={
-										<ProtectedRoute>
-											<AccountDetailPage />
-										</ProtectedRoute>
-									}
-								/>
-							</Routes>
-						</Router>
-					</BudgetsProvider>
-				</AccountsProvider>
-			</TransactionsProvider>
+				<CategoriesProvider>
+					<TransactionsProvider>
+						<AccountsProvider>
+							<BudgetsProvider>
+								<Router>
+									<Routes>
+										<Route path="/" element={<Home />} />
+										<Route
+											path="/dashboard"
+											element={
+												<ProtectedRoute>
+													<Dashboard />
+												</ProtectedRoute>
+											}
+										/>
+										<Route
+											path="/accounts/:accountId"
+											element={
+												<ProtectedRoute>
+													<AccountDetailPage />
+												</ProtectedRoute>
+											}
+										/>
+									</Routes>
+								</Router>
+							</BudgetsProvider>
+						</AccountsProvider>
+					</TransactionsProvider>
+				</CategoriesProvider>
 			</FilterPreferencesProvider>
 		</ThemeProvider>
 	);

--- a/src/components/app/SettingsModal.tsx
+++ b/src/components/app/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { FiSettings, FiDatabase, FiFilter } from 'react-icons/fi';
+import { FiSettings, FiDatabase, FiFilter, FiTag, FiEdit2, FiTrash2, FiPlus } from 'react-icons/fi';
 import { useTheme } from '../../context/ThemeContext';
 import { useAuth } from '../../hooks/useAuth';
 import { signOut } from 'firebase/auth';
@@ -15,7 +15,9 @@ import {
 import { Button } from '../app/ui/button';
 import { Switch } from '../app/ui/switch';
 import { Label } from '../app/ui/label';
+import { Input } from '../app/ui/input';
 import { useTransactionsContext } from '@/context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { useFilterPreferences, FilterPreferences } from '../../context/FilterPreferencesContext';
 
 interface SettingsModalProps {
@@ -24,7 +26,7 @@ interface SettingsModalProps {
 	onImport?: (file: File) => Promise<void> | void;
 	onExportCSV?: () => void;
 	onExportJSON?: () => void;
-	initialTab?: 'general' | 'data' | 'filters';
+	initialTab?: 'general' | 'data' | 'filters' | 'categories';
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -36,13 +38,27 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 	initialTab,
 }) => {
 	const { deleteAllTransactions } = useTransactionsContext();
+	const {
+		categories,
+		loading: categoriesLoading,
+		addCategory,
+		renameCategory,
+		deleteCategory,
+	} = useCategoriesContext();
 	const { theme, setTheme } = useTheme();
 	const { prefs, setFilterVisible } = useFilterPreferences();
 	const [localTheme, setLocalTheme] = useState(theme);
 	const { currentUser } = useAuth();
 	const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
 	const [deleteAllConfirmOpen, setDeleteAllConfirmOpen] = useState(false);
-	const [activeTab, setActiveTab] = useState<'general' | 'data' | 'filters'>(initialTab ?? 'general');
+	const [activeTab, setActiveTab] = useState<'general' | 'data' | 'filters' | 'categories'>(
+		initialTab ?? 'general'
+	);
+	const [newCategoryLabel, setNewCategoryLabel] = useState('');
+	const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+	const [editingCategoryLabel, setEditingCategoryLabel] = useState('');
+	const [categoryError, setCategoryError] = useState('');
+	const [categoryBusy, setCategoryBusy] = useState(false);
 
 	useEffect(() => {
 		setLocalTheme(theme);
@@ -51,6 +67,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 	useEffect(() => {
 		if (open) setActiveTab(initialTab ?? 'general');
 	}, [open, initialTab]);
+
+	useEffect(() => {
+		if (!open) {
+			setNewCategoryLabel('');
+			setEditingCategoryId(null);
+			setEditingCategoryLabel('');
+			setCategoryError('');
+			setCategoryBusy(false);
+		}
+	}, [open]);
 
 	const handleApply = () => {
 		if (localTheme !== theme) setTheme(localTheme);
@@ -76,6 +102,64 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 		await deleteAllTransactions();
 		setDeleteAllConfirmOpen(false);
 		onClose();
+	};
+
+	const handleAddCategory = async () => {
+		setCategoryError('');
+		setCategoryBusy(true);
+		try {
+			await addCategory(newCategoryLabel);
+			setNewCategoryLabel('');
+		} catch (error) {
+			setCategoryError(
+				error instanceof Error
+					? error.message
+					: 'Unable to add category right now.'
+			);
+		} finally {
+			setCategoryBusy(false);
+		}
+	};
+
+	const handleStartRename = (id: string, label: string) => {
+		setEditingCategoryId(id);
+		setEditingCategoryLabel(label);
+		setCategoryError('');
+	};
+
+	const handleSaveRename = async () => {
+		if (!editingCategoryId) return;
+		setCategoryError('');
+		setCategoryBusy(true);
+		try {
+			await renameCategory(editingCategoryId, editingCategoryLabel);
+			setEditingCategoryId(null);
+			setEditingCategoryLabel('');
+		} catch (error) {
+			setCategoryError(
+				error instanceof Error
+					? error.message
+					: 'Unable to rename category right now.'
+			);
+		} finally {
+			setCategoryBusy(false);
+		}
+	};
+
+	const handleDeleteCategory = async (id: string) => {
+		setCategoryError('');
+		setCategoryBusy(true);
+		try {
+			await deleteCategory(id);
+		} catch (error) {
+			setCategoryError(
+				error instanceof Error
+					? error.message
+					: 'Unable to delete category right now.'
+			);
+		} finally {
+			setCategoryBusy(false);
+		}
 	};
 
 	return (
@@ -119,6 +203,19 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 								>
 									<FiDatabase className="h-4 w-4" />
 									Data
+								</button>
+								<button
+									role="tab"
+									aria-selected={activeTab === 'categories'}
+									aria-controls="settings-tab-categories"
+									onClick={() => setActiveTab('categories')}
+									className={`flex-1 sm:flex-none flex items-center justify-center sm:justify-start gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${activeTab === 'categories'
+										? 'bg-accent text-accent-foreground'
+										: 'text-muted-foreground hover:bg-muted'
+										}`}
+								>
+									<FiTag className="h-4 w-4" />
+									Categories
 								</button>
 								<button
 									role="tab"
@@ -319,6 +416,130 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 												/>
 											</div>
 										</div>
+									</div>
+								</div>
+							)}
+
+							{activeTab === 'categories' && (
+								<div className="space-y-4" id="settings-tab-categories" role="tabpanel">
+									<p className="text-sm text-muted-foreground">
+										Manage the categories used by transactions, recurring transactions,
+										budgets, and category filters. Changes save immediately.
+									</p>
+
+									<div className="space-y-4 rounded-lg border p-4 sm:p-5">
+										<div className="flex flex-col gap-2 sm:flex-row">
+											<Input
+												value={newCategoryLabel}
+												onChange={(e) => setNewCategoryLabel(e.target.value)}
+												placeholder="Add a new category"
+												className="flex-1"
+											/>
+											<Button
+												type="button"
+												onClick={handleAddCategory}
+												disabled={categoryBusy || !newCategoryLabel.trim()}
+											>
+												<FiPlus className="mr-2 h-4 w-4" />
+												Add Category
+											</Button>
+										</div>
+
+										{categoryError && (
+											<div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+												{categoryError}
+											</div>
+										)}
+
+										{categoriesLoading ? (
+											<p className="text-sm text-muted-foreground">
+												Loading categories...
+											</p>
+										) : (
+											<div className="space-y-2">
+												{categories.map((category) => {
+													const isEditing = editingCategoryId === category.id;
+
+													return (
+														<div
+															key={category.id}
+															className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+														>
+															{isEditing ? (
+																<Input
+																	value={editingCategoryLabel}
+																	onChange={(e) =>
+																		setEditingCategoryLabel(e.target.value)
+																	}
+																	className="flex-1"
+																/>
+															) : (
+																<div>
+																	<p className="font-medium">{category.label}</p>
+																	<p className="text-xs text-muted-foreground">
+																		{category.value}
+																	</p>
+																</div>
+															)}
+
+															<div className="flex items-center gap-2">
+																{isEditing ? (
+																	<>
+																		<Button
+																			type="button"
+																			size="sm"
+																			onClick={handleSaveRename}
+																			disabled={
+																				categoryBusy ||
+																				!editingCategoryLabel.trim()
+																			}
+																		>
+																			Save
+																		</Button>
+																		<Button
+																			type="button"
+																			size="sm"
+																			variant="outline"
+																			onClick={() => {
+																				setEditingCategoryId(null);
+																				setEditingCategoryLabel('');
+																				setCategoryError('');
+																			}}
+																		>
+																			Cancel
+																		</Button>
+																	</>
+																) : (
+																	<>
+																		<Button
+																			type="button"
+																			size="icon"
+																			variant="ghost"
+																			onClick={() =>
+																				handleStartRename(category.id, category.label)
+																			}
+																			aria-label={`Edit ${category.label}`}
+																		>
+																			<FiEdit2 className="h-4 w-4" />
+																		</Button>
+																		<Button
+																			type="button"
+																			size="icon"
+																			variant="ghost"
+																			onClick={() => handleDeleteCategory(category.id)}
+																			aria-label={`Delete ${category.label}`}
+																			className="text-destructive hover:text-destructive"
+																		>
+																			<FiTrash2 className="h-4 w-4" />
+																		</Button>
+																	</>
+																)}
+															</div>
+														</div>
+													);
+												})}
+											</div>
+										)}
 									</div>
 								</div>
 							)}

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,13 @@
+import { CategoryDefinition } from '../types';
+
+export const TRANSFER_CATEGORY_VALUE = 'transfer';
+
+export const DEFAULT_CATEGORY_TEMPLATES: Array<Pick<CategoryDefinition, 'value' | 'label'>> = [
+	{ value: 'personal', label: 'Personal' },
+	{ value: 'cash_withdrawal', label: 'Cash Withdrawal' },
+	{ value: 'other', label: 'Other' },
+	{ value: 'debit_order', label: 'Debit Order' },
+	{ value: 'travel', label: 'Travel' },
+	{ value: 'food', label: 'Food' },
+	{ value: 'entertainment', label: 'Entertainment' },
+];

--- a/src/context/BudgetsContext.tsx
+++ b/src/context/BudgetsContext.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useBudgetsController } from '../controllers/BudgetsController';
-import { Budget, BudgetProgress, Transaction } from '../types';
+import { Budget, BudgetProgress, DateRange, Transaction } from '../types';
 
 interface BudgetsContextValue {
 	budgets: Budget[];
 	loading: boolean;
 	addBudget: (budget: Omit<Budget, 'id' | 'createdAt' | 'userId'>) => Promise<void>;
 	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
+	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
 	deleteBudget: (id: string) => Promise<void>;
 	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
 	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];

--- a/src/context/CategoriesContext.tsx
+++ b/src/context/CategoriesContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+import { useCategoriesController } from '../controllers/CategoriesController';
+import { Category, CategoryDefinition } from '../types';
+
+interface CategoriesContextValue {
+	categories: CategoryDefinition[];
+	categoryOptions: Category[];
+	categoryLabelMap: Record<string, string>;
+	loading: boolean;
+	getCategoryLabel: (value: string) => string;
+	addCategory: (label: string) => Promise<void>;
+	renameCategory: (id: string, label: string) => Promise<void>;
+	deleteCategory: (id: string) => Promise<void>;
+}
+
+const CategoriesContext = createContext<CategoriesContextValue | undefined>(undefined);
+
+export const CategoriesProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+	const controller = useCategoriesController();
+
+	return (
+		<CategoriesContext.Provider value={controller}>
+			{children}
+		</CategoriesContext.Provider>
+	);
+};
+
+export const useCategoriesContext = (): CategoriesContextValue => {
+	const context = useContext(CategoriesContext);
+
+	if (!context) {
+		throw new Error('useCategoriesContext must be used within a CategoriesProvider');
+	}
+
+	return context;
+};

--- a/src/controllers/BudgetsController.ts
+++ b/src/controllers/BudgetsController.ts
@@ -1,5 +1,5 @@
 import { useBudgets } from '../hooks/useBudgets';
-import { Budget, BudgetProgress, Transaction } from '../types';
+import { Budget, BudgetProgress, DateRange, Transaction } from '../types';
 import { calculateBudgetUsage } from '../models/BudgetModel';
 
 interface BudgetsControllerReturn {
@@ -7,19 +7,22 @@ interface BudgetsControllerReturn {
 	loading: boolean;
 	addBudget: (budget: Omit<Budget, 'id' | 'createdAt' | 'userId'>) => Promise<void>;
 	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
+	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
 	deleteBudget: (id: string) => Promise<void>;
 	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
 	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];
 }
 
 export const useBudgetsController = (): BudgetsControllerReturn => {
-	const { budgets, addBudget, updateBudget, deleteBudget, loading } = useBudgets();
+	const { budgets, addBudget, updateBudget, startBudget, deleteBudget, loading } =
+		useBudgets();
 
 	return {
 		budgets,
 		loading,
 		addBudget,
 		updateBudget,
+		startBudget,
 		deleteBudget,
 		getBudgetProgress: (budgetId, transactions) => {
 			const budget = budgets.find((b) => b.id === budgetId);

--- a/src/controllers/CategoriesController.ts
+++ b/src/controllers/CategoriesController.ts
@@ -1,0 +1,37 @@
+import { useCategories } from '../hooks/useCategories';
+import { Category, CategoryDefinition } from '../types';
+
+interface CategoriesControllerReturn {
+	categories: CategoryDefinition[];
+	categoryOptions: Category[];
+	categoryLabelMap: Record<string, string>;
+	loading: boolean;
+	getCategoryLabel: (value: string) => string;
+	addCategory: (label: string) => Promise<void>;
+	renameCategory: (id: string, label: string) => Promise<void>;
+	deleteCategory: (id: string) => Promise<void>;
+}
+
+export const useCategoriesController = (): CategoriesControllerReturn => {
+	const {
+		categories,
+		categoryOptions,
+		categoryLabelMap,
+		loading,
+		getCategoryLabel,
+		addCategory,
+		renameCategory,
+		deleteCategory,
+	} = useCategories();
+
+	return {
+		categories,
+		categoryOptions,
+		categoryLabelMap,
+		loading,
+		getCategoryLabel,
+		addCategory,
+		renameCategory,
+		deleteCategory,
+	};
+};

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -10,7 +10,7 @@ import {
 	onSnapshot,
 	Timestamp,
 } from 'firebase/firestore';
-import { Budget } from '../types';
+import { Budget, DateRange } from '../types';
 import { normalizeBudget } from '../models/BudgetModel';
 
 export const useBudgets = () => {
@@ -67,6 +67,19 @@ export const useBudgets = () => {
 		await updateDoc(ref, updates as any);
 	};
 
+	const startBudget = async (id: string, actualRange: DateRange) => {
+		if (!user) throw new Error('User not authenticated');
+		if (!actualRange.startDate || !actualRange.endDate) {
+			throw new Error('Please select a start and end date before starting a budget.');
+		}
+
+		const ref = doc(db, 'users', user.uid, 'budgets', id);
+		await updateDoc(ref, {
+			actualStartDate: actualRange.startDate,
+			actualEndDate: actualRange.endDate,
+		});
+	};
+
 	const deleteBudget = async (id: string) => {
 		if (!user) throw new Error('User not authenticated');
 		const ref = doc(db, 'users', user.uid, 'budgets', id);
@@ -77,6 +90,7 @@ export const useBudgets = () => {
 		budgets,
 		addBudget,
 		updateBudget,
+		startBudget,
 		deleteBudget,
 		loading,
 	};

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+	Timestamp,
+	addDoc,
+	collection,
+	deleteDoc,
+	doc,
+	getDocs,
+	onSnapshot,
+	query,
+	updateDoc,
+	where,
+	writeBatch,
+} from 'firebase/firestore';
+import { auth, db } from '../services/firebase';
+import { CategoryDefinition } from '../types';
+import { TRANSFER_CATEGORY_VALUE } from '../constants/categories';
+import {
+	buildCategoryLabelMap,
+	formatCategoryLabel,
+	getDefaultCategories,
+	mergeCategoryOptions,
+	normalizeCategoryDefinition,
+	slugifyCategoryLabel,
+} from '../utils/categories';
+
+const USERS_COLLECTION = 'users';
+
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+	const chunks: T[][] = [];
+
+	for (let index = 0; index < items.length; index += size) {
+		chunks.push(items.slice(index, index + size));
+	}
+
+	return chunks;
+};
+
+export const useCategories = () => {
+	const [categories, setCategories] = useState<CategoryDefinition[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [user, setUser] = useState(() => auth.currentUser);
+	const seededUsersRef = useRef<Set<string>>(new Set());
+
+	useEffect(() => {
+		const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
+			setUser(firebaseUser);
+		});
+
+		return () => unsubscribe();
+	}, []);
+
+	useEffect(() => {
+		if (!user) {
+			setCategories([]);
+			setLoading(false);
+			return;
+		}
+
+		setLoading(true);
+
+		const categoriesRef = collection(db, USERS_COLLECTION, user.uid, 'categories');
+		const unsubscribe = onSnapshot(
+			query(categoriesRef),
+			async (snapshot) => {
+				if (
+					snapshot.empty &&
+					!seededUsersRef.current.has(user.uid)
+				) {
+					seededUsersRef.current.add(user.uid);
+					await Promise.all(
+						getDefaultCategories().map((category) =>
+							addDoc(categoriesRef, {
+								...category,
+								createdAt: Timestamp.now(),
+								updatedAt: Timestamp.now(),
+							})
+						)
+					);
+					return;
+				}
+
+				const normalized = snapshot.docs
+					.map((categoryDoc) =>
+						normalizeCategoryDefinition({ id: categoryDoc.id, ...categoryDoc.data() })
+					)
+					.sort((left, right) => left.label.localeCompare(right.label));
+
+				setCategories(normalized);
+				setLoading(false);
+			},
+			(error) => {
+				console.error('Error fetching categories:', error);
+				setLoading(false);
+			}
+		);
+
+		return () => unsubscribe();
+	}, [user]);
+
+	const ensureAuthenticated = () => {
+		if (!user) throw new Error('User not authenticated');
+	};
+
+	const getSanitizedCategoryPayload = (label: string) => {
+		const trimmedLabel = label.trim();
+		const value = slugifyCategoryLabel(trimmedLabel);
+
+		if (!trimmedLabel) {
+			throw new Error('Category name cannot be empty.');
+		}
+
+		if (!value) {
+			throw new Error('Category name must include at least one letter or number.');
+		}
+
+		if (value === TRANSFER_CATEGORY_VALUE) {
+			throw new Error('Transfer is reserved and cannot be used as a category.');
+		}
+
+		return {
+			label: trimmedLabel,
+			value,
+		};
+	};
+
+	const assertCategoryIsUnique = (value: string, categoryIdToIgnore?: string) => {
+		const conflict = categories.find(
+			(category) =>
+				category.id !== categoryIdToIgnore &&
+				category.value.toLowerCase() === value.toLowerCase()
+		);
+
+		if (conflict) {
+			throw new Error(`"${conflict.label}" already exists.`);
+		}
+	};
+
+	const addCategory = async (label: string) => {
+		ensureAuthenticated();
+
+		const payload = getSanitizedCategoryPayload(label);
+		assertCategoryIsUnique(payload.value);
+
+		await addDoc(collection(db, USERS_COLLECTION, user!.uid, 'categories'), {
+			...payload,
+			createdAt: Timestamp.now(),
+			updatedAt: Timestamp.now(),
+		});
+	};
+
+	const renameCategory = async (id: string, label: string) => {
+		ensureAuthenticated();
+
+		const category = categories.find((item) => item.id === id);
+		if (!category) {
+			throw new Error('Category not found.');
+		}
+
+		const payload = getSanitizedCategoryPayload(label);
+		assertCategoryIsUnique(payload.value, id);
+
+		if (category.value === payload.value && category.label === payload.label) {
+			return;
+		}
+
+		const transactionsRef = collection(db, USERS_COLLECTION, user!.uid, 'transactions');
+		const recurringRef = collection(
+			db,
+			USERS_COLLECTION,
+			user!.uid,
+			'recurringTransactions'
+		);
+		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
+
+		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
+			getDocs(query(transactionsRef, where('category', '==', category.value))),
+			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('category', '==', category.value))),
+		]);
+
+		const allRefs = [
+			...transactionDocs.docs.map((docRef) => docRef.ref),
+			...recurringDocs.docs.map((docRef) => docRef.ref),
+			...budgetDocs.docs.map((docRef) => docRef.ref),
+		];
+
+		const categoryRef = doc(db, USERS_COLLECTION, user!.uid, 'categories', id);
+		const refChunks = chunkArray(allRefs, 400);
+
+		if (refChunks.length === 0) {
+			await updateDoc(categoryRef, {
+				...payload,
+				updatedAt: Timestamp.now(),
+			});
+			return;
+		}
+
+		for (let index = 0; index < refChunks.length; index += 1) {
+			const batch = writeBatch(db);
+			const chunk = refChunks[index];
+
+			if (index === 0) {
+				batch.update(categoryRef, {
+					...payload,
+					updatedAt: Timestamp.now(),
+				});
+			}
+
+			for (const ref of chunk) {
+				batch.update(ref, {
+					category: payload.value,
+				});
+			}
+
+			await batch.commit();
+		}
+	};
+
+	const deleteCategory = async (id: string) => {
+		ensureAuthenticated();
+
+		const category = categories.find((item) => item.id === id);
+		if (!category) {
+			throw new Error('Category not found.');
+		}
+
+		const transactionsRef = collection(db, USERS_COLLECTION, user!.uid, 'transactions');
+		const recurringRef = collection(
+			db,
+			USERS_COLLECTION,
+			user!.uid,
+			'recurringTransactions'
+		);
+		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
+
+		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
+			getDocs(query(transactionsRef, where('category', '==', category.value))),
+			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('category', '==', category.value))),
+		]);
+
+		const usageCount =
+			transactionDocs.size + recurringDocs.size + budgetDocs.size;
+
+		if (usageCount > 0) {
+			throw new Error(
+				`"${category.label}" is still in use and cannot be deleted yet.`
+			);
+		}
+
+		await deleteDoc(doc(db, USERS_COLLECTION, user!.uid, 'categories', id));
+	};
+
+	const categoryOptions = useMemo(() => mergeCategoryOptions(categories), [categories]);
+	const categoryLabelMap = useMemo(() => buildCategoryLabelMap(categories), [categories]);
+
+	const getCategoryLabel = (value: string) =>
+		categoryLabelMap[value] ?? formatCategoryLabel(value);
+
+	return {
+		categories,
+		categoryOptions,
+		categoryLabelMap,
+		getCategoryLabel,
+		addCategory,
+		renameCategory,
+		deleteCategory,
+		loading,
+	};
+};

--- a/src/models/BudgetModel.ts
+++ b/src/models/BudgetModel.ts
@@ -1,14 +1,42 @@
-import { Budget, BudgetProgress, Transaction } from '../types';
+import { Budget, BudgetProgress, DateRange, Transaction } from '../types';
+import { filterTransactionsByDateRangeObject } from '../utils/dateRangeFilter';
+import { parseDbDateOrNull } from '../utils/date';
 
 export type { Budget };
 
+const toIsoDate = (value: Date): string => value.toISOString().split('T')[0];
+
+const getMonthBounds = (baseDate: Date): DateRange => {
+	const start = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
+	const end = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, 0);
+
+	return {
+		startDate: toIsoDate(start),
+		endDate: toIsoDate(end),
+	};
+};
+
+const getLegacyBudgetRange = (doc: any): DateRange => {
+	const createdAt =
+		parseDbDateOrNull(doc.createdAt) ??
+		parseDbDateOrNull(doc.updatedAt) ??
+		new Date();
+
+	return getMonthBounds(createdAt);
+};
+
 export const normalizeBudget = (doc: any): Budget => {
+	const legacyRange = getLegacyBudgetRange(doc);
 	const budget: Budget = {
 		id: doc.id,
 		userId: doc.userId,
 		category: doc.category,
 		amount: doc.amount ?? 0,
 		period: doc.period ?? 'monthly',
+		plannedStartDate: doc.plannedStartDate ?? legacyRange.startDate,
+		plannedEndDate: doc.plannedEndDate ?? legacyRange.endDate,
+		actualStartDate: doc.actualStartDate ?? undefined,
+		actualEndDate: doc.actualEndDate ?? undefined,
 	};
 
 	if (doc.createdAt) {
@@ -30,28 +58,40 @@ export const calculateBudgetUsage = (
 	budget: Budget,
 	transactions: Transaction[]
 ): BudgetProgress => {
-	const now = new Date();
-	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-	const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+	const started = Boolean(budget.actualStartDate && budget.actualEndDate);
+	const actualRange: DateRange = {
+		startDate: budget.actualStartDate ?? '',
+		endDate: budget.actualEndDate ?? '',
+	};
 
-	const spent = transactions
-		.filter((t) => {
-			if (t.type !== 'expense') return false;
-			if (t.category !== budget.category) return false;
-			const txDate = getTransactionDate(t);
-			return txDate >= monthStart && txDate <= monthEnd;
-		})
-		.reduce((sum, t) => sum + t.amount, 0);
+	const actualSpent = started
+		? filterTransactionsByDateRangeObject(
+				transactions.filter(
+					(transaction) =>
+						transaction.type === 'expense' && transaction.category === budget.category
+					),
+				actualRange
+		  ).reduce((sum, transaction) => sum + transaction.amount, 0)
+		: 0;
 
-	const remaining = Math.max(0, budget.amount - spent);
-	const percent = budget.amount > 0 ? Math.min(100, (spent / budget.amount) * 100) : 0;
+	const remaining = started ? Math.max(0, budget.amount - actualSpent) : budget.amount;
+	const overBudget = started ? Math.max(0, actualSpent - budget.amount) : 0;
+	const percent =
+		started && budget.amount > 0
+			? Math.min(100, (actualSpent / budget.amount) * 100)
+			: 0;
 
-	return { budget, spent, remaining, percent };
-};
-
-const getTransactionDate = (t: Transaction): Date => {
-	if (!t.date) return t.createdAt instanceof Date ? t.createdAt : new Date();
-	if (typeof t.date === 'object' && 'toDate' in t.date) return t.date.toDate();
-	if (t.date instanceof Date) return t.date;
-	return new Date();
+	return {
+		budget,
+		plannedAmount: budget.amount,
+		plannedStartDate: budget.plannedStartDate,
+		plannedEndDate: budget.plannedEndDate,
+		actualStartDate: budget.actualStartDate,
+		actualEndDate: budget.actualEndDate,
+		started,
+		actualSpent,
+		remaining,
+		overBudget,
+		percent,
+	};
 };

--- a/src/pages/AccountDetail.tsx
+++ b/src/pages/AccountDetail.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-icons/fi';
 import { useAccountsContext } from '../context/AccountsContext';
 import { useTransactionsContext } from '../context/TransactionsContext';
+import { useCategoriesContext } from '../context/CategoriesContext';
 import { ACCOUNT_TYPE_LABELS } from '../models/AccountModel';
 import { formatCurrency } from '../utils/formatCurrency';
 import { parseDbDate } from '../utils/date';
@@ -25,6 +26,7 @@ const AccountDetailPage: React.FC = () => {
 	const navigate = useNavigate();
 	const { accounts } = useAccountsContext();
 	const { transactions } = useTransactionsContext();
+	const { getCategoryLabel } = useCategoriesContext();
 
 	const [subView, setSubView] = useState<SubView>('detail');
 
@@ -219,7 +221,7 @@ const AccountDetailPage: React.FC = () => {
 												<p className="font-medium text-sm">{tx.title}</p>
 												<p className="text-xs text-muted-foreground">
 													{tx.category
-														? `${tx.category} &#183; `
+														? `${getCategoryLabel(tx.category)} &#183; `
 														: ''}
 													{dateStr}
 												</p>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,14 @@ export interface Category {
 	label: string;
 }
 
+export interface CategoryDefinition {
+	id: string;
+	value: string;
+	label: string;
+	createdAt?: Date | { toDate: () => Date };
+	updatedAt?: Date | { toDate: () => Date };
+}
+
 // Account
 export type AccountType = 'debit' | 'credit' | 'savings' | 'cash';
 
@@ -65,13 +73,24 @@ export interface Budget {
 	category: string;
 	amount: number;
 	period: 'monthly';
+	plannedStartDate: string;
+	plannedEndDate: string;
+	actualStartDate?: string;
+	actualEndDate?: string;
 	createdAt?: Date | { toDate: () => Date };
 }
 
 export interface BudgetProgress {
 	budget: Budget;
-	spent: number;
+	plannedAmount: number;
+	plannedStartDate: string;
+	plannedEndDate: string;
+	actualStartDate?: string;
+	actualEndDate?: string;
+	started: boolean;
+	actualSpent: number;
 	remaining: number;
+	overBudget: number;
 	percent: number;
 }
 

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,0 +1,87 @@
+import { Category, CategoryDefinition } from '../types';
+import { DEFAULT_CATEGORY_TEMPLATES, TRANSFER_CATEGORY_VALUE } from '../constants/categories';
+
+export const slugifyCategoryLabel = (label: string): string =>
+	label
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '');
+
+export const formatCategoryLabel = (value: string): string =>
+	value
+		.split('_')
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+
+export const normalizeCategoryDefinition = (doc: any): CategoryDefinition => {
+	const category: CategoryDefinition = {
+		id: doc.id,
+		value: doc.value ?? doc.id,
+		label: doc.label ?? formatCategoryLabel(doc.value ?? doc.id ?? ''),
+	};
+
+	if (doc.createdAt) {
+		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
+			category.createdAt = doc.createdAt.toDate();
+		} else if (doc.createdAt instanceof Date) {
+			category.createdAt = doc.createdAt;
+		} else {
+			category.createdAt = new Date(doc.createdAt);
+		}
+	}
+
+	if (doc.updatedAt) {
+		if (typeof doc.updatedAt === 'object' && 'toDate' in doc.updatedAt) {
+			category.updatedAt = doc.updatedAt.toDate();
+		} else if (doc.updatedAt instanceof Date) {
+			category.updatedAt = doc.updatedAt;
+		} else {
+			category.updatedAt = new Date(doc.updatedAt);
+		}
+	}
+
+	return category;
+};
+
+export const toCategoryOption = (category: Pick<CategoryDefinition, 'value' | 'label'>): Category => ({
+	value: category.value,
+	label: category.label,
+});
+
+export const mergeCategoryOptions = (
+	categories: Pick<CategoryDefinition, 'value' | 'label'>[],
+	extraValues: string[] = []
+): Category[] => {
+	const merged = new Map<string, Category>();
+
+	for (const category of categories) {
+		if (category.value === TRANSFER_CATEGORY_VALUE) continue;
+		merged.set(category.value, toCategoryOption(category));
+	}
+
+	for (const value of extraValues) {
+		if (!value || value === TRANSFER_CATEGORY_VALUE || merged.has(value)) continue;
+		merged.set(value, {
+			value,
+			label: formatCategoryLabel(value),
+		});
+	}
+
+	return Array.from(merged.values()).sort((left, right) =>
+		left.label.localeCompare(right.label)
+	);
+};
+
+export const buildCategoryLabelMap = (
+	categories: Pick<CategoryDefinition, 'value' | 'label'>[]
+): Record<string, string> =>
+	Object.fromEntries(
+		categories
+			.filter((category) => category.value !== TRANSFER_CATEGORY_VALUE)
+			.map((category) => [category.value, category.label])
+	);
+
+export const getDefaultCategories = (): Array<Pick<CategoryDefinition, 'value' | 'label'>> =>
+	DEFAULT_CATEGORY_TEMPLATES.map((category) => ({ ...category }));

--- a/src/views/Accounts/ReconcileForm.tsx
+++ b/src/views/Accounts/ReconcileForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { FiCheckCircle } from 'react-icons/fi';
 import { useAccountsContext } from '../../context/AccountsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { useTransactionsContext } from '../../context/TransactionsContext';
 import { ACCOUNT_TYPE_LABELS } from '../../models/AccountModel';
 import { formatCurrency } from '../../utils/formatCurrency';
@@ -23,6 +24,7 @@ type Step = 'select' | 'reconcile' | 'done';
 const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 	const { accounts } = useAccountsContext();
 	const { addTransaction } = useTransactionsContext();
+	const { categoryOptions } = useCategoriesContext();
 
 	const [step, setStep] = useState<Step>('select');
 	const [selectedAccountId, setSelectedAccountId] = useState('');
@@ -32,6 +34,10 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 	const [error, setError] = useState('');
 
 	const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+	const reconcileCategory =
+		categoryOptions.find((category) => category.value === 'other')?.value ??
+		categoryOptions[0]?.value ??
+		'other';
 	const discrepancy = selectedAccount
 		? Number(statementBalance) - selectedAccount.balance
 		: 0;
@@ -59,7 +65,7 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 					type: isPositive ? 'income' : 'expense',
 					accountId: selectedAccount.id,
 					title: 'Reconciliation Adjustment',
-					category: 'other',
+					category: reconcileCategory,
 					amount: Math.abs(discrepancy),
 					description: `Reconciled to statement balance of ${formatCurrency(statementBalance)}`,
 					date: date ? new Date(date) : new Date(),

--- a/src/views/Budgets/BudgetForm.tsx
+++ b/src/views/Budgets/BudgetForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useBudgetsContext } from '../../context/BudgetsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { Budget } from '../../types';
 import { Button } from '../../components/app/ui/button';
 import { Input } from '../../components/app/ui/input';
@@ -10,37 +11,51 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '../../components/app/ui/select';
+import { mergeCategoryOptions } from '../../utils/categories';
+
+const getCurrentMonthRange = () => {
+	const now = new Date();
+	const start = new Date(now.getFullYear(), now.getMonth(), 1);
+	const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+	return {
+		startDate: start.toISOString().split('T')[0],
+		endDate: end.toISOString().split('T')[0],
+	};
+};
 
 interface BudgetFormProps {
 	onClose: () => void;
 	budget?: Budget;
 }
 
-const CATEGORIES = [
-	{ value: 'personal', label: 'Personal' },
-	{ value: 'food', label: 'Food' },
-	{ value: 'travel', label: 'Travel' },
-	{ value: 'entertainment', label: 'Entertainment' },
-	{ value: 'debit_order', label: 'Debit Order' },
-	{ value: 'housing', label: 'Housing' },
-	{ value: 'transport', label: 'Transport' },
-	{ value: 'health', label: 'Health' },
-	{ value: 'education', label: 'Education' },
-	{ value: 'other', label: 'Other' },
-];
-
 const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 	const { addBudget, updateBudget } = useBudgetsContext();
+	const { categoryOptions } = useCategoriesContext();
 
 	const [category, setCategory] = useState('');
 	const [amount, setAmount] = useState(0);
+	const [plannedStartDate, setPlannedStartDate] = useState(getCurrentMonthRange().startDate);
+	const [plannedEndDate, setPlannedEndDate] = useState(getCurrentMonthRange().endDate);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState('');
+	const availableCategories = React.useMemo(
+		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
+		[categoryOptions, category]
+	);
 
 	useEffect(() => {
 		if (budget) {
 			setCategory(budget.category);
 			setAmount(budget.amount);
+			setPlannedStartDate(budget.plannedStartDate);
+			setPlannedEndDate(budget.plannedEndDate);
+		} else {
+			const defaultRange = getCurrentMonthRange();
+			setCategory('');
+			setAmount(0);
+			setPlannedStartDate(defaultRange.startDate);
+			setPlannedEndDate(defaultRange.endDate);
 		}
 	}, [budget]);
 
@@ -54,6 +69,14 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 			setError('Budget amount must be greater than zero.');
 			return;
 		}
+		if (!plannedStartDate || !plannedEndDate) {
+			setError('Please choose both a planned start and end date.');
+			return;
+		}
+		if (plannedStartDate > plannedEndDate) {
+			setError('Planned end date must be on or after the planned start date.');
+			return;
+		}
 		setError('');
 		setLoading(true);
 		try {
@@ -61,6 +84,8 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 				category,
 				amount: Number(amount),
 				period: 'monthly' as const,
+				plannedStartDate,
+				plannedEndDate,
 			};
 			if (budget?.id) {
 				await updateBudget(budget.id, data);
@@ -84,8 +109,8 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 					</h2>
 					<p className="mt-1.5 text-sm text-muted-foreground">
 						{budget
-							? 'Update your monthly spending limit'
-							: 'Set a monthly spending limit for a category'}
+							? 'Update your planned budget amount and date range'
+							: 'Set a planned budget amount and date range for a category'}
 					</p>
 				</div>
 
@@ -103,7 +128,7 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 								<SelectValue placeholder="Select a category" />
 							</SelectTrigger>
 							<SelectContent>
-								{CATEGORIES.map((c) => (
+								{availableCategories.map((c) => (
 									<SelectItem key={c.value} value={c.value}>
 										{c.label}
 									</SelectItem>
@@ -113,7 +138,7 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 					</div>
 
 					<div className="space-y-1.5">
-						<label className="text-sm font-medium">Monthly Limit (ZAR)</label>
+						<label className="text-sm font-medium">Planned Amount (ZAR)</label>
 						<Input
 							type="number"
 							step="0.01"
@@ -125,8 +150,30 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 						/>
 					</div>
 
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+						<div className="space-y-1.5">
+							<label className="text-sm font-medium">Planned Start Date</label>
+							<Input
+								type="date"
+								value={plannedStartDate}
+								onChange={(e) => setPlannedStartDate(e.target.value)}
+								required
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<label className="text-sm font-medium">Planned End Date</label>
+							<Input
+								type="date"
+								value={plannedEndDate}
+								onChange={(e) => setPlannedEndDate(e.target.value)}
+								required
+							/>
+						</div>
+					</div>
+
 					<div className="rounded-xl border bg-muted/30 p-3 text-sm text-muted-foreground">
-						Budgets reset at the start of each calendar month.
+						Use the budget screen filter to choose an actual date range, then click
+						Start on a budget to compare that period against this plan.
 					</div>
 
 					<div className="flex gap-3 pt-2">

--- a/src/views/Budgets/BudgetsList.tsx
+++ b/src/views/Budgets/BudgetsList.tsx
@@ -1,10 +1,25 @@
-import React, { useState } from 'react';
-import { FiPlus, FiEdit2, FiTrash2, FiAlertCircle } from 'react-icons/fi';
+import React, { useMemo, useState } from 'react';
+import {
+	FiAlertCircle,
+	FiCalendar,
+	FiEdit2,
+	FiPlay,
+	FiPlus,
+	FiTarget,
+	FiTrash2,
+} from 'react-icons/fi';
 import { useBudgetsContext } from '../../context/BudgetsContext';
 import { useTransactionsContext } from '../../context/TransactionsContext';
-import { Budget, BudgetProgress } from '../../types';
+import { Budget, BudgetProgress, DateRange } from '../../types';
 import { formatCurrency } from '../../utils/formatCurrency';
+import {
+	filterTransactionsByDateRangeObject,
+	formatDateRange,
+} from '../../utils/dateRangeFilter';
+import { parseDbDate } from '../../utils/date';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { Button } from '../../components/app/ui/button';
+import DateRangeFilter from '../../components/app/DateRangeFilter';
 import {
 	Dialog,
 	DialogContent,
@@ -15,19 +30,6 @@ import {
 } from '../../components/app/ui/dialog';
 import BudgetForm from './BudgetForm';
 
-const CATEGORY_LABELS: Record<string, string> = {
-	personal: 'Personal',
-	food: 'Food',
-	travel: 'Travel',
-	entertainment: 'Entertainment',
-	debit_order: 'Debit Order',
-	housing: 'Housing',
-	transport: 'Transport',
-	health: 'Health',
-	education: 'Education',
-	other: 'Other',
-};
-
 const getBarColour = (percent: number): string => {
 	if (percent >= 90) return 'bg-red-500';
 	if (percent >= 70) return 'bg-amber-500';
@@ -35,15 +37,24 @@ const getBarColour = (percent: number): string => {
 };
 
 const BudgetsList: React.FC = () => {
-	const { budgets, deleteBudget, getAllBudgetProgress } = useBudgetsContext();
+	const { budgets, deleteBudget, getAllBudgetProgress, startBudget } = useBudgetsContext();
+	const { getCategoryLabel } = useCategoriesContext();
 	const { transactions } = useTransactionsContext();
 
 	const [showForm, setShowForm] = useState(false);
 	const [editingBudget, setEditingBudget] = useState<Budget | undefined>(undefined);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [budgetToDelete, setBudgetToDelete] = useState<string | null>(null);
+	const [dateRange, setDateRange] = useState<DateRange>({ startDate: '', endDate: '' });
+	const [actionError, setActionError] = useState('');
+	const [startingBudgetId, setStartingBudgetId] = useState<string | null>(null);
 
 	const allProgress: BudgetProgress[] = getAllBudgetProgress(transactions);
+	const startedBudgets = useMemo(
+		() => allProgress.filter((progress) => progress.started),
+		[allProgress]
+	);
+	const hasSelectedRange = Boolean(dateRange.startDate && dateRange.endDate);
 
 	const handleEdit = (budget: Budget) => {
 		setEditingBudget(budget);
@@ -66,20 +77,53 @@ const BudgetsList: React.FC = () => {
 		setEditingBudget(undefined);
 	};
 
+	const handleStartBudget = async (budgetId: string) => {
+		if (!dateRange.startDate || !dateRange.endDate) {
+			setActionError('Select a budget start and end date before starting a budget.');
+			return;
+		}
+
+		setActionError('');
+		setStartingBudgetId(budgetId);
+
+		try {
+			await startBudget(budgetId, dateRange);
+		} catch (error) {
+			setActionError(
+				error instanceof Error
+					? error.message
+					: 'Unable to start this budget right now. Please try again.'
+			);
+		} finally {
+			setStartingBudgetId(null);
+		}
+	};
+
 	if (showForm) {
 		return <BudgetForm onClose={handleCloseForm} budget={editingBudget} />;
 	}
 
-	const now = new Date();
-	const monthLabel = now.toLocaleDateString('en-ZA', { month: 'long', year: 'numeric' });
-
-	const totalBudgeted = allProgress.reduce((sum, p) => sum + p.budget.amount, 0);
-	const totalSpent = allProgress.reduce((sum, p) => sum + p.spent, 0);
+	const totalPlanned = startedBudgets.reduce(
+		(sum, progress) => sum + progress.plannedAmount,
+		0
+	);
+	const totalActual = startedBudgets.reduce(
+		(sum, progress) => sum + progress.actualSpent,
+		0
+	);
+	const totalRemaining = startedBudgets.reduce(
+		(sum, progress) => sum + progress.remaining,
+		0
+	);
+	const totalOverBudget = startedBudgets.reduce(
+		(sum, progress) => sum + progress.overBudget,
+		0
+	);
 
 	return (
-		<div className="flex flex-col min-h-screen bg-background">
+		<div className="flex min-h-screen flex-col bg-background">
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-				<DialogContent className="w-[90vw] md:w-full rounded-lg">
+				<DialogContent className="w-[90vw] rounded-lg md:w-full">
 					<DialogHeader>
 						<DialogTitle>Delete Budget</DialogTitle>
 						<DialogDescription>
@@ -88,10 +132,7 @@ const BudgetsList: React.FC = () => {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setDeleteDialogOpen(false)}
-						>
+						<Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
 							Cancel
 						</Button>
 						<Button variant="destructive" onClick={handleConfirmDelete}>
@@ -102,13 +143,13 @@ const BudgetsList: React.FC = () => {
 			</Dialog>
 
 			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				{/* Header */}
-				<div className="mb-6 flex items-center justify-between">
+				<div className="mb-6 flex items-center justify-between gap-4">
 					<div>
-						<h1 className="text-2xl md:text-3xl font-bold tracking-tight">
-							Budgets
-						</h1>
-						<p className="mt-1 text-sm text-muted-foreground">{monthLabel}</p>
+						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">Budgets</h1>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Plan a budget period, then capture an actual comparison period from
+							the filter below.
+						</p>
 					</div>
 					<Button onClick={() => setShowForm(true)}>
 						<FiPlus className="mr-2 h-4 w-4" />
@@ -116,37 +157,65 @@ const BudgetsList: React.FC = () => {
 					</Button>
 				</div>
 
-				{/* Summary */}
-				{allProgress.length > 0 && (
-					<div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+				<div className="mb-6 rounded-xl border bg-card p-4">
+					<div className="mb-3 flex items-center gap-2">
+						<FiCalendar className="h-4 w-4 text-muted-foreground" />
+						<p className="text-sm font-medium">Actual Budget Period</p>
+					</div>
+					<DateRangeFilter
+						dateRange={dateRange}
+						onDateRangeChange={setDateRange}
+						onClear={() => {
+							setDateRange({ startDate: '', endDate: '' });
+							setActionError('');
+						}}
+					/>
+					<p className="mt-3 text-xs text-muted-foreground">
+						Set the actual date range here, then click Start on a budget card to
+						capture that period.
+					</p>
+					{!hasSelectedRange && (
+						<div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+							Select a start and end date to enable budget start tracking.
+						</div>
+					)}
+					{actionError && (
+						<div className="mt-3 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+							{actionError}
+						</div>
+					)}
+				</div>
+
+				{startedBudgets.length > 0 ? (
+					<div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
 						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Total Budgeted</p>
-							<p className="mt-1 text-xl font-bold">
-								{formatCurrency(totalBudgeted)}
-							</p>
+							<p className="text-sm text-muted-foreground">Planned Total</p>
+							<p className="mt-1 text-xl font-bold">{formatCurrency(totalPlanned)}</p>
 						</div>
 						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Total Spent</p>
-							<p className="mt-1 text-xl font-bold">
-								{formatCurrency(totalSpent)}
-							</p>
+							<p className="text-sm text-muted-foreground">Actual Total</p>
+							<p className="mt-1 text-xl font-bold">{formatCurrency(totalActual)}</p>
 						</div>
 						<div className="rounded-xl border bg-card p-5">
 							<p className="text-sm text-muted-foreground">Remaining</p>
-							<p
-								className={`mt-1 text-xl font-bold ${
-									totalBudgeted - totalSpent >= 0
-										? 'text-green-600 dark:text-green-400'
-										: 'text-red-600 dark:text-red-400'
-								}`}
-							>
-								{formatCurrency(Math.max(0, totalBudgeted - totalSpent))}
+							<p className="mt-1 text-xl font-bold text-green-600 dark:text-green-400">
+								{formatCurrency(totalRemaining)}
+							</p>
+						</div>
+						<div className="rounded-xl border bg-card p-5">
+							<p className="text-sm text-muted-foreground">Over Budget</p>
+							<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
+								{formatCurrency(totalOverBudget)}
 							</p>
 						</div>
 					</div>
-				)}
+				) : budgets.length > 0 ? (
+					<div className="mb-8 rounded-xl border border-dashed bg-card px-4 py-5 text-sm text-muted-foreground">
+						No budgets have started yet. Pick an actual date range above and click
+						Start on any budget to compare plan vs actual.
+					</div>
+				) : null}
 
-				{/* Budget list */}
 				{budgets.length === 0 ? (
 					<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed py-16 text-center">
 						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
@@ -154,7 +223,7 @@ const BudgetsList: React.FC = () => {
 						</div>
 						<h3 className="text-lg font-semibold">No budgets yet</h3>
 						<p className="mt-1 text-sm text-muted-foreground">
-							Create a budget to track your monthly spending by category
+							Create a budget to track a custom planned period by category
 						</p>
 						<Button className="mt-4" onClick={() => setShowForm(true)}>
 							Create Budget
@@ -163,36 +232,75 @@ const BudgetsList: React.FC = () => {
 				) : (
 					<div className="space-y-4">
 						{allProgress.map((progress) => {
-							const { budget, spent, remaining, percent } = progress;
-							const isOverBudget = spent > budget.amount;
+							const {
+								budget,
+								plannedAmount,
+								plannedStartDate,
+								plannedEndDate,
+								actualStartDate,
+								actualEndDate,
+								started,
+								actualSpent,
+								remaining,
+								overBudget,
+								percent,
+							} = progress;
+							const label = getCategoryLabel(budget.category);
+							const isOverBudget = overBudget > 0;
 							const barColour = getBarColour(percent);
-							const label =
-								CATEGORY_LABELS[budget.category] ?? budget.category;
+							const matchingTransactions =
+								started && actualStartDate && actualEndDate
+									? filterTransactionsByDateRangeObject(
+											transactions.filter(
+												(transaction) =>
+													transaction.type === 'expense' &&
+													transaction.category === budget.category
+											),
+											{
+												startDate: actualStartDate,
+												endDate: actualEndDate,
+											}
+									  ).sort((left, right) => {
+											const leftDate = parseDbDate(left.date ?? left.createdAt);
+											const rightDate = parseDbDate(right.date ?? right.createdAt);
+											return rightDate.getTime() - leftDate.getTime();
+									  })
+									: [];
 
 							return (
-								<div
-									key={budget.id}
-									className="group rounded-2xl border bg-card p-5"
-								>
-									<div className="mb-3 flex items-start justify-between gap-3">
-										<div className="flex-1 min-w-0">
+								<div key={budget.id} className="group rounded-2xl border bg-card p-5">
+									<div className="mb-4 flex items-start justify-between gap-3">
+										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-2">
-												<h3 className="font-semibold truncate">
-													{label}
-												</h3>
+												<h3 className="truncate font-semibold">{label}</h3>
 												{isOverBudget && (
-													<FiAlertCircle className="h-4 w-4 text-red-500 flex-shrink-0" />
+													<FiAlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
 												)}
 											</div>
 											<p className="mt-0.5 text-xs text-muted-foreground">
-												Monthly limit
+												Plan vs actual budget tracking
 											</p>
 										</div>
-										<div className="flex items-center gap-1 flex-shrink-0">
+										<div className="flex flex-shrink-0 items-center gap-1">
+											<Button
+												type="button"
+												size="sm"
+												variant={started ? 'outline' : 'default'}
+												className="h-8"
+												onClick={() => budget.id && handleStartBudget(budget.id)}
+												disabled={!hasSelectedRange || startingBudgetId === budget.id}
+											>
+												<FiPlay className="mr-1.5 h-3.5 w-3.5" />
+												{startingBudgetId === budget.id
+													? 'Starting...'
+													: started
+														? 'Restart'
+														: 'Start'}
+											</Button>
 											<Button
 												variant="ghost"
 												size="icon"
-												className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity"
+												className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
 												onClick={() => handleEdit(budget)}
 												aria-label="Edit budget"
 											>
@@ -201,10 +309,8 @@ const BudgetsList: React.FC = () => {
 											<Button
 												variant="ghost"
 												size="icon"
-												className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
-												onClick={() =>
-													budget.id && handleDeleteClick(budget.id)
-												}
+												className="h-8 w-8 opacity-0 transition-opacity text-muted-foreground group-hover:opacity-100 hover:text-destructive"
+												onClick={() => budget.id && handleDeleteClick(budget.id)}
 												aria-label="Delete budget"
 											>
 												<FiTrash2 className="h-3.5 w-3.5" />
@@ -212,7 +318,54 @@ const BudgetsList: React.FC = () => {
 										</div>
 									</div>
 
-									{/* Progress bar */}
+									<div className="mb-4 grid gap-3 md:grid-cols-2">
+										<div className="rounded-xl border bg-muted/20 p-3">
+											<div className="mb-1 flex items-center gap-2">
+												<FiTarget className="h-4 w-4 text-primary" />
+												<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+													Planned
+												</p>
+											</div>
+											<p className="text-lg font-semibold">
+												{formatCurrency(plannedAmount)}
+											</p>
+											<p className="mt-1 text-sm text-muted-foreground">
+												{formatDateRange({
+													startDate: plannedStartDate,
+													endDate: plannedEndDate,
+												})}
+											</p>
+										</div>
+										<div className="rounded-xl border bg-muted/20 p-3">
+											<div className="mb-1 flex items-center gap-2">
+												<FiCalendar className="h-4 w-4 text-primary" />
+												<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+													Actual
+												</p>
+											</div>
+											{started ? (
+												<>
+													<p className="text-lg font-semibold">
+														{formatCurrency(actualSpent)}
+													</p>
+													<p className="mt-1 text-sm text-muted-foreground">
+														{formatDateRange({
+															startDate: actualStartDate ?? '',
+															endDate: actualEndDate ?? '',
+														})}
+													</p>
+												</>
+											) : (
+												<>
+													<p className="text-lg font-semibold">Not started</p>
+													<p className="mt-1 text-sm text-muted-foreground">
+														Use the date filter and click Start.
+													</p>
+												</>
+											)}
+										</div>
+									</div>
+
 									<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-muted">
 										<div
 											className={`h-full rounded-full transition-all ${barColour}`}
@@ -220,29 +373,88 @@ const BudgetsList: React.FC = () => {
 										/>
 									</div>
 
-									{/* Amounts */}
-									<div className="flex items-center justify-between text-sm">
-										<span className="text-muted-foreground">
-											{formatCurrency(spent)} spent
-										</span>
-										<span
-											className={`font-medium ${
-												isOverBudget
-													? 'text-red-600 dark:text-red-400'
-													: 'text-muted-foreground'
-											}`}
-										>
-											{isOverBudget
-												? `${formatCurrency(Math.abs(remaining))} over`
-												: `${formatCurrency(remaining)} remaining`}{' '}
-											of {formatCurrency(budget.amount)}
-										</span>
-									</div>
+									{started ? (
+										<>
+											<div className="flex items-center justify-between text-sm">
+												<span className="text-muted-foreground">
+													{formatCurrency(actualSpent)} actual spend
+												</span>
+												<span
+													className={`font-medium ${
+														isOverBudget
+															? 'text-red-600 dark:text-red-400'
+															: 'text-muted-foreground'
+													}`}
+												>
+													{isOverBudget
+														? `${formatCurrency(overBudget)} over`
+														: `${formatCurrency(remaining)} remaining`}{' '}
+													of {formatCurrency(plannedAmount)}
+												</span>
+											</div>
+											<div className="mt-1 text-right text-xs text-muted-foreground">
+												{percent.toFixed(0)}% used
+											</div>
+											<div className="mt-4 border-t pt-4">
+												<div className="mb-3 flex items-center justify-between">
+													<h4 className="text-sm font-semibold">
+														Matching Transactions
+													</h4>
+													<span className="text-xs text-muted-foreground">
+														{matchingTransactions.length}{' '}
+														{matchingTransactions.length === 1
+															? 'transaction'
+															: 'transactions'}
+													</span>
+												</div>
+												{matchingTransactions.length === 0 ? (
+													<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
+														No transactions matched this budget category in the
+														selected actual period.
+													</div>
+												) : (
+													<div className="space-y-2">
+														{matchingTransactions.map((transaction) => {
+															const transactionDate = parseDbDate(
+																transaction.date ?? transaction.createdAt
+															).toLocaleDateString('en-ZA', {
+																day: 'numeric',
+																month: 'short',
+																year: 'numeric',
+															});
 
-									{/* Percentage label */}
-									<div className="mt-1 text-xs text-muted-foreground text-right">
-										{percent.toFixed(0)}% used
-									</div>
+															return (
+																<div
+																	key={transaction.id}
+																	className="flex items-center justify-between rounded-xl border bg-background px-3 py-3"
+																>
+																	<div className="min-w-0">
+																		<p className="truncate text-sm font-medium">
+																			{transaction.title}
+																		</p>
+																		<p className="text-xs text-muted-foreground">
+																			{transactionDate}
+																			{transaction.description
+																				? ` • ${transaction.description}`
+																				: ''}
+																		</p>
+																	</div>
+																	<p className="ml-3 flex-shrink-0 font-semibold text-red-600 dark:text-red-400">
+																		{formatCurrency(transaction.amount)}
+																	</p>
+																</div>
+															);
+														})}
+													</div>
+												)}
+											</div>
+										</>
+									) : (
+										<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
+											This budget has a planned amount and period, but no actual
+											comparison period yet.
+										</div>
+									)}
 								</div>
 							);
 						})}

--- a/src/views/RecurringTransactions/RecurringTransactionForm.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionForm.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiDollarSign, FiTag, FiInfo, FiSave, FiX, FiRefreshCw, FiArrowUpCircle, FiArrowDownCircle } from 'react-icons/fi';
 import { useTransactionsContext } from '../../context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { RecurringTransaction } from '../../models/RecurringTransactionModel';
-import { Category } from '../../types';
 import { Button } from '../../components/app/ui/button';
 import { Input } from '../../components/app/ui/input';
 import { Label } from '../../components/app/ui/label';
@@ -15,20 +15,12 @@ import {
 	SelectValue,
 } from '../../components/app/ui/select';
 import { Loader2 } from 'lucide-react';
+import { mergeCategoryOptions } from '../../utils/categories';
 
 interface RecurringTransactionFormProps {
 	onClose: () => void;
 	transaction?: RecurringTransaction;
 }
-
-const CATEGORIES: Category[] = [
-	{ value: 'personal', label: 'Personal' },
-	{ value: 'food', label: 'Food' },
-	{ value: 'travel', label: 'Travel' },
-	{ value: 'entertainment', label: 'Entertainment' },
-	{ value: 'debit_order', label: 'Debit Order' },
-	{ value: 'other', label: 'Other' },
-];
 
 const FREQUENCIES = [
 	{ value: 'daily', label: 'Daily' },
@@ -39,6 +31,7 @@ const FREQUENCIES = [
 
 const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onClose, transaction: expense }) => {
 	const { addRecurringTransaction, updateRecurringTransaction } = useTransactionsContext();
+	const { categoryOptions } = useCategoriesContext();
 	const [title, setTitle] = useState('');
 	const [amount, setAmount] = useState(0);
 	const [transactionType, setTransactionType] = useState<'expense' | 'income'>('expense');
@@ -48,6 +41,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 		'monthly'
 	);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const availableCategories = React.useMemo(
+		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
+		[categoryOptions, category]
+	);
 
 	useEffect(() => {
 		if (expense) {
@@ -212,7 +209,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 								<SelectValue placeholder="Select a category" />
 							</SelectTrigger>
 							<SelectContent>
-								{CATEGORIES.map((cat) => (
+								{availableCategories.map((cat) => (
 									<SelectItem key={cat.value} value={cat.value}>
 										{cat.label}
 									</SelectItem>

--- a/src/views/RecurringTransactions/RecurringTransactionsList.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionsList.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { FiEdit, FiTrash2, FiPlus, FiDollarSign } from 'react-icons/fi';
 import { useTransactionsContext } from '../../context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { RecurringTransaction } from '../../models/RecurringTransactionModel';
 import { Button } from '../../components/app/ui/button';
 import RecurringTransactionForm from './RecurringTransactionForm';
@@ -17,6 +18,7 @@ import { formatCurrency } from '../../utils/formatCurrency';
 const RecurringTransactionsList: React.FC = () => {
 	const { recurringTransactions, deleteRecurringTransaction, recurringTransactionsLoading } =
 		useTransactionsContext();
+	const { getCategoryLabel } = useCategoriesContext();
 	const [editingTransaction, setEditingTransaction] = useState<RecurringTransaction | undefined>(undefined);
 	const [isFormOpen, setIsFormOpen] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -120,7 +122,7 @@ const RecurringTransactionsList: React.FC = () => {
 								<div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
 									<span>{formatCurrency(transaction.amount)}</span>
 									<span className="hidden sm:inline">•</span>
-									<span>{transaction.category}</span>
+									<span>{getCategoryLabel(transaction.category)}</span>
 									{transaction.description && (
 										<>
 											<span className="hidden sm:inline">•</span>

--- a/src/views/RecurringTransactions/RecurringTransactionsView.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionsView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { FiEdit, FiTrash2, FiPlus, FiDollarSign, FiRefreshCw, FiX, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '../../context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { RecurringTransaction } from '../../models/RecurringTransactionModel';
 import { Button } from '../../components/app/ui/button';
 import { Badge } from '../../components/app/ui/badge';
@@ -22,6 +23,7 @@ import {
 } from '../../components/app/ui/select';
 import { formatCurrency } from '../../utils/formatCurrency';
 import { useFilterPreferences } from '../../context/FilterPreferencesContext';
+import { mergeCategoryOptions } from '../../utils/categories';
 
 const FREQUENCY_OPTIONS = [
 	{ value: 'all', label: 'All Frequencies' },
@@ -29,16 +31,6 @@ const FREQUENCY_OPTIONS = [
 	{ value: 'weekly', label: 'Weekly' },
 	{ value: 'monthly', label: 'Monthly' },
 	{ value: 'yearly', label: 'Yearly' },
-];
-
-const CATEGORY_OPTIONS = [
-	{ value: 'all', label: 'All Categories' },
-	{ value: 'personal', label: 'Personal' },
-	{ value: 'food', label: 'Food' },
-	{ value: 'travel', label: 'Travel' },
-	{ value: 'entertainment', label: 'Entertainment' },
-	{ value: 'debit_order', label: 'Debit Order' },
-	{ value: 'other', label: 'Other' },
 ];
 
 const TYPE_OPTIONS = [
@@ -76,12 +68,13 @@ const buildFilterLabel = (
 	frequencyFilter: string,
 	categoryFilter: string,
 	typeFilter: string,
-	sortBy: SortBy
+	sortBy: SortBy,
+	categoryOptions: Array<{ value: string; label: string }>
 ): string => {
 	const parts: string[] = [];
 	if (frequencyFilter !== 'all') parts.push(getFrequencyLabel(frequencyFilter));
 	if (categoryFilter !== 'all') {
-		const opt = CATEGORY_OPTIONS.find((o) => o.value === categoryFilter);
+		const opt = categoryOptions.find((o) => o.value === categoryFilter);
 		if (opt) parts.push(opt.label);
 	}
 	if (typeFilter !== 'all') {
@@ -97,6 +90,7 @@ const buildFilterLabel = (
 const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ onOpenSettings }) => {
 	const { recurringTransactions, deleteRecurringTransaction, recurringTransactionsLoading } =
 		useTransactionsContext();
+	const { categoryOptions, getCategoryLabel } = useCategoriesContext();
 
 	const { prefs } = useFilterPreferences();
 	const recurringPrefs = prefs.recurring;
@@ -109,6 +103,16 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	const [editingTransaction, setEditingTransaction] = useState<RecurringTransaction | undefined>(undefined);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [transactionToDelete, setTransactionToDelete] = useState<string | null>(null);
+	const filterCategoryOptions = useMemo(
+		() => [
+			{ value: 'all', label: 'All Categories' },
+			...mergeCategoryOptions(
+				categoryOptions,
+				recurringTransactions.map((transaction) => transaction.category)
+			),
+		],
+		[categoryOptions, recurringTransactions]
+	);
 
 	const hasActiveFilters =
 		frequencyFilter !== 'all' || categoryFilter !== 'all' || typeFilter !== 'all' || sortBy !== 'default';
@@ -149,8 +153,15 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	);
 
 	const filterLabel = useMemo(
-		() => buildFilterLabel(frequencyFilter, categoryFilter, typeFilter, sortBy),
-		[frequencyFilter, categoryFilter, typeFilter, sortBy]
+		() =>
+			buildFilterLabel(
+				frequencyFilter,
+				categoryFilter,
+				typeFilter,
+				sortBy,
+				filterCategoryOptions
+			),
+		[frequencyFilter, categoryFilter, typeFilter, sortBy, filterCategoryOptions]
 	);
 
 	const handleEdit = (transaction: RecurringTransaction) => {
@@ -254,7 +265,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								{CATEGORY_OPTIONS.map((opt) => (
+								{filterCategoryOptions.map((opt) => (
 									<SelectItem key={opt.value} value={opt.value}>
 										{opt.label}
 									</SelectItem>
@@ -382,7 +393,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 										{formatCurrency(expense.amount)}
 									</span>
 									<span>•</span>
-									<span>{expense.category}</span>
+									<span>{getCategoryLabel(expense.category)}</span>
 									{expense.description && (
 										<>
 											<span>•</span>

--- a/src/views/Reports/ReportsView.tsx
+++ b/src/views/Reports/ReportsView.tsx
@@ -16,6 +16,7 @@ import {
 } from 'recharts';
 import { useTransactionsContext } from '../../context/TransactionsContext';
 import { useAccountsContext } from '../../context/AccountsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { DateRange } from '../../types';
 import {
 	getSpendingByCategory,
@@ -30,6 +31,7 @@ import DateRangeFilter from '../../components/app/DateRangeFilter';
 const ReportsView: React.FC = () => {
 	const { transactions } = useTransactionsContext();
 	const { accounts } = useAccountsContext();
+	const { getCategoryLabel } = useCategoriesContext();
 
 	const [dateRange, setDateRange] = useState<DateRange>({ startDate: '', endDate: '' });
 
@@ -43,6 +45,14 @@ const ReportsView: React.FC = () => {
 	const categoryData = useMemo(
 		() => getSpendingByCategory(filteredTransactions, dateRange),
 		[filteredTransactions, dateRange]
+	);
+	const labeledCategoryData = useMemo(
+		() =>
+			categoryData.map((entry) => ({
+				...entry,
+				displayCategory: getCategoryLabel(entry.category),
+			})),
+		[categoryData, getCategoryLabel]
 	);
 
 	const accountData = useMemo(
@@ -232,23 +242,23 @@ const ReportsView: React.FC = () => {
 						<h2 className="mb-4 text-base font-semibold">
 							Spending by Category
 						</h2>
-						{categoryData.length > 0 ? (
+						{labeledCategoryData.length > 0 ? (
 							<>
 								<ResponsiveContainer width="100%" height={220}>
 									<PieChart>
 										<Pie
-											data={categoryData}
+											data={labeledCategoryData}
 											dataKey="amount"
-											nameKey="category"
+											nameKey="displayCategory"
 											cx="50%"
 											cy="50%"
 											outerRadius={80}
-											label={({ category, percent }) =>
-												`${category} ${(percent * 100).toFixed(0)}%`
+											label={({ displayCategory, percent }) =>
+												`${displayCategory} ${(percent * 100).toFixed(0)}%`
 											}
 											labelLine={false}
 										>
-											{categoryData.map((entry, index) => (
+											{labeledCategoryData.map((entry, index) => (
 												<Cell
 													key={`cell-${index}`}
 													fill={entry.color}
@@ -267,7 +277,7 @@ const ReportsView: React.FC = () => {
 									</PieChart>
 								</ResponsiveContainer>
 								<div className="mt-2 space-y-1">
-									{categoryData.slice(0, 5).map((d) => (
+									{labeledCategoryData.slice(0, 5).map((d) => (
 										<div
 											key={d.category}
 											className="flex items-center justify-between text-sm"
@@ -277,9 +287,7 @@ const ReportsView: React.FC = () => {
 													className="h-2.5 w-2.5 rounded-full flex-shrink-0"
 													style={{ backgroundColor: d.color }}
 												/>
-												<span className="capitalize">
-													{d.category}
-												</span>
+												<span>{d.displayCategory}</span>
 											</div>
 											<span className="font-medium">
 												{formatCurrency(d.amount)}

--- a/src/views/Transactions/TransactionForm.tsx
+++ b/src/views/Transactions/TransactionForm.tsx
@@ -4,7 +4,8 @@ import { useTransactionsContext } from '../../context/TransactionsContext';
 import { useAccountsContext } from '../../context/AccountsContext';
 import { Transaction } from '../../models/TransactionModel';
 import { RecurringTransaction } from '../../models/RecurringTransactionModel';
-import { Category, TransactionType } from '../../types';
+import { TransactionType } from '../../types';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { Button } from '../../components/app/ui/button';
 import { Input } from '../../components/app/ui/input';
 import { Textarea } from '../../components/app/ui/textarea';
@@ -16,21 +17,13 @@ import {
 	SelectValue,
 } from '../../components/app/ui/select';
 import { formatCurrency } from '../../utils/formatCurrency';
+import { mergeCategoryOptions } from '../../utils/categories';
 
 interface TransactionFormProps {
 	onClose: () => void;
 	transaction?: Transaction;
 	recurringTransaction?: RecurringTransaction;
 }
-
-const CATEGORIES: Category[] = [
-	{ value: 'personal', label: 'Personal' },
-	{ value: 'food', label: 'Food' },
-	{ value: 'travel', label: 'Travel' },
-	{ value: 'entertainment', label: 'Entertainment' },
-	{ value: 'debit_order', label: 'Debit Order' },
-	{ value: 'other', label: 'Other' },
-];
 
 const TransactionForm: React.FC<TransactionFormProps> = ({
 	onClose,
@@ -39,6 +32,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 }) => {
 	const { addTransaction, addTransfer, updateTransaction, recurringTransactions } = useTransactionsContext();
 	const { accounts } = useAccountsContext();
+	const { categoryOptions } = useCategoriesContext();
 
 	const [title, setTitle] = useState('');
 	const [amount, setAmount] = useState(0);
@@ -50,6 +44,11 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 	const [date, setDate] = useState<string>('');
 	const [selectedRecurringId, setSelectedRecurringId] = useState<string | null>(
 		initialRecurringTransaction?.id || null
+	);
+
+	const availableCategories = React.useMemo(
+		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
+		[categoryOptions, category]
 	);
 
 	// Default to first account
@@ -300,14 +299,14 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 					<div className="grid gap-6 md:grid-cols-2">
 						{type !== 'transfer' && (
 							<Select value={category} onValueChange={setCategory}>
-								<SelectTrigger>
-									<SelectValue placeholder="Category" />
-								</SelectTrigger>
-								<SelectContent>
-									{CATEGORIES.map((cat) => (
-										<SelectItem key={cat.value} value={cat.value}>
-											{cat.label}
-										</SelectItem>
+							<SelectTrigger>
+								<SelectValue placeholder="Category" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableCategories.map((cat) => (
+									<SelectItem key={cat.value} value={cat.value}>
+										{cat.label}
+									</SelectItem>
 									))}
 								</SelectContent>
 							</Select>

--- a/src/views/Transactions/TransactionsList.tsx
+++ b/src/views/Transactions/TransactionsList.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { FiArrowUp, FiArrowDown, FiSearch, FiCalendar, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '../../context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import { formatCurrency } from '../../utils/formatCurrency';
 import { Input } from '../../components/app/ui/input';
 import { Badge } from '../../components/app/ui/badge';
@@ -25,6 +26,7 @@ const CATEGORY_COLORS: Record<string, string> = {
 
 const TransactionsList: React.FC<TransactionsListProps> = ({ onSelect, selectedId, onOpenSettings }) => {
 	const { transactions } = useTransactionsContext();
+	const { getCategoryLabel } = useCategoriesContext();
 	const { prefs } = useFilterPreferences();
 	const listPrefs = prefs.transactionsList;
 	const [search, setSearch] = useState('');
@@ -164,7 +166,7 @@ const TransactionsList: React.FC<TransactionsListProps> = ({ onSelect, selectedI
 																		backgroundColor: `${CATEGORY_COLORS[tx.category] || '#9CA3AF'}15`,
 																	}}
 																>
-																	{tx.category}
+																	{getCategoryLabel(tx.category)}
 																</Badge>
 																<span className="text-xs text-muted-foreground font-medium">
 																	{tx.type}

--- a/src/views/Transactions/TransactionsTable.tsx
+++ b/src/views/Transactions/TransactionsTable.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { FiTrash2, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '../../context/TransactionsContext';
+import { useCategoriesContext } from '../../context/CategoriesContext';
 import DateRangeFilter from '../../components/app/DateRangeFilter';
 import { filterTransactionsByDateRangeObject } from '../../utils/dateRangeFilter';
 import { formatCurrency } from '../../utils/formatCurrency';
@@ -24,6 +25,7 @@ import {
 import { Button } from '../../components/app/ui/button';
 import { Badge } from '../../components/app/ui/badge';
 import { useFilterPreferences } from '../../context/FilterPreferencesContext';
+import { mergeCategoryOptions } from '../../utils/categories';
 
 interface TransactionsTableProps {
 	onDelete: (id: string) => void;
@@ -68,6 +70,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 	onOpenSettings,
 }) => {
 	const { transactions } = useTransactionsContext();
+	const { categoryOptions, getCategoryLabel } = useCategoriesContext();
 	const { prefs } = useFilterPreferences();
 	const tablePrefs = prefs.transactionsTable;
 	const [search, setSearch] = useState('');
@@ -124,10 +127,11 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
 	const allCategories = useMemo(
 		() =>
-			Array.from(
-				new Set(transactions.map((tx) => tx.category?.trim() || 'Uncategorized'))
-			).sort(),
-		[transactions]
+			mergeCategoryOptions(
+				categoryOptions,
+				transactions.map((tx) => tx.category?.trim() || '')
+			),
+		[categoryOptions, transactions]
 	);
 
 	const visibleTransactions = filtered.slice(0, visibleCount);
@@ -224,15 +228,16 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							<SelectContent>
 								<SelectItem value="all">All categories</SelectItem>
 								{allCategories.map((category) => (
-									<SelectItem key={category} value={category}>
+									<SelectItem key={category.value} value={category.value}>
 										<div className="flex items-center gap-2">
 											<span
 												className="h-2.5 w-2.5 rounded-full"
 												style={{
-													backgroundColor: CATEGORY_COLORS[category] || '#9CA3AF',
+													backgroundColor:
+														CATEGORY_COLORS[category.value] || '#9CA3AF',
 												}}
 											/>
-											{category}
+											{category.label}
 										</div>
 									</SelectItem>
 								))}
@@ -342,7 +347,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 													CATEGORY_COLORS[tx.category] || '#9CA3AF',
 											}}
 										>
-											{tx.category}
+											{getCategoryLabel(tx.category)}
 										</Badge>
 									</TableCell>
 


### PR DESCRIPTION
### Summary

This PR introduces two major improvements to the budgeting and categorization system:

1. **Configurable Budget Periods with Plan vs Actual tracking**
2. **User-configurable Categories managed via Settings**

These changes make budgeting more flexible and ensure category consistency across the entire application.

---

### What Changed

#### 1. Plan vs Actual Budgets

* Budgets are no longer tied to calendar months
* Each budget now stores:

  * `plannedStartDate` / `plannedEndDate`
  * `actualStartDate` / `actualEndDate`
* Added `startBudget` action to capture actual tracking period from the UI filter
* Budget calculations now use explicit date ranges instead of implicit monthly logic
* Budgets without actual dates show a **“not started”** state

##### UI Updates

* Budget form now supports custom planned date ranges
* Budgets screen includes a date filter used to set actual tracking periods
* Budget cards redesigned to show:

  * Planned vs actual ranges
  * Actual spend vs planned amount
  * Remaining / over budget
  * Progress bar
  * Matching transactions (filtered by category + date range)

---

#### 2. User-Configurable Categories

* Replaced static category constants with per-user categories stored in Firestore
* Added Categories management section in Settings modal

Users can:

* Create custom categories
* Rename categories (propagates across all related data)
* Delete unused categories (blocked if in use)

##### Default Categories (seeded for new users)

* Personal
* Cash Withdrawal
* Other
* Debit Order
* Travel
* Food
* Entertainment

##### App-wide Changes

* All category selectors now use the shared category data layer
* Transactions, budgets, recurring transactions, filters, and reports are fully synced
* Transfer logic remains unchanged and excluded from configurable categories

---

### Architecture Notes

* Maintains existing MVC structure (hooks → controllers → context)
* Introduces a shared category data layer:

  * `useCategories`
  * `CategoriesController`
  * `CategoriesContext`
* Budget calculations now accept explicit date ranges instead of deriving month boundaries

---

### Testing

* Verified via `npm run build`
* Manual validation includes:

  * Creating/editing budgets with custom dates
  * Starting/restarting budget tracking
  * Category CRUD flows in Settings
  * Category rename propagation across data
  * Budget transaction filtering by category + date range

---

### Notes

* Legacy `period: 'monthly'` is retained for compatibility but no longer used
* Existing budgets without planned dates fall back safely
* No automated tests added in this PR (manual + build verification only)
