### PR TITLE
Fix recurring edit category fallback and expected-day sorting

### DIFF
--- a/src/views/RecurringTransactions/RecurringTransactionForm.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionForm.tsx
@@ -72,6 +72,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 		setIsSubmitting(true);
 		try {
 			const normalizedExpectedDate = expectedDate === '' ? undefined : expectedDate;
+			const normalizedCategory = category.trim();
+			const categoryForSubmit = expense
+				? (normalizedCategory || expense.category || '')
+				: normalizedCategory;
 			const data: Pick<
 				RecurringTransaction,
 				'title' | 'amount' | 'type' | 'category' | 'description' | 'frequency' | 'expectedDate'
@@ -79,7 +83,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 				title,
 				amount: Number(amount),
 				type: transactionType,
-				category,
+				category: categoryForSubmit,
 				description,
 				frequency,
 				expectedDate: normalizedExpectedDate,
@@ -133,11 +137,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 						<button
 							type="button"
 							onClick={() => setTransactionType('expense')}
-							className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-2.5 text-sm font-medium transition-all ${
-								transactionType === 'expense'
+							className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-2.5 text-sm font-medium transition-all ${transactionType === 'expense'
 									? 'border-red-500 bg-red-50 text-red-600 dark:bg-red-950/30 dark:text-red-400'
 									: 'border-border bg-background text-muted-foreground hover:border-muted-foreground'
-							}`}
+								}`}
 						>
 							<FiArrowDownCircle className="h-4 w-4" />
 							Expense
@@ -145,11 +148,10 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 						<button
 							type="button"
 							onClick={() => setTransactionType('income')}
-							className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-2.5 text-sm font-medium transition-all ${
-								transactionType === 'income'
+							className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-2.5 text-sm font-medium transition-all ${transactionType === 'income'
 									? 'border-green-500 bg-green-50 text-green-600 dark:bg-green-950/30 dark:text-green-400'
 									: 'border-border bg-background text-muted-foreground hover:border-muted-foreground'
-							}`}
+								}`}
 						>
 							<FiArrowUpCircle className="h-4 w-4" />
 							Income

--- a/src/views/RecurringTransactions/RecurringTransactionsView.tsx
+++ b/src/views/RecurringTransactions/RecurringTransactionsView.tsx
@@ -47,7 +47,14 @@ const EXPECTED_DATE_OPTIONS = [
 	}),
 ];
 
-type SortBy = 'default' | 'alpha-asc' | 'alpha-desc' | 'price-asc' | 'price-desc';
+type SortBy =
+	| 'default'
+	| 'alpha-asc'
+	| 'alpha-desc'
+	| 'price-asc'
+	| 'price-desc'
+	| 'expected-date-asc'
+	| 'expected-date-desc';
 
 const SORT_OPTIONS: { value: SortBy; label: string }[] = [
 	{ value: 'default', label: 'Default order' },
@@ -55,6 +62,8 @@ const SORT_OPTIONS: { value: SortBy; label: string }[] = [
 	{ value: 'alpha-desc', label: 'Name Z → A' },
 	{ value: 'price-asc', label: 'Price: Low → High' },
 	{ value: 'price-desc', label: 'Price: High → Low' },
+	{ value: 'expected-date-asc', label: 'Expected Day: Low → High' },
+	{ value: 'expected-date-desc', label: 'Expected Day: High → Low' },
 ];
 
 const getFrequencyLabel = (frequency?: string) => {
@@ -171,6 +180,18 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 			filtered.sort((a, b) => a.amount - b.amount);
 		} else if (sortBy === 'price-desc') {
 			filtered.sort((a, b) => b.amount - a.amount);
+		} else if (sortBy === 'expected-date-asc') {
+			filtered.sort((a, b) => {
+				const dayA = a.expectedDate ?? Number.MAX_SAFE_INTEGER;
+				const dayB = b.expectedDate ?? Number.MAX_SAFE_INTEGER;
+				return dayA - dayB;
+			});
+		} else if (sortBy === 'expected-date-desc') {
+			filtered.sort((a, b) => {
+				const dayA = a.expectedDate ?? Number.MIN_SAFE_INTEGER;
+				const dayB = b.expectedDate ?? Number.MIN_SAFE_INTEGER;
+				return dayB - dayA;
+			});
 		}
 
 		return filtered;


### PR DESCRIPTION
## Summary
- fix recurring edit modal so category is preserved when updating without selecting a new category
- add expected day sorting options in recurring transactions:
  - Expected Day: Low -> High
  - Expected Day: High -> Low

## Why
- editing a recurring transaction could save an empty category state instead of preserving existing value
- expected date filter needed ordering support for clearer monthly planning

## Validation
- npm run lint (no errors; existing project warnings only)
- npm run build (passes)