### PR TITLE
Docs, sidebar UX, keyboard shortcut, and lint-quality cleanup

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -108,6 +108,51 @@ Authorization: Bearer <firebase_id_token>
 }
 ```
 
+### 3. Ask AI Assistant
+
+**POST** `/askAI`
+
+Generate a finance summary/answer from the authenticated user's transactions and accounts.
+
+**Request:**
+
+```http
+POST /askAI
+Authorization: Bearer <firebase_id_token>
+Content-Type: application/json
+```
+
+```json
+{
+	"question": "How much did I spend this month?",
+	"userId": "user_uid"
+}
+```
+
+**Response:**
+
+```json
+{
+	"success": true,
+	"answer": "You spent R2,350.00 this month across 12 expenses..."
+}
+```
+
+**Status Codes:**
+
+- `200` - Success (including no-transaction guidance responses)
+- `400` - Missing `question` or `userId`
+- `401` - Missing/invalid auth token
+- `403` - Authenticated token user does not match `userId`
+- `405` - Method not allowed
+- `500` - Internal server error
+
+**Notes:**
+
+- `askAI` currently analyzes up to 2000 transactions per request.
+- Monthly calculations use `date` and fall back to `createdAt` when `date` is unavailable.
+- Responses are rule-based summaries from user data (no external model call in this function).
+
 ## Data Models
 
 ### Transaction
@@ -124,6 +169,7 @@ interface Transaction {
 	description?: string;
 	date?: string;
 	createdAt?: string;
+	updatedAt?: string;
 	transferAccountId?: string;
 }
 ```
@@ -147,7 +193,8 @@ The API returns appropriate HTTP status codes and error messages:
 | ----------- | --------------------- | --------------------------------- |
 | `200`       | Success               | -                                 |
 | `401`       | Unauthorized          | "Invalid or expired token"        |
-| `405`       | Method not allowed    | "Only GET requests are supported" |
+| `403`       | Forbidden             | "Authenticated user does not match the provided userId" |
+| `405`       | Method not allowed    | "Only GET/POST requests are supported" |
 | `500`       | Internal server error | "Internal server error"           |
 
 ## CORS

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,59 @@
+# Coding Standards Uplift Backlog
+
+This backlog defines incremental engineering-standard improvements with clear acceptance checks.
+
+## 1) Type Safety Hardening
+
+- Replace remaining `any` usage in app code paths with shared domain types from `src/types`.
+- Prefer explicit union types for view routing and UI state transitions.
+
+Acceptance checks:
+
+- `rg "\bany\b" src --glob "*.{ts,tsx}"` should only match intentional library interop exceptions.
+- Dashboard/table/list selection and delete handlers compile without type assertions.
+
+## 2) Shared Date Semantics
+
+- Use centralized date helpers from `src/utils/date.ts` for transaction sorting and display fallback behavior.
+- Ensure every transaction surface consistently uses `date ?? createdAt`.
+
+Acceptance checks:
+
+- No duplicated inline `toDate` parsing logic in sidebar/list/table flows.
+- Transaction ordering is consistent across dashboard surfaces for the same dataset.
+
+## 3) Cloud Function Modularity
+
+- Break `functions/src/index.ts` into focused helpers/services:
+  - request/auth validation
+  - transaction/account analytics
+  - intent routing and response formatting
+- Keep endpoint handlers thin and orchestrator-like.
+
+Acceptance checks:
+
+- Each service/helper file has a single responsibility and isolated unit-test targets.
+- Endpoint handlers are primarily validation + orchestration (minimal business branching inline).
+
+## 4) Error Handling Standards
+
+- Replace console-only failures in user workflows with surfaced UI feedback where appropriate.
+- Ensure API responses are explicit and consistent (`success`, `error`, actionable messages).
+
+Acceptance checks:
+
+- High-risk user flows (import, delete, transaction submit) always produce user-visible feedback on failure.
+- Functions endpoints return predictable status codes and stable error shapes.
+
+## 5) Test Coverage Priorities
+
+- Add regression tests around known risk areas:
+  - single-confirm delete flow
+  - import-without-account guard
+  - AI month date fallback
+  - transfer balance invariants
+
+Acceptance checks:
+
+- New tests fail before regressions are fixed and pass after.
+- `npm test` and `npm run lint` pass on CI for touched files.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **Reports:** Spending by category (pie chart), spending by account (bar chart), income vs expense trend (area chart), and net worth breakdown.
 - **Account Detail Page:** Per-account transaction history with income/expense totals and category breakdown.
 - **Recurring Transactions:** Create income or expense recurring templates accessible from the dedicated "Recurring" sidebar view, with filtering by frequency, category, and type, and Quick Fill support in the transaction form.
+- **AI Assistant:** Ask natural-language questions about spending, categories, merchants, and account trends from your own transaction data.
 - **Import/Export:** Import transactions from CSV/JSON with validation and deduping; export all data as CSV/JSON.
 - **MVC Architecture:** Clean separation of concerns — models, hooks, controllers, contexts, views.
 - **Theme Support:** Dark and light mode throughout.
@@ -132,6 +133,7 @@ ThemeProvider → TransactionsProvider → AccountsProvider → BudgetsProvider 
 - Use `writeBatch` + `increment()` for any operation that touches both a transaction and an account balance.
 - Reuse utilities from `src/utils/` instead of duplicating logic.
 - Use shared types from `src/types/` across all layers.
+- See `CODING_STANDARDS.md` for the incremental standards uplift backlog and acceptance checks.
 
 ## Goals
 
@@ -166,8 +168,18 @@ ThemeProvider → TransactionsProvider → AccountsProvider → BudgetsProvider 
 ## Import/Export Usage
 
 - Open the Dashboard → Settings (bottom-left in the sidebar) → "Data" tab.
-- **Import:** upload a `.csv` or `.json` file. Required fields: `title`, `amount`, `type`, `category`. Optional: `accountId`, `description`, `date`. Duplicates are skipped via title+amount+type+category+date signature.
+- **Import:** upload a `.csv` or `.json` file. Required fields: `title`, `amount`, `type`, `category`. Optional: `accountId`, `description`, `date`.
+- Import requires at least one account to exist first. If `accountId` is missing on a row, the first available account is used.
+- Only `income` and `expense` rows are accepted during import (`transfer` rows are rejected).
+- Duplicates are skipped via `title+amount+type+category+date` signature.
 - **Export CSV / Export JSON:** downloads all your transactions including `accountId`.
+
+## AI Assistant Notes
+
+- AI responses are scoped to the authenticated user's data only, and the API verifies that request `userId` matches the auth token user.
+- The assistant uses deterministic, rule-based analytics over up to 2000 transactions.
+- Date-based monthly analysis uses transaction `date` and falls back to `createdAt` when needed.
+- Best supported prompts: monthly spend, category totals, merchant frequency/spend, and highest-spend account comparisons.
 
 ## Ideal For
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,152 +2,65 @@
 
 ## Overview
 
-This document outlines the testing strategy for the Cash Flow application, focusing on authentication and currency formatting functionality.
+This document summarizes current automated coverage and manual testing priorities for Cash Flow.
 
 ## Testing Stack
 
-- **Jest**: Test runner and assertion library
-- **React Testing Library**: Component testing utilities
-- **@testing-library/user-event**: User interaction simulation
-- **@testing-library/jest-dom**: Custom Jest matchers for DOM testing
+- **Jest**: test runner and assertions
+- **React Testing Library**: component-level testing
+- **@testing-library/user-event**: realistic UI interactions
+- **@testing-library/jest-dom**: DOM matchers
 
 ## Test Structure
 
 ```
 src/
-├── __tests__/
-│   └── utils/
-│       └── test-utils.ts          # Test utilities and mocks
-├── hooks/__tests__/
-│   └── useAuth.test.ts            # Authentication hook tests
 ├── components/__tests__/
-│   └── AuthModals.test.tsx       # Authentication modal tests
-└── utils/__tests__/
-    └── formatCurrency.test.ts     # ZAR currency formatting tests
+│   ├── AIChatbot.test.tsx
+│   └── AuthModals.test.tsx
+├── hooks/__tests__/
+│   └── useAuth.test.ts
+├── utils/__tests__/
+│   └── formatCurrency.test.ts
+└── setupTests.ts
 ```
 
 ## Running Tests
 
-### Quick Start
-
 ```bash
-# Install dependencies (if not already installed)
-npm install
-
-# Run all tests
 npm test
-
-# Run tests in watch mode
 npm run test:watch
-
-# Run tests with coverage
 npm run test:coverage
 ```
 
-## Test Categories
+## Current Automated Coverage
 
-### 1. Authentication Tests
+- `useAuth` authentication state and login/register behavior
+- `AuthModals` UI flows and validation
+- `formatCurrency` numeric and formatting edge cases
+- `AIChatbot` chat UI flow and API error handling
 
-#### Hooks Testing
+Run `npm test` for the latest exact test count in your environment.
 
-- **useAuth**: Tests authentication state management
-    - User authentication state changes
-    - Firebase auth integration
-    - Error handling
-    - Token management
+## Manual Regression Checklist
 
-#### Component Testing
-
-- **AuthModals**: Tests authentication UI
-    - Login/Register form validation
-    - Google sign-in integration
-    - Error message display
-    - Loading states
-    - Form reset functionality
-
-### 2. Currency Formatting Tests
-
-#### Utility Testing
-
-- **formatCurrency**: Tests ZAR currency formatting
-    - Positive and negative amounts
-    - Zero amounts (including negative zero)
-    - String input handling
-    - Invalid input handling (NaN, Infinity)
-    - Decimal precision and rounding
-    - Large numbers with proper grouping
-    - Very small amounts
-
-## Test Coverage
-
-### Authentication Features
-
-- ✅ User registration (email/password and Google OAuth)
-- ✅ User login (email/password and Google OAuth)
-- ✅ Authentication state management
-- ✅ Error handling for invalid credentials
-- ✅ Loading states during authentication
-- ✅ Form validation and submission
-
-### Currency Features
-
-- ✅ ZAR (South African Rand) currency formatting
-- ✅ Proper locale formatting (en-ZA)
-- ✅ Non-breaking space handling
-- ✅ Decimal and thousands separators
-- ✅ Edge case handling (invalid inputs, negative zero)
-
-### Recurring Transaction Features (Manual Testing Required)
-
-- ✅ Create recurring transaction (income and expense types)
-- ✅ Edit recurring transaction
-- ✅ Delete recurring transaction (with confirmation dialog)
-- ✅ Income/expense type toggle in form
-- ✅ Frequency, category, and type filtering in RecurringTransactionsView
-- ✅ Filter reset button clears all active filters
-- ✅ Total summary card updates when filters are applied
-- ✅ Quick Fill feature in transaction form
-- ✅ Real-time updates via Firestore subscriptions
-- ✅ User data isolation (users can only see their own recurring transactions)
-- ✅ Form validation (required fields, amount > 0)
-- ✅ Frequency selection (daily/weekly/monthly/yearly)
-
-## Test Results
-
-Current test suite includes:
-
-- **20 authentication tests** (useAuth + AuthModals)
-- **8 currency formatting tests** (formatCurrency)
-- **Total: 28 automated tests passing**
-
-**Manual Testing Checklist:**
-- Recurring transaction CRUD operations
-- Quick Fill functionality
-- Firestore security rules
+- Recurring transaction CRUD and quick-fill behavior
+- Import/export flows (CSV/JSON, duplicate handling)
+- Dashboard/Table/List filtering and sorting behavior
+- Multi-account transfer and reconcile flows
 - Theme switching (dark/light mode)
-- Responsive design
+- Mobile responsiveness and sidebar navigation
 
-## Configuration
+## High-Priority Missing Tests
 
-### Jest Configuration
+1. Single-confirm transaction deletion flow (no duplicate confirmation dialogs).
+2. Import should fail fast when no accounts exist.
+3. `askAI` monthly analytics should include entries that only have `createdAt`.
+4. Transfer pair update/delete invariants and account-balance integrity.
+5. Dashboard selection/edit lifecycle across `transaction`, `table`, and `list` views.
 
-- ES modules support
-- TypeScript compilation
-- JSDOM environment
-- CSS and asset mocking
-- Environment variable mocking
+## Configuration Notes
 
-### Mock Setup
-
-- Firebase Auth mocking
-- React Router mocking
-- localStorage mocking
-- Material-UI component mocking
-
-## Best Practices
-
-1. **Focused Testing**: Tests focus only on authentication and currency features
-2. **Mock Isolation**: External dependencies are properly mocked
-3. **Edge Case Coverage**: Invalid inputs and error scenarios are tested
-4. **Realistic Scenarios**: Tests simulate actual user interactions
-5. **Maintainable**: Clean, readable test code with proper setup/teardown
+- JSDOM environment with TypeScript (`ts-jest`)
+- Firebase/auth and browser API mocks in test setup utilities
+- Local storage and router behavior mocked where needed

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -59,12 +59,12 @@ async function verifyToken(authHeader: string): Promise<admin.auth.DecodedIdToke
 	try {
 		const decodedToken = await admin.auth().verifyIdToken(token);
 		return decodedToken;
-	} catch (error) {
+	} catch {
 		throw new Error('Invalid or expired token');
 	}
 }
 
-function setCorsHeaders(res: functions.Response<any>): void {
+function setCorsHeaders(res: functions.Response<unknown>): void {
 	res.set('Access-Control-Allow-Origin', '*');
 	res.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
 	res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
@@ -243,7 +243,10 @@ function formatTopBreakdown(
 }
 
 // Helper function to create API response
-function createResponse(statusCode: number, body: ApiResponse): any {
+function createResponse(
+	statusCode: number,
+	body: ApiResponse
+): { statusCode: number; headers: Record<string, string>; body: string } {
 	return {
 		statusCode,
 		headers: {
@@ -476,7 +479,7 @@ export const askAI = functions.https.onRequest(async (req, res) => {
 		const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
 		const inThisMonth = (transaction: Transaction): boolean => {
-			const parsedDate = parseDate(transaction.date);
+			const parsedDate = parseDate(transaction.date) ?? parseDate(transaction.createdAt);
 			if (!parsedDate) {
 				return false;
 			}

--- a/src/components/__tests__/AuthModals.test.tsx
+++ b/src/components/__tests__/AuthModals.test.tsx
@@ -57,7 +57,7 @@ describe('AuthModals - Authentication', () => {
 	it('should render register modal when mode is register', () => {
 		render(<AuthModals {...defaultProps} mode="register" />);
 
-		expect(screen.getByText('Create Account', { selector: 'span' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Create Account' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Create Account' })).toBeInTheDocument();
 	});
 
@@ -75,9 +75,7 @@ describe('AuthModals - Authentication', () => {
 		const user = userEvent.setup();
 		render(<AuthModals {...defaultProps} />);
 
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 		await user.type(passwordInput, 'password123');
 
 		expect(passwordInput).toHaveValue('password123');
@@ -87,10 +85,8 @@ describe('AuthModals - Authentication', () => {
 		const user = userEvent.setup();
 		render(<AuthModals {...defaultProps} />);
 
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
-		const toggleButton = screen.getByLabelText('toggle password visibility');
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
+		const toggleButton = screen.getByLabelText('Toggle password visibility');
 
 		// Password should be hidden by default
 		expect(passwordInput).toHaveAttribute('type', 'password');
@@ -111,9 +107,7 @@ describe('AuthModals - Authentication', () => {
 		render(<AuthModals {...defaultProps} />);
 
 		const emailInput = screen.getByRole('textbox', { name: /email/i });
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 		const submitButton = screen.getByRole('button', { name: 'Sign In' });
 
 		await user.type(emailInput, 'test@example.com');
@@ -139,9 +133,7 @@ describe('AuthModals - Authentication', () => {
 		render(<AuthModals {...defaultProps} mode="register" />);
 
 		const emailInput = screen.getByRole('textbox', { name: /email/i });
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 		const submitButton = screen.getByRole('button', { name: 'Create Account' });
 
 		await user.type(emailInput, 'test@example.com');
@@ -168,9 +160,7 @@ describe('AuthModals - Authentication', () => {
 		render(<AuthModals {...defaultProps} />);
 
 		const emailInput = screen.getByRole('textbox', { name: /email/i });
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 		const submitButton = screen.getByRole('button', { name: 'Sign In' });
 
 		await user.type(emailInput, 'test@example.com');
@@ -243,9 +233,7 @@ describe('AuthModals - Authentication', () => {
 		render(<AuthModals {...defaultProps} />);
 
 		const emailInput = screen.getByRole('textbox', { name: /email/i });
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 
 		// Fill form
 		await user.type(emailInput, 'test@example.com');
@@ -265,9 +253,7 @@ describe('AuthModals - Authentication', () => {
 		render(<AuthModals {...defaultProps} />);
 
 		const emailInput = screen.getByRole('textbox', { name: /email/i });
-		const passwordInput = screen
-			.getAllByDisplayValue('')
-			.find((element) => element.getAttribute('name') === 'password') as HTMLInputElement;
+		const passwordInput = screen.getByLabelText(/^Password$/) as HTMLInputElement;
 		const submitButton = screen.getByRole('button', { name: 'Sign In' });
 
 		await user.type(emailInput, 'test@example.com');

--- a/src/components/app/AuthModals.tsx
+++ b/src/components/app/AuthModals.tsx
@@ -52,8 +52,8 @@ const AuthModals: React.FC<AuthModalsProps> = ({ open, onClose, mode, onModeChan
 			handleSuccessfulAuth();
 			setEmail('');
 			setPassword('');
-		} catch (error: any) {
-			setError(error.message);
+		} catch (error: unknown) {
+			setError(error instanceof Error ? error.message : 'Something went wrong');
 		} finally {
 			setLoading(false);
 		}
@@ -73,8 +73,8 @@ const AuthModals: React.FC<AuthModalsProps> = ({ open, onClose, mode, onModeChan
 			const provider = new GoogleAuthProvider();
 			await signInWithPopup(auth, provider);
 			handleSuccessfulAuth();
-		} catch (error: any) {
-			setError(error.message);
+		} catch (error: unknown) {
+			setError(error instanceof Error ? error.message : 'Something went wrong');
 		} finally {
 			setGoogleLoading(false);
 		}
@@ -160,6 +160,7 @@ const AuthModals: React.FC<AuthModalsProps> = ({ open, onClose, mode, onModeChan
 						<div className="relative">
 							<Input
 								id="password"
+								name="password"
 								type={showPassword ? 'text' : 'password'}
 								placeholder="Enter your password"
 								value={password}
@@ -173,6 +174,7 @@ const AuthModals: React.FC<AuthModalsProps> = ({ open, onClose, mode, onModeChan
 							/>
 							<button
 								type="button"
+								aria-label="Toggle password visibility"
 								onClick={() => setShowPassword(!showPassword)}
 								disabled={loading || googleLoading}
 								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground disabled:opacity-50"

--- a/src/components/app/SettingsModal.tsx
+++ b/src/components/app/SettingsModal.tsx
@@ -563,7 +563,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 									onClick={onClose}
 									className="w-full sm:w-auto"
 								>
-									Sign In
+									Close
 								</Button>
 							)}
 							<Button

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -11,22 +11,15 @@ import {
 	FiBarChart2,
 	FiList,
 	FiRefreshCw,
+	FiChevronLeft,
 } from 'react-icons/fi';
 import { useAuth } from '../../hooks/useAuth';
-import { Transaction } from '../../types';
+import { Transaction, ViewType } from '../../types';
 import logoDark from '@/assets/images/logos/cflow-transparent-dark.png';
 import logoLight from '@/assets/images/logos/cflow-transparent-light.png';
 import { useTheme } from '../../context/ThemeContext';
 import { useTransactionsContext } from '../../context/TransactionsContext';
 import { useAccountsContext } from '../../context/AccountsContext';
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from '../app/ui/dialog';
 import { Button } from '../app/ui/button';
 import { Input } from '../app/ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from '../app/ui/avatar';
@@ -42,12 +35,12 @@ interface SidebarProps {
 	toggleSidebar: () => void;
 	onOpenSettings?: () => void;
 	onOpenLogin?: () => void;
-	onViewChange: (view: string) => void;
-	activeView: string;
+	onViewChange: (view: ViewType) => void;
+	activeView: ViewType;
 }
 
 interface NavItem {
-	id: string;
+	id: ViewType;
 	label: string;
 	icon: React.ElementType;
 }
@@ -77,8 +70,6 @@ const Sidebar: React.FC<SidebarProps> = ({
 	const { transactions } = useTransactionsContext();
 	const { accounts, calculateTotalBalance } = useAccountsContext();
 	const [searchTerm, setSearchTerm] = useState('');
-	const [dialogOpen, setDialogOpen] = useState(false);
-	const [transactionToDelete, setTransactionToDelete] = useState<string | null>(null);
 	const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
 	useEffect(() => {
@@ -105,24 +96,8 @@ const Sidebar: React.FC<SidebarProps> = ({
 		if (window.innerWidth < 768) toggleSidebar();
 	}, [onCreate, toggleSidebar]);
 
-	const handleDeleteClick = useCallback((id: string) => {
-		setTransactionToDelete(id);
-		setDialogOpen(true);
-	}, []);
-
-	const handleConfirmAction = useCallback(() => {
-		if (transactionToDelete) onDelete(transactionToDelete);
-		setDialogOpen(false);
-		setTransactionToDelete(null);
-	}, [transactionToDelete, onDelete]);
-
-	const handleCancelAction = useCallback(() => {
-		setDialogOpen(false);
-		setTransactionToDelete(null);
-	}, []);
-
 	const handleViewClick = useCallback(
-		(view: string) => {
+		(view: ViewType) => {
 			onViewChange(view);
 			if (window.innerWidth < 768) toggleSidebar();
 		},
@@ -176,25 +151,6 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 	return (
 		<>
-			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-				<DialogContent className="w-[90vw] md:w-full rounded-lg">
-					<DialogHeader>
-						<DialogTitle>Confirm Deletion</DialogTitle>
-						<DialogDescription>
-							Are you sure you want to delete this transaction?
-						</DialogDescription>
-					</DialogHeader>
-					<DialogFooter>
-						<Button variant="outline" onClick={handleCancelAction}>
-							Cancel
-						</Button>
-						<Button variant="destructive" onClick={handleConfirmAction}>
-							Delete
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-
 			{/* Mobile backdrop */}
 			{!collapsed && isMobile && (
 				<div
@@ -246,15 +202,26 @@ const Sidebar: React.FC<SidebarProps> = ({
 							</div>
 						</div>
 						{!collapsed && (
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={toggleSidebar}
-								className="md:hidden flex-shrink-0"
-								aria-label="Close sidebar"
-							>
-								<FiX className="h-5 w-5" />
-							</Button>
+							<>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={toggleSidebar}
+									className="md:hidden flex-shrink-0"
+									aria-label="Close sidebar"
+								>
+									<FiX className="h-5 w-5" />
+								</Button>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={toggleSidebar}
+									className="hidden md:inline-flex flex-shrink-0"
+									aria-label="Collapse sidebar"
+								>
+									<FiChevronLeft className="h-5 w-5" />
+								</Button>
+							</>
 						)}
 					</div>
 
@@ -383,8 +350,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 														<button
 															onClick={(e) => {
 																e.stopPropagation();
-																if (tx.id)
-																	handleDeleteClick(tx.id);
+																if (tx.id) onDelete(tx.id);
 															}}
 															className="ml-2 opacity-0 transition-opacity group-hover:opacity-100"
 															aria-label="Delete transaction"

--- a/src/components/app/ui/input.tsx
+++ b/src/components/app/ui/input.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> { }
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
 	({ className, type, ...props }, ref) => {

--- a/src/components/app/ui/textarea.tsx
+++ b/src/components/app/ui/textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 	({ className, ...props }, ref) => {

--- a/src/components/app/ui/use-toast.ts
+++ b/src/components/app/ui/use-toast.ts
@@ -11,13 +11,6 @@ type ToasterToast = ToastProps & {
 	action?: ToastActionElement;
 };
 
-const actionTypes = {
-	ADD_TOAST: 'ADD_TOAST',
-	UPDATE_TOAST: 'UPDATE_TOAST',
-	DISMISS_TOAST: 'DISMISS_TOAST',
-	REMOVE_TOAST: 'REMOVE_TOAST',
-} as const;
-
 let count = 0;
 
 function genId() {
@@ -25,23 +18,23 @@ function genId() {
 	return count.toString();
 }
 
-type ActionType = typeof actionTypes;
+type ToastActionType = 'ADD_TOAST' | 'UPDATE_TOAST' | 'DISMISS_TOAST' | 'REMOVE_TOAST';
 
 type Action =
 	| {
-		type: ActionType['ADD_TOAST'];
+		type: Extract<ToastActionType, 'ADD_TOAST'>;
 		toast: ToasterToast;
 	}
 	| {
-		type: ActionType['UPDATE_TOAST'];
+		type: Extract<ToastActionType, 'UPDATE_TOAST'>;
 		toast: Partial<ToasterToast>;
 	}
 	| {
-		type: ActionType['DISMISS_TOAST'];
+		type: Extract<ToastActionType, 'DISMISS_TOAST'>;
 		toastId?: ToasterToast['id'];
 	}
 	| {
-		type: ActionType['REMOVE_TOAST'];
+		type: Extract<ToastActionType, 'REMOVE_TOAST'>;
 		toastId?: ToasterToast['id'];
 	};
 

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -10,6 +10,7 @@ import {
 	onSnapshot,
 	Timestamp,
 	increment,
+	type UpdateData,
 } from 'firebase/firestore';
 import { Account } from '../types';
 import { normalizeAccount } from '../models/AccountModel';
@@ -65,7 +66,7 @@ export const useAccounts = () => {
 	const updateAccount = async (id: string, updates: Partial<Account>) => {
 		if (!user) throw new Error('User not authenticated');
 		const ref = doc(db, 'users', user.uid, 'accounts', id);
-		await updateDoc(ref, updates as any);
+		await updateDoc(ref, updates as UpdateData<Account>);
 	};
 
 	const deleteAccount = async (id: string) => {

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -9,6 +9,7 @@ import {
 	query,
 	onSnapshot,
 	Timestamp,
+	type UpdateData,
 } from 'firebase/firestore';
 import { Budget, DateRange } from '../types';
 import { normalizeBudget } from '../models/BudgetModel';
@@ -64,7 +65,7 @@ export const useBudgets = () => {
 	const updateBudget = async (id: string, updates: Partial<Budget>) => {
 		if (!user) throw new Error('User not authenticated');
 		const ref = doc(db, 'users', user.uid, 'budgets', id);
-		await updateDoc(ref, updates as any);
+		await updateDoc(ref, updates as UpdateData<Budget>);
 	};
 
 	const startBudget = async (id: string, actualRange: DateRange) => {

--- a/src/hooks/useRecurringTransactions.ts
+++ b/src/hooks/useRecurringTransactions.ts
@@ -1,98 +1,107 @@
 import { useState, useEffect } from 'react';
 import { db, auth } from '../services/firebase';
 import {
-collection,
-addDoc,
-deleteDoc,
-updateDoc,
-doc,
-query,
-onSnapshot,
-Timestamp,
+	collection,
+	addDoc,
+	deleteDoc,
+	updateDoc,
+	doc,
+	query,
+	onSnapshot,
+	Timestamp,
+	type UpdateData,
 } from 'firebase/firestore';
-import { normalizeRecurringTransactions, RecurringTransaction } from '../models/RecurringTransactionModel';
+import {
+	normalizeRecurringTransactions,
+	RecurringTransaction,
+} from '../models/RecurringTransactionModel';
 
 export const useRecurringTransactions = () => {
-const [recurringTransactions, setRecurringTransactions] = useState<RecurringTransaction[]>([]);
-const [loading, setLoading] = useState(true);
-const [user, setUser] = useState(() => auth.currentUser);
+	const [recurringTransactions, setRecurringTransactions] = useState<RecurringTransaction[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [user, setUser] = useState(() => auth.currentUser);
 
-useEffect(() => {
-const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
-setUser(firebaseUser);
-});
-return () => unsubscribe();
-}, []);
+	useEffect(() => {
+		const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
+			setUser(firebaseUser);
+		});
+		return () => unsubscribe();
+	}, []);
 
-useEffect(() => {
-if (!user) {
-setRecurringTransactions([]);
-setLoading(false);
-return;
-}
+	useEffect(() => {
+		if (!user) {
+			setRecurringTransactions([]);
+			setLoading(false);
+			return;
+		}
 
-setLoading(true);
+		setLoading(true);
 
-const col = collection(db, 'users', user.uid, 'recurringTransactions');
-const q = query(col);
+		const col = collection(db, 'users', user.uid, 'recurringTransactions');
+		const q = query(col);
 
-const unsubscribe = onSnapshot(
-q,
-(querySnapshot) => {
-const fetched = querySnapshot.docs.map((d) => ({
-id: d.id,
-...d.data(),
-}));
-const normalized = normalizeRecurringTransactions(fetched);
-setRecurringTransactions(normalized);
-setLoading(false);
-},
-(error) => {
-console.error('Error fetching recurring transactions:', error);
-setLoading(false);
-}
-);
+		const unsubscribe = onSnapshot(
+			q,
+			(querySnapshot) => {
+				const fetched = querySnapshot.docs.map((d) => ({
+					id: d.id,
+					...d.data(),
+				}));
+				const normalized = normalizeRecurringTransactions(fetched);
+				setRecurringTransactions(normalized);
+				setLoading(false);
+			},
+			(error) => {
+				console.error('Error fetching recurring transactions:', error);
+				setLoading(false);
+			}
+		);
 
-return () => unsubscribe();
-}, [user]);
+		return () => unsubscribe();
+	}, [user]);
 
-const addRecurringTransaction = async (transaction: Omit<RecurringTransaction, 'id' | 'createdAt' | 'userId'>) => {
-if (!user) throw new Error('User not authenticated');
+	const addRecurringTransaction = async (
+		transaction: Omit<RecurringTransaction, 'id' | 'createdAt' | 'userId'>
+	) => {
+		if (!user) throw new Error('User not authenticated');
 
-const col = collection(db, 'users', user.uid, 'recurringTransactions');
-await addDoc(col, {
-...transaction,
-createdAt: Timestamp.now(),
-userId: user.uid,
-});
-};
+		const col = collection(db, 'users', user.uid, 'recurringTransactions');
+		await addDoc(col, {
+			...transaction,
+			createdAt: Timestamp.now(),
+			userId: user.uid,
+		});
+	};
 
-const deleteRecurringTransaction = async (id: string) => {
-if (!user) throw new Error('User not authenticated');
-try {
-await deleteDoc(doc(db, 'users', user.uid, 'recurringTransactions', id));
-} catch (error) {
-console.error('Error deleting recurring transaction:', error);
-throw error;
-}
-};
+	const deleteRecurringTransaction = async (id: string) => {
+		if (!user) throw new Error('User not authenticated');
+		try {
+			await deleteDoc(doc(db, 'users', user.uid, 'recurringTransactions', id));
+		} catch (error) {
+			console.error('Error deleting recurring transaction:', error);
+			throw error;
+		}
+	};
 
-const updateRecurringTransaction = async (id: string, updates: Partial<RecurringTransaction>) => {
-if (!user) throw new Error('User not authenticated');
-try {
-const ref = doc(db, 'users', user.uid, 'recurringTransactions', id);
-await updateDoc(ref, updates as any);
-} catch (error) {
-console.error('Error updating recurring transaction:', error);
-throw error;
-}
-};
+	const updateRecurringTransaction = async (
+		id: string,
+		updates: Partial<RecurringTransaction>
+	) => {
+		if (!user) throw new Error('User not authenticated');
+		try {
+			const ref = doc(db, 'users', user.uid, 'recurringTransactions', id);
+			await updateDoc(ref, updates as UpdateData<RecurringTransaction>);
+		} catch (error) {
+			console.error('Error updating recurring transaction:', error);
+			throw error;
+		}
+	};
 
-return {
-recurringTransactions,
-addRecurringTransaction,
-deleteRecurringTransaction,
-updateRecurringTransaction,
-loading,
-};
+	return {
+		recurringTransactions,
+		addRecurringTransaction,
+		deleteRecurringTransaction,
+		updateRecurringTransaction,
+		loading,
+	};
 };

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -10,6 +10,7 @@ import {
 	getDocs,
 	getDoc,
 	increment,
+	type DocumentData,
 } from 'firebase/firestore';
 import { Transaction } from '../types';
 import { normalizeTransaction } from '../models/TransactionModel';
@@ -78,14 +79,15 @@ export const useTransactions = () => {
 		const txCol = collection(db, 'users', user.uid, 'transactions');
 		const txRef = doc(txCol);
 
-		const txData: any = {
-			...data,
+		const { date, ...rest } = data;
+		const txData: DocumentData = {
+			...rest,
 			createdAt: Timestamp.now(),
 			userId: user.uid,
 		};
 
-		if (data.date) {
-			txData.date = Timestamp.fromDate(data.date);
+		if (date) {
+			txData.date = Timestamp.fromDate(date);
 		}
 
 		batch.set(txRef, txData);
@@ -154,9 +156,9 @@ export const useTransactions = () => {
 
 			// Read current state so we can compute balance delta
 			const snap = await getDoc(txRef);
-			const old = snap.exists() ? (snap.data() as any) : null;
+			const old: DocumentData | null = snap.exists() ? snap.data() : null;
 
-			const updateData: any = { ...updates };
+			const updateData: DocumentData = { ...updates };
 			if (updates.date instanceof Date) {
 				updateData.date = Timestamp.fromDate(updates.date);
 			}

--- a/src/models/AccountModel.ts
+++ b/src/models/AccountModel.ts
@@ -1,34 +1,43 @@
 import { Account, AccountType, NetWorthData } from '../types';
+import { parseDbDateOrNull } from '../utils/date';
 
 export type { Account };
 
-export const normalizeAccount = (doc: any): Account => {
+type AccountDoc = {
+	id: string;
+	userId?: string;
+	name?: string;
+	bank?: string;
+	type?: string;
+	currency?: string;
+	balance?: number;
+	color?: string;
+	icon?: string;
+	createdAt?: unknown;
+};
+
+export const normalizeAccount = (doc: AccountDoc): Account => {
 	const account: Account = {
 		id: doc.id,
 		userId: doc.userId,
-		name: doc.name,
+		name: doc.name ?? '',
 		bank: doc.bank,
-		type: doc.type as AccountType,
+		type: (doc.type as AccountType) ?? 'cash',
 		currency: doc.currency ?? 'ZAR',
 		balance: doc.balance ?? 0,
 		color: doc.color,
 		icon: doc.icon,
 	};
 
-	if (doc.createdAt) {
-		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
-			account.createdAt = doc.createdAt.toDate();
-		} else if (doc.createdAt instanceof Date) {
-			account.createdAt = doc.createdAt;
-		} else {
-			account.createdAt = new Date(doc.createdAt);
-		}
+	const createdParsed = doc.createdAt != null ? parseDbDateOrNull(doc.createdAt) : null;
+	if (createdParsed) {
+		account.createdAt = createdParsed;
 	}
 
 	return account;
 };
 
-export const normalizeAccounts = (docs: any[]): Account[] => docs.map(normalizeAccount);
+export const normalizeAccounts = (docs: AccountDoc[]): Account[] => docs.map(normalizeAccount);
 
 export const calculateNetWorth = (accounts: Account[]): NetWorthData => {
 	const assets = accounts

--- a/src/models/BudgetModel.ts
+++ b/src/models/BudgetModel.ts
@@ -16,7 +16,12 @@ const getMonthBounds = (baseDate: Date): DateRange => {
 	};
 };
 
-const getLegacyBudgetRange = (doc: any): DateRange => {
+type BudgetDocForLegacy = {
+	createdAt?: unknown;
+	updatedAt?: unknown;
+};
+
+const getLegacyBudgetRange = (doc: BudgetDocForLegacy): DateRange => {
 	const createdAt =
 		parseDbDateOrNull(doc.createdAt) ??
 		parseDbDateOrNull(doc.updatedAt) ??
@@ -25,12 +30,26 @@ const getLegacyBudgetRange = (doc: any): DateRange => {
 	return getMonthBounds(createdAt);
 };
 
-export const normalizeBudget = (doc: any): Budget => {
+type BudgetDoc = {
+	id: string;
+	userId?: string;
+	category?: string;
+	amount?: number;
+	period?: Budget['period'];
+	plannedStartDate?: string;
+	plannedEndDate?: string;
+	actualStartDate?: string;
+	actualEndDate?: string;
+	createdAt?: unknown;
+	updatedAt?: unknown;
+};
+
+export const normalizeBudget = (doc: BudgetDoc): Budget => {
 	const legacyRange = getLegacyBudgetRange(doc);
 	const budget: Budget = {
 		id: doc.id,
 		userId: doc.userId,
-		category: doc.category,
+		category: doc.category ?? '',
 		amount: doc.amount ?? 0,
 		period: doc.period ?? 'monthly',
 		plannedStartDate: doc.plannedStartDate ?? legacyRange.startDate,
@@ -39,20 +58,15 @@ export const normalizeBudget = (doc: any): Budget => {
 		actualEndDate: doc.actualEndDate ?? undefined,
 	};
 
-	if (doc.createdAt) {
-		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
-			budget.createdAt = doc.createdAt.toDate();
-		} else if (doc.createdAt instanceof Date) {
-			budget.createdAt = doc.createdAt;
-		} else {
-			budget.createdAt = new Date(doc.createdAt);
-		}
+	const createdParsed = doc.createdAt != null ? parseDbDateOrNull(doc.createdAt) : null;
+	if (createdParsed) {
+		budget.createdAt = createdParsed;
 	}
 
 	return budget;
 };
 
-export const normalizeBudgets = (docs: any[]): Budget[] => docs.map(normalizeBudget);
+export const normalizeBudgets = (docs: BudgetDoc[]): Budget[] => docs.map(normalizeBudget);
 
 export const calculateBudgetUsage = (
 	budget: Budget,

--- a/src/models/RecurringTransactionModel.ts
+++ b/src/models/RecurringTransactionModel.ts
@@ -1,63 +1,79 @@
 export interface RecurringTransaction {
-id?: string;
-userId?: string;
-accountId?: string;
-title: string;
-amount: number;
-type?: 'income' | 'expense';
-category: string;
-description?: string;
-frequency?: 'daily' | 'weekly' | 'monthly' | 'yearly';
-createdAt?: Date | { toDate: () => Date };
+	id?: string;
+	userId?: string;
+	accountId?: string;
+	title: string;
+	amount: number;
+	type?: 'income' | 'expense';
+	category: string;
+	description?: string;
+	frequency?: 'daily' | 'weekly' | 'monthly' | 'yearly';
+	createdAt?: Date | { toDate: () => Date };
 }
 
-export const normalizeRecurringTransaction = (doc: any): RecurringTransaction => {
-const recurringTransaction: RecurringTransaction = {
-id: doc.id,
-userId: doc.userId,
-accountId: doc.accountId,
-title: doc.title,
-amount: doc.amount,
-type: doc.type ?? 'expense',
-category: doc.category,
-description: doc.description,
-frequency: doc.frequency,
+type RecurringDoc = {
+	id?: string;
+	userId?: string;
+	accountId?: string;
+	title?: string;
+	amount?: number;
+	type?: string;
+	category?: string;
+	description?: string;
+	frequency?: string;
+	createdAt?: unknown;
 };
 
-if (doc.createdAt) {
-if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
-recurringTransaction.createdAt = doc.createdAt.toDate();
-} else if (doc.createdAt instanceof Date) {
-recurringTransaction.createdAt = doc.createdAt;
-} else {
-recurringTransaction.createdAt = new Date(doc.createdAt);
-}
-}
+export const normalizeRecurringTransaction = (doc: RecurringDoc): RecurringTransaction => {
+	const recurringTransaction: RecurringTransaction = {
+		id: doc.id,
+		userId: doc.userId,
+		accountId: doc.accountId,
+		title: doc.title ?? '',
+		amount: doc.amount ?? 0,
+		type: (doc.type as RecurringTransaction['type']) ?? 'expense',
+		category: doc.category ?? '',
+		description: doc.description,
+		frequency: doc.frequency as RecurringTransaction['frequency'],
+	};
 
-return recurringTransaction;
+	if (doc.createdAt) {
+		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
+			recurringTransaction.createdAt = (doc.createdAt as { toDate: () => Date }).toDate();
+		} else if (doc.createdAt instanceof Date) {
+			recurringTransaction.createdAt = doc.createdAt;
+		} else {
+			recurringTransaction.createdAt = new Date(doc.createdAt as string | number);
+		}
+	}
+
+	return recurringTransaction;
 };
 
-export const normalizeRecurringTransactions = (docs: any[]): RecurringTransaction[] =>
-docs.map(normalizeRecurringTransaction);
+export const normalizeRecurringTransactions = (docs: RecurringDoc[]): RecurringTransaction[] =>
+	docs.map(normalizeRecurringTransaction);
 
 export const validateRecurringTransaction = (transaction: Partial<RecurringTransaction>): string[] => {
-const errors: string[] = [];
+	const errors: string[] = [];
 
-if (!transaction.title || transaction.title.trim() === '') {
-errors.push('Title is required');
-}
+	if (!transaction.title || transaction.title.trim() === '') {
+		errors.push('Title is required');
+	}
 
-if (transaction.amount === undefined || transaction.amount === null || transaction.amount <= 0) {
-errors.push('Amount must be greater than 0');
-}
+	if (transaction.amount === undefined || transaction.amount === null || transaction.amount <= 0) {
+		errors.push('Amount must be greater than 0');
+	}
 
-if (!transaction.category || transaction.category.trim() === '') {
-errors.push('Category is required');
-}
+	if (!transaction.category || transaction.category.trim() === '') {
+		errors.push('Category is required');
+	}
 
-if (transaction.frequency && !['daily', 'weekly', 'monthly', 'yearly'].includes(transaction.frequency)) {
-errors.push('Frequency must be daily, weekly, monthly, or yearly');
-}
+	if (
+		transaction.frequency &&
+		!['daily', 'weekly', 'monthly', 'yearly'].includes(transaction.frequency)
+	) {
+		errors.push('Frequency must be daily, weekly, monthly, or yearly');
+	}
 
-return errors;
+	return errors;
 };

--- a/src/models/TransactionModel.ts
+++ b/src/models/TransactionModel.ts
@@ -3,43 +3,48 @@ import { parseDbDateOrNull } from '../utils/date';
 
 export type { Transaction };
 
-export const normalizeTransaction = (doc: any): Transaction => {
+type TransactionDoc = {
+	id: string;
+	userId?: string;
+	accountId?: string;
+	title?: string;
+	amount?: number;
+	type?: string;
+	category?: string;
+	description?: string;
+	transferAccountId?: string;
+	date?: unknown;
+	createdAt?: unknown;
+	updatedAt?: unknown;
+};
+
+export const normalizeTransaction = (doc: TransactionDoc): Transaction => {
 	const transaction: Transaction = {
 		id: doc.id,
 		userId: doc.userId,
-		accountId: doc.accountId,
-		title: doc.title,
-		amount: doc.amount,
-		type: doc.type as TransactionType,
-		category: doc.category,
+		accountId: doc.accountId ?? '',
+		title: doc.title ?? '',
+		amount: doc.amount ?? 0,
+		type: (doc.type as TransactionType) ?? 'expense',
+		category: doc.category ?? '',
 		description: doc.description,
 		transferAccountId: doc.transferAccountId,
 	};
 
-	if (doc.date) {
-		if (typeof doc.date === 'object' && 'toDate' in doc.date) {
-			transaction.date = doc.date.toDate();
-		} else if (doc.date instanceof Date) {
-			transaction.date = doc.date;
-		} else {
-			transaction.date = new Date(doc.date);
-		}
+	const dateParsed = doc.date != null ? parseDbDateOrNull(doc.date) : null;
+	if (dateParsed) {
+		transaction.date = dateParsed;
 	}
 
-	if (doc.createdAt) {
-		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
-			transaction.createdAt = doc.createdAt.toDate();
-		} else if (doc.createdAt instanceof Date) {
-			transaction.createdAt = doc.createdAt;
-		} else {
-			transaction.createdAt = new Date(doc.createdAt);
-		}
+	const createdParsed = doc.createdAt != null ? parseDbDateOrNull(doc.createdAt) : null;
+	if (createdParsed) {
+		transaction.createdAt = createdParsed;
 	}
 
 	return transaction;
 };
 
-export const normalizeTransactions = (docs: any[]): Transaction[] =>
+export const normalizeTransactions = (docs: TransactionDoc[]): Transaction[] =>
 	docs.map(normalizeTransaction);
 
 export const filterExpenses = (transactions: Transaction[]): Transaction[] =>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { FiMenu } from 'react-icons/fi';
 import { useTransactionsContext } from '../context/TransactionsContext';
 import { useAccountsContext } from '../context/AccountsContext';
-import { ViewType } from '../types';
+import { Transaction, ViewType } from '../types';
 import Sidebar from '../components/app/Sidebar';
 import SettingsModal from '../components/app/SettingsModal';
 import TransactionForm from '../views/Transactions/TransactionForm';
@@ -37,7 +37,7 @@ const Dashboard: React.FC = () => {
 	const { accounts } = useAccountsContext();
 	const { toast } = useToast();
 
-	const [selectedTx, setSelectedTx] = useState<any | null>(null);
+	const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
 	const [selectedTransactionId, setSelectedTransactionId] = useState<string | null>(null);
 	const [sidebarVisible, setSidebarVisible] = useState(true);
 	const [activeView, setActiveView] = useState<ViewType>('dashboard');
@@ -62,16 +62,29 @@ const Dashboard: React.FC = () => {
 		};
 	}, []);
 
-	const handleCreate = () => {
+	const handleCreate = useCallback(() => {
 		setSelectedTx(null);
 		setSelectedTransactionId(null);
 		setActiveView('transaction');
-	};
+	}, []);
 
-	const handleSelect = (tx: any | null) => {
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key.toLowerCase() !== 'k') return;
+			if (!e.ctrlKey && !e.metaKey) return;
+			const target = e.target as HTMLElement | null;
+			if (target?.closest('input, textarea, [contenteditable="true"]')) return;
+			e.preventDefault();
+			handleCreate();
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [handleCreate]);
+
+	const handleSelect = (tx: Transaction | null) => {
 		if (tx) {
 			setSelectedTx(tx);
-			setSelectedTransactionId(tx.id);
+			setSelectedTransactionId(tx.id ?? null);
 			setActiveView('transaction');
 		} else {
 			setSelectedTx(null);
@@ -94,7 +107,7 @@ const Dashboard: React.FC = () => {
 					setSelectedTransactionId(null);
 				}
 				toast({ title: 'Success', description: 'Transaction deleted successfully' });
-			} catch (err: any) {
+			} catch {
 				toast({
 					title: 'Error',
 					description: 'Failed to delete transaction. Please try again.',
@@ -124,13 +137,13 @@ const Dashboard: React.FC = () => {
 		setSettingsOpen(true);
 	};
 
-	const handleViewChange = (view: string) => {
+	const handleViewChange = (view: ViewType) => {
 		// If switching away from transaction detail, clear selection
 		if (view !== 'transaction') {
 			setSelectedTx(null);
 			setSelectedTransactionId(null);
 		}
-		setActiveView(view as ViewType);
+		setActiveView(view);
 	};
 
 	const renderMainContent = () => {
@@ -300,12 +313,21 @@ const Dashboard: React.FC = () => {
 				onClose={() => setSettingsOpen(false)}
 				initialTab={settingsInitialTab}
 				onImport={async (file) => {
+					if (accounts.length === 0) {
+						toast({
+							title: 'Import unavailable',
+							description: 'Create an account before importing transactions.',
+							variant: 'destructive',
+						});
+						return;
+					}
+
 					try {
 						const result = await importTransactionsFromFile(
 							file,
 							transactions,
 							addTransaction,
-							accounts[0]?.id ?? ""
+							accounts[0].id ?? ''
 						);
 						if (result.errors.length) {
 							toast({
@@ -321,10 +343,11 @@ const Dashboard: React.FC = () => {
 								description: `Imported ${result.importedCount}, skipped ${result.skippedDuplicates}.`,
 							});
 						}
-					} catch (e: any) {
+					} catch (e: unknown) {
 						toast({
 							title: 'Import failed',
-							description: e.message || 'Failed to import file.',
+							description:
+								e instanceof Error ? e.message : 'Failed to import file.',
 							variant: 'destructive',
 						});
 					}
@@ -368,13 +391,13 @@ const Dashboard: React.FC = () => {
 			/>
 
 			<div
-				className={`flex-1 flex flex-col h-screen-safe md:h-auto overflow-y-auto transition-all duration-300 ease-in-out ${sidebarVisible ? 'md:ml-8' : 'md:ml-0'
-					}`}
+				className={`relative flex min-h-0 flex-1 flex-col overflow-y-auto transition-all duration-300 ease-in-out h-screen-safe md:h-auto ${sidebarVisible ? 'md:ml-8' : 'md:ml-0'
+					} ${!sidebarVisible ? 'pt-[4.5rem]' : ''}`}
 			>
 				{!sidebarVisible && (
 					<Button
 						variant="outline"
-						className="absolute left-4 top-4 z-50"
+						className="absolute left-4 top-4 z-50 shadow-sm"
 						onClick={toggleSidebar}
 						aria-label="Open menu"
 					>

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,5 +1,6 @@
 import { Category, CategoryDefinition } from '../types';
 import { DEFAULT_CATEGORY_TEMPLATES, TRANSFER_CATEGORY_VALUE } from '../constants/categories';
+import { parseDbDateOrNull } from './date';
 
 export const slugifyCategoryLabel = (label: string): string =>
 	label
@@ -15,31 +16,29 @@ export const formatCategoryLabel = (value: string): string =>
 		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
 		.join(' ');
 
-export const normalizeCategoryDefinition = (doc: any): CategoryDefinition => {
+type CategoryDoc = {
+	id: string;
+	value?: string;
+	label?: string;
+	createdAt?: unknown;
+	updatedAt?: unknown;
+};
+
+export const normalizeCategoryDefinition = (doc: CategoryDoc): CategoryDefinition => {
 	const category: CategoryDefinition = {
 		id: doc.id,
 		value: doc.value ?? doc.id,
 		label: doc.label ?? formatCategoryLabel(doc.value ?? doc.id ?? ''),
 	};
 
-	if (doc.createdAt) {
-		if (typeof doc.createdAt === 'object' && 'toDate' in doc.createdAt) {
-			category.createdAt = doc.createdAt.toDate();
-		} else if (doc.createdAt instanceof Date) {
-			category.createdAt = doc.createdAt;
-		} else {
-			category.createdAt = new Date(doc.createdAt);
-		}
+	const createdParsed = doc.createdAt != null ? parseDbDateOrNull(doc.createdAt) : null;
+	if (createdParsed) {
+		category.createdAt = createdParsed;
 	}
 
-	if (doc.updatedAt) {
-		if (typeof doc.updatedAt === 'object' && 'toDate' in doc.updatedAt) {
-			category.updatedAt = doc.updatedAt.toDate();
-		} else if (doc.updatedAt instanceof Date) {
-			category.updatedAt = doc.updatedAt;
-		} else {
-			category.updatedAt = new Date(doc.updatedAt);
-		}
+	const updatedParsed = doc.updatedAt != null ? parseDbDateOrNull(doc.updatedAt) : null;
+	if (updatedParsed) {
+		category.updatedAt = updatedParsed;
 	}
 
 	return category;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -22,3 +22,22 @@ export const parseDbDateOrNull = (dateInput: unknown): Date | null => {
 export const parseDbDate = (dateInput: unknown): Date => {
 	return parseDbDateOrNull(dateInput) ?? new Date();
 };
+
+export const getTransactionDateOrEpoch = (
+	dateInput: unknown,
+	fallbackInput?: unknown
+): Date => {
+	return parseDbDateOrNull(dateInput) ?? parseDbDateOrNull(fallbackInput) ?? new Date(0);
+};
+
+export const compareTransactionsByDateDesc = <
+	T extends { date?: unknown; createdAt?: unknown },
+>(
+	left: T,
+	right: T
+): number => {
+	return (
+		getTransactionDateOrEpoch(right.date, right.createdAt).getTime() -
+		getTransactionDateOrEpoch(left.date, left.createdAt).getTime()
+	);
+};

--- a/src/utils/transactionImportExport.ts
+++ b/src/utils/transactionImportExport.ts
@@ -56,6 +56,10 @@ export const importTransactionsFromFile = async (
 	addTransaction: (data: { type: 'income' | 'expense'; accountId: string; title: string; category: string; description?: string; amount: number }) => Promise<void>,
 	defaultAccountId: string = ''
 ): Promise<ImportResult> => {
+	if (!defaultAccountId) {
+		throw new Error('Create an account before importing transactions.');
+	}
+
 	const text = await file.text();
 	let records: SerializableTransaction[] = [];
 
@@ -97,13 +101,16 @@ export const importTransactionsFromFile = async (
 		}
 
 		try {
+			const resolvedAccountId = row.accountId
+				? String(row.accountId)
+				: defaultAccountId;
 			await addTransaction({
 				title: String(row.title),
 				amount: amountNum,
 				type: row.type as 'income' | 'expense',
 				category: String(row.category),
 				description: row.description ? String(row.description) : '',
-				accountId: row.accountId ? String(row.accountId) : defaultAccountId,
+				accountId: resolvedAccountId,
 			});
 			importedCount++;
 			existingSignatures.add(signature);

--- a/src/views/Accounts/AccountForm.tsx
+++ b/src/views/Accounts/AccountForm.tsx
@@ -61,8 +61,8 @@ const AccountForm: React.FC<AccountFormProps> = ({ onClose, account }) => {
 				await addAccount(data);
 			}
 			onClose();
-		} catch (err: any) {
-			setError(err?.message || 'Failed to save account. Please try again.');
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to save account. Please try again.');
 		} finally {
 			setLoading(false);
 		}

--- a/src/views/Accounts/AccountsList.tsx
+++ b/src/views/Accounts/AccountsList.tsx
@@ -149,8 +149,9 @@ const AccountsList: React.FC = () => {
 									account.id && navigate(`/accounts/${account.id}`)
 								}
 								onKeyDown={(e) => {
-									if (e.key === 'Enter' || e.key === ' ')
-										account.id && navigate(`/accounts/${account.id}`);
+									if (e.key === 'Enter' || e.key === ' ') {
+										if (account.id) navigate(`/accounts/${account.id}`);
+									}
 								}}
 								className="group relative cursor-pointer rounded-2xl border bg-card overflow-hidden transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							>

--- a/src/views/Accounts/ReconcileForm.tsx
+++ b/src/views/Accounts/ReconcileForm.tsx
@@ -72,8 +72,10 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 				});
 			}
 			setStep('done');
-		} catch (err: any) {
-			setError(err?.message || 'Failed to reconcile account. Please try again.');
+		} catch (err: unknown) {
+			setError(
+				err instanceof Error ? err.message : 'Failed to reconcile account. Please try again.'
+			);
 		} finally {
 			setLoading(false);
 		}

--- a/src/views/Accounts/TransferForm.tsx
+++ b/src/views/Accounts/TransferForm.tsx
@@ -62,8 +62,10 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 				date: date ? new Date(date) : new Date(),
 			});
 			onClose();
-		} catch (err: any) {
-			setError(err?.message || 'Failed to complete transfer. Please try again.');
+		} catch (err: unknown) {
+			setError(
+				err instanceof Error ? err.message : 'Failed to complete transfer. Please try again.'
+			);
 		} finally {
 			setLoading(false);
 		}

--- a/src/views/Budgets/BudgetForm.tsx
+++ b/src/views/Budgets/BudgetForm.tsx
@@ -93,8 +93,8 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 				await addBudget(data);
 			}
 			onClose();
-		} catch (err: any) {
-			setError(err?.message || 'Failed to save budget. Please try again.');
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to save budget. Please try again.');
 		} finally {
 			setLoading(false);
 		}

--- a/src/views/RecurringTransactions/RecurringTransactionForm.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionForm.tsx
@@ -68,7 +68,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 		e.preventDefault();
 		setIsSubmitting(true);
 		try {
-			const data: any = {
+			const data: Pick<
+				RecurringTransaction,
+				'title' | 'amount' | 'type' | 'category' | 'description' | 'frequency'
+			> = {
 				title,
 				amount: Number(amount),
 				type: transactionType,
@@ -228,7 +231,9 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 						</Label>
 						<Select
 							value={frequency}
-							onValueChange={(value) => setFrequency(value as any)}
+							onValueChange={(value) =>
+								setFrequency(value as 'daily' | 'weekly' | 'monthly' | 'yearly')
+							}
 						>
 							<SelectTrigger
 								id="re-frequency"

--- a/src/views/Transactions/TransactionForm.tsx
+++ b/src/views/Transactions/TransactionForm.tsx
@@ -56,7 +56,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 		if (!accountId && accounts.length > 0) {
 			setAccountId(accounts[0].id!);
 		}
-	}, [accounts]);
+	}, [accountId, accounts]);
 
 	useEffect(() => {
 		if (transaction) {
@@ -123,7 +123,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 		if (type === 'transfer' && !transferAccountId) return;
 		try {
 			if (transaction && transaction.id) {
-				const data: any = {
+				const data: Partial<Transaction> = {
 					title,
 					amount: Number(amount),
 					type,

--- a/src/views/Transactions/TransactionsList.tsx
+++ b/src/views/Transactions/TransactionsList.tsx
@@ -8,9 +8,11 @@ import { Badge } from '../../components/app/ui/badge';
 import { Avatar, AvatarFallback } from '../../components/app/ui/avatar';
 import { Card } from '../../components/app/ui/card';
 import { useFilterPreferences } from '../../context/FilterPreferencesContext';
+import { Transaction } from '../../types';
+import { compareTransactionsByDateDesc, getTransactionDateOrEpoch } from '../../utils/date';
 
 interface TransactionsListProps {
-	onSelect?: (tx: any) => void;
+	onSelect?: (tx: Transaction) => void;
 	selectedId?: string | null;
 	onOpenSettings?: () => void;
 }
@@ -32,17 +34,7 @@ const TransactionsList: React.FC<TransactionsListProps> = ({ onSelect, selectedI
 	const [search, setSearch] = useState('');
 
 	const sorted = useMemo(() => {
-		return [...transactions].sort((a, b) => {
-			const getValidDate = (val: any) => {
-				if (!val) return new Date(0);
-				if (typeof val === 'object' && 'toDate' in val) return val.toDate();
-				return new Date(val);
-			};
-			return (
-				getValidDate(b.date ?? b.createdAt).getTime() -
-				getValidDate(a.date ?? a.createdAt).getTime()
-			);
-		});
+		return [...transactions].sort(compareTransactionsByDateDesc);
 	}, [transactions]);
 
 	const filtered = useMemo(() => {
@@ -50,13 +42,8 @@ const TransactionsList: React.FC<TransactionsListProps> = ({ onSelect, selectedI
 	}, [sorted, search]);
 
 	const grouped = useMemo(() => {
-		return filtered.reduce((acc: Record<string, any[]>, tx) => {
-			const dateVal = tx.date ?? tx.createdAt;
-			let dateObj: Date;
-			if (!dateVal) dateObj = new Date(0);
-			else if (typeof dateVal === 'object' && 'toDate' in dateVal) dateObj = dateVal.toDate();
-			else dateObj = new Date(dateVal);
-
+		return filtered.reduce((acc: Record<string, Transaction[]>, tx) => {
+			const dateObj = getTransactionDateOrEpoch(tx.date, tx.createdAt);
 			const dateKey = dateObj.toLocaleDateString('en-GB', {
 				day: 'numeric',
 				month: 'long',

--- a/src/views/Transactions/TransactionsTable.tsx
+++ b/src/views/Transactions/TransactionsTable.tsx
@@ -5,7 +5,8 @@ import { useCategoriesContext } from '../../context/CategoriesContext';
 import DateRangeFilter from '../../components/app/DateRangeFilter';
 import { filterTransactionsByDateRangeObject } from '../../utils/dateRangeFilter';
 import { formatCurrency } from '../../utils/formatCurrency';
-import { DateRange } from '../../types';
+import { DateRange, Transaction } from '../../types';
+import { compareTransactionsByDateDesc, getTransactionDateOrEpoch } from '../../utils/date';
 import {
 	Table,
 	TableBody,
@@ -29,7 +30,7 @@ import { mergeCategoryOptions } from '../../utils/categories';
 
 interface TransactionsTableProps {
 	onDelete: (id: string) => void;
-	onSelect: (tx: any) => void;
+	onSelect: (tx: Transaction) => void;
 	selectedId: string | null;
 	onOpenSettings?: () => void;
 }
@@ -103,16 +104,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
 				return matchesSearch && matchesType && matchesCategory && matchesMonth;
 			})
-			.sort((a, b) => {
-				const getValidDate = (value: any) => {
-					if (!value) return new Date(0);
-					if (typeof value === 'object' && 'toDate' in value) return value.toDate();
-					return new Date(value);
-				};
-				const dateA = getValidDate(a.date ?? a.createdAt).getTime();
-				const dateB = getValidDate(b.date ?? b.createdAt).getTime();
-				return dateB - dateA;
-			});
+			.sort(compareTransactionsByDateDesc);
 
 		const totalAmount = filtered.reduce((sum, tx) => sum + tx.amount, 0);
 		const totalIncome = filtered
@@ -325,13 +317,10 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
 									<TableCell className="text-right text-sm text-muted-foreground">
 										{(() => {
-											const dateValue = tx.date ?? tx.createdAt;
-											const date =
-												typeof dateValue === 'object' &&
-													'toDate' in dateValue
-													? dateValue.toDate()
-													: new Date(dateValue || new Date());
-											return date.toLocaleDateString('en-US', {
+											return getTransactionDateOrEpoch(
+												tx.date,
+												tx.createdAt
+											).toLocaleDateString('en-US', {
 												month: 'short',
 												day: 'numeric',
 												year: 'numeric',
@@ -357,7 +346,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 											size="icon"
 											onClick={(e) => {
 												e.stopPropagation();
-												tx.id && onDelete(tx.id);
+												if (tx.id) onDelete(tx.id);
 											}}
 										>
 											<FiTrash2 className="h-4 w-4" />


### PR DESCRIPTION
## Summary

This PR delivers a final cleanup pass: documentation alignment, dashboard/sidebar UX, safer data handling, and a clean ESLint/test baseline.

## Changes

### Documentation
- **README**: AI assistant notes, import prerequisites, link to `CODING_STANDARDS.md`
- **API_DOCUMENTATION**: `POST /askAI` contract, error codes, model fields
- **TESTING**: Current suites, manual checklist, high-priority missing tests
- **CODING_STANDARDS.md**: Incremental standards backlog with acceptance checks

### UX
- **Sidebar**: Desktop collapse (chevron) + mobile close unchanged
- **Dashboard**: Top padding when sidebar collapsed so content sits below the Menu button; **Ctrl/Cmd+K** opens new transaction (same as New transaction), ignored in text fields
- **Settings**: Logged-out footer button label clarity (Close)

### Correctness and quality
- Single delete-confirm path; import guard when no accounts; **askAI** month filter uses `date` with `createdAt` fallback
- Shared date sort/compare helpers; stricter types in transaction views
- **Firestore**: `DocumentData` / `UpdateData` where appropriate; model normalizers use `parseDbDateOrNull` and defaults
- **AuthModals**: `name="password"`, toggle `aria-label`; tests use label/role queries

## Verification
- `npm run lint` (0 errors; existing fast-refresh warnings in contexts only)
- `npm run build`
- `npm test` (34/34)

## Notes
Optional follow-up: chunk splitting for the main bundle (Vite warning).

Made with [Cursor](https://cursor.com)