### PR TITLE
Add expected day field and date filter for recurring transactions

### DIFF
--- a/src/components/app/SettingsModal.tsx
+++ b/src/components/app/SettingsModal.tsx
@@ -347,6 +347,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 													['frequency', 'Frequency filter'],
 													['category', 'Category filter'],
 													['type', 'Type filter (Income / Expense)'],
+													['date', 'Expected date filter'],
 													['sortBy', 'Sort by'],
 												] as [keyof FilterPreferences['recurring'], string][]
 											).map(([key, label]) => (

--- a/src/context/FilterPreferencesContext.tsx
+++ b/src/context/FilterPreferencesContext.tsx
@@ -5,6 +5,7 @@ export interface FilterPreferences {
 		frequency: boolean;
 		category: boolean;
 		type: boolean;
+		date: boolean;
 		sortBy: boolean;
 	};
 	transactionsTable: {
@@ -24,6 +25,7 @@ const DEFAULT_PREFS: FilterPreferences = {
 		frequency: true,
 		category: true,
 		type: true,
+		date: true,
 		sortBy: true,
 	},
 	transactionsTable: {

--- a/src/hooks/useRecurringTransactions.ts
+++ b/src/hooks/useRecurringTransactions.ts
@@ -9,12 +9,44 @@ import {
 	query,
 	onSnapshot,
 	Timestamp,
+	deleteField,
 	type UpdateData,
 } from 'firebase/firestore';
 import {
 	normalizeRecurringTransactions,
 	RecurringTransaction,
 } from '../models/RecurringTransactionModel';
+
+const sanitizeRecurringPayload = (
+	payload: Partial<RecurringTransaction>,
+	allowExpectedDateDelete: boolean,
+) => {
+	const sanitized: Record<string, unknown> = Object.fromEntries(
+		Object.entries(payload).filter(([, value]) => value !== undefined)
+	);
+
+	if (payload.expectedDate !== undefined) {
+		if (
+			Number.isInteger(payload.expectedDate) &&
+			payload.expectedDate >= 1 &&
+			payload.expectedDate <= 31
+		) {
+			sanitized.expectedDate = payload.expectedDate;
+		} else {
+			delete sanitized.expectedDate;
+		}
+	}
+
+	if (
+		allowExpectedDateDelete &&
+		Object.prototype.hasOwnProperty.call(payload, 'expectedDate') &&
+		payload.expectedDate === undefined
+	) {
+		sanitized.expectedDate = deleteField();
+	}
+
+	return sanitized;
+};
 
 export const useRecurringTransactions = () => {
 	const [recurringTransactions, setRecurringTransactions] = useState<RecurringTransaction[]>([]);
@@ -66,8 +98,9 @@ export const useRecurringTransactions = () => {
 		if (!user) throw new Error('User not authenticated');
 
 		const col = collection(db, 'users', user.uid, 'recurringTransactions');
+		const sanitizedTransaction = sanitizeRecurringPayload(transaction, false);
 		await addDoc(col, {
-			...transaction,
+			...sanitizedTransaction,
 			createdAt: Timestamp.now(),
 			userId: user.uid,
 		});
@@ -90,7 +123,8 @@ export const useRecurringTransactions = () => {
 		if (!user) throw new Error('User not authenticated');
 		try {
 			const ref = doc(db, 'users', user.uid, 'recurringTransactions', id);
-			await updateDoc(ref, updates as UpdateData<RecurringTransaction>);
+			const sanitizedUpdates = sanitizeRecurringPayload(updates, true);
+			await updateDoc(ref, sanitizedUpdates as UpdateData<RecurringTransaction>);
 		} catch (error) {
 			console.error('Error updating recurring transaction:', error);
 			throw error;

--- a/src/models/RecurringTransactionModel.ts
+++ b/src/models/RecurringTransactionModel.ts
@@ -8,6 +8,7 @@ export interface RecurringTransaction {
 	category: string;
 	description?: string;
 	frequency?: 'daily' | 'weekly' | 'monthly' | 'yearly';
+	expectedDate?: number;
 	createdAt?: Date | { toDate: () => Date };
 }
 
@@ -21,7 +22,23 @@ type RecurringDoc = {
 	category?: string;
 	description?: string;
 	frequency?: string;
+	expectedDate?: unknown;
 	createdAt?: unknown;
+};
+
+const normalizeExpectedDate = (value: unknown): number | undefined => {
+	if (typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 31) {
+		return value;
+	}
+
+	if (typeof value === 'string') {
+		const parsed = Number.parseInt(value, 10);
+		if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 31) {
+			return parsed;
+		}
+	}
+
+	return undefined;
 };
 
 export const normalizeRecurringTransaction = (doc: RecurringDoc): RecurringTransaction => {
@@ -35,6 +52,7 @@ export const normalizeRecurringTransaction = (doc: RecurringDoc): RecurringTrans
 		category: doc.category ?? '',
 		description: doc.description,
 		frequency: doc.frequency as RecurringTransaction['frequency'],
+		expectedDate: normalizeExpectedDate(doc.expectedDate),
 	};
 
 	if (doc.createdAt) {
@@ -73,6 +91,15 @@ export const validateRecurringTransaction = (transaction: Partial<RecurringTrans
 		!['daily', 'weekly', 'monthly', 'yearly'].includes(transaction.frequency)
 	) {
 		errors.push('Frequency must be daily, weekly, monthly, or yearly');
+	}
+
+	if (
+		transaction.expectedDate !== undefined &&
+		(!Number.isInteger(transaction.expectedDate) ||
+			transaction.expectedDate < 1 ||
+			transaction.expectedDate > 31)
+	) {
+		errors.push('Expected date must be a day between 1 and 31');
 	}
 
 	return errors;

--- a/src/views/RecurringTransactions/RecurringTransactionForm.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionForm.tsx
@@ -40,6 +40,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 	const [frequency, setFrequency] = useState<'daily' | 'weekly' | 'monthly' | 'yearly'>(
 		'monthly'
 	);
+	const [expectedDate, setExpectedDate] = useState<number | ''>('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const availableCategories = React.useMemo(
 		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
@@ -54,6 +55,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			setCategory(expense.category ?? '');
 			setDescription(expense.description ?? '');
 			setFrequency(expense.frequency ?? 'monthly');
+			setExpectedDate(expense.expectedDate ?? '');
 		} else {
 			setTitle('');
 			setAmount(0);
@@ -61,6 +63,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			setCategory('');
 			setDescription('');
 			setFrequency('monthly');
+			setExpectedDate('');
 		}
 	}, [expense]);
 
@@ -68,9 +71,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 		e.preventDefault();
 		setIsSubmitting(true);
 		try {
+			const normalizedExpectedDate = expectedDate === '' ? undefined : expectedDate;
 			const data: Pick<
 				RecurringTransaction,
-				'title' | 'amount' | 'type' | 'category' | 'description' | 'frequency'
+				'title' | 'amount' | 'type' | 'category' | 'description' | 'frequency' | 'expectedDate'
 			> = {
 				title,
 				amount: Number(amount),
@@ -78,6 +82,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 				category,
 				description,
 				frequency,
+				expectedDate: normalizedExpectedDate,
 			};
 
 			if (expense && expense.id) {
@@ -249,6 +254,28 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 								))}
 							</SelectContent>
 						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="re-expected-date" className="text-sm font-medium">
+							Expected Day (Optional)
+						</Label>
+						<Input
+							id="re-expected-date"
+							type="number"
+							value={expectedDate}
+							onChange={(e) => {
+								const value = e.target.value;
+								setExpectedDate(value === '' ? '' : Number(value));
+							}}
+							placeholder="e.g. 1"
+							min="1"
+							max="31"
+							className="h-10 rounded-lg border-2 transition-all focus:border-primary"
+						/>
+						<p className="text-xs text-muted-foreground">
+							Use this for monthly schedules, like salary on day 1.
+						</p>
 					</div>
 				</div>
 

--- a/src/views/RecurringTransactions/RecurringTransactionsView.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionsView.tsx
@@ -39,6 +39,14 @@ const TYPE_OPTIONS = [
 	{ value: 'income', label: 'Income' },
 ];
 
+const EXPECTED_DATE_OPTIONS = [
+	{ value: 'all', label: 'All Dates' },
+	...Array.from({ length: 31 }, (_, index) => {
+		const day = index + 1;
+		return { value: String(day), label: `Day ${day}` };
+	}),
+];
+
 type SortBy = 'default' | 'alpha-asc' | 'alpha-desc' | 'price-asc' | 'price-desc';
 
 const SORT_OPTIONS: { value: SortBy; label: string }[] = [
@@ -64,10 +72,16 @@ const getFrequencyLabel = (frequency?: string) => {
 	}
 };
 
+const getExpectedDateLabel = (expectedDate?: number): string => {
+	if (!expectedDate) return 'Unscheduled';
+	return `Day ${expectedDate}`;
+};
+
 const buildFilterLabel = (
 	frequencyFilter: string,
 	categoryFilter: string,
 	typeFilter: string,
+	expectedDateFilter: string,
 	sortBy: SortBy,
 	categoryOptions: Array<{ value: string; label: string }>
 ): string => {
@@ -79,6 +93,9 @@ const buildFilterLabel = (
 	}
 	if (typeFilter !== 'all') {
 		parts.push(typeFilter === 'expense' ? 'Expenses' : 'Income');
+	}
+	if (expectedDateFilter !== 'all') {
+		parts.push(`Day ${expectedDateFilter}`);
 	}
 	if (sortBy !== 'default') {
 		const sortOpt = SORT_OPTIONS.find((o) => o.value === sortBy);
@@ -98,6 +115,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	const [frequencyFilter, setFrequencyFilter] = useState('all');
 	const [categoryFilter, setCategoryFilter] = useState('all');
 	const [typeFilter, setTypeFilter] = useState('all');
+	const [expectedDateFilter, setExpectedDateFilter] = useState('all');
 	const [sortBy, setSortBy] = useState<SortBy>('default');
 	const [isFormOpen, setIsFormOpen] = useState(false);
 	const [editingTransaction, setEditingTransaction] = useState<RecurringTransaction | undefined>(undefined);
@@ -115,12 +133,17 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	);
 
 	const hasActiveFilters =
-		frequencyFilter !== 'all' || categoryFilter !== 'all' || typeFilter !== 'all' || sortBy !== 'default';
+		frequencyFilter !== 'all' ||
+		categoryFilter !== 'all' ||
+		typeFilter !== 'all' ||
+		expectedDateFilter !== 'all' ||
+		sortBy !== 'default';
 
 	const allFiltersHidden =
 		!recurringPrefs.frequency &&
 		!recurringPrefs.category &&
 		!recurringPrefs.type &&
+		!recurringPrefs.date &&
 		!recurringPrefs.sortBy;
 
 	const filteredTransactions = useMemo(() => {
@@ -130,6 +153,12 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 			if (typeFilter !== 'all') {
 				const transactionType = transaction.type ?? 'expense';
 				if (transactionType !== typeFilter) return false;
+			}
+			if (
+				expectedDateFilter !== 'all' &&
+				transaction.expectedDate !== Number(expectedDateFilter)
+			) {
+				return false;
 			}
 			return true;
 		});
@@ -145,7 +174,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 		}
 
 		return filtered;
-	}, [recurringTransactions, frequencyFilter, categoryFilter, typeFilter, sortBy]);
+	}, [recurringTransactions, frequencyFilter, categoryFilter, typeFilter, expectedDateFilter, sortBy]);
 
 	const filteredTotal = useMemo(
 		() => filteredTransactions.reduce((sum, e) => sum + e.amount, 0),
@@ -158,10 +187,11 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 				frequencyFilter,
 				categoryFilter,
 				typeFilter,
+				expectedDateFilter,
 				sortBy,
 				filterCategoryOptions
 			),
-		[frequencyFilter, categoryFilter, typeFilter, sortBy, filterCategoryOptions]
+		[frequencyFilter, categoryFilter, typeFilter, expectedDateFilter, sortBy, filterCategoryOptions]
 	);
 
 	const handleEdit = (transaction: RecurringTransaction) => {
@@ -200,6 +230,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 		setFrequencyFilter('all');
 		setCategoryFilter('all');
 		setTypeFilter('all');
+		setExpectedDateFilter('all');
 		setSortBy('default');
 	};
 
@@ -281,6 +312,21 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 							</SelectTrigger>
 							<SelectContent>
 								{TYPE_OPTIONS.map((opt) => (
+									<SelectItem key={opt.value} value={opt.value}>
+										{opt.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+
+					{recurringPrefs.date && (
+						<Select value={expectedDateFilter} onValueChange={setExpectedDateFilter}>
+							<SelectTrigger className="h-9 w-36 text-sm">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{EXPECTED_DATE_OPTIONS.map((opt) => (
 									<SelectItem key={opt.value} value={opt.value}>
 										{opt.label}
 									</SelectItem>
@@ -378,6 +424,11 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 									<Badge variant="outline" className="text-xs">
 										{getFrequencyLabel(expense.frequency)}
 									</Badge>
+									{expense.expectedDate !== undefined && (
+										<Badge variant="outline" className="text-xs">
+											{getExpectedDateLabel(expense.expectedDate)}
+										</Badge>
+									)}
 									{(expense.type === 'income') ? (
 										<Badge variant="secondary" className="text-xs text-green-600 dark:text-green-400">
 											Income


### PR DESCRIPTION
## Summary
- add optional `expectedDate` (day 1-31) to recurring transaction model
- add Expected Day input to recurring transaction create/edit form
- add recurring transactions date filter (All Dates / Day 1..31)
- show expected day badge in recurring transaction list cards
- add filter visibility toggle for recurring expected date in Settings
- sanitize recurring payloads to persist/clear `expectedDate` safely in Firestore

## Validation
- `npm run lint` (no errors; existing non-blocking warnings)
- `npm run build` (passes)

## Notes
- date concept is day-of-month (e.g., salary on the 1st of each month)