### PR TITLE
feat: add draft budget publishing

### DIFF
--- a/src/context/BudgetsContext.tsx
+++ b/src/context/BudgetsContext.tsx
@@ -2,12 +2,19 @@ import React, { createContext, useContext, ReactNode } from 'react';
 import { useBudgetsController } from '../controllers/BudgetsController';
 import { Budget, BudgetProgress, DateRange, Transaction } from '../types';
 
+type BudgetFormData = Omit<
+	Budget,
+	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
+>;
+
 interface BudgetsContextValue {
 	budgets: Budget[];
 	loading: boolean;
-	addBudget: (budget: Omit<Budget, 'id' | 'createdAt' | 'userId'>) => Promise<void>;
+	addBudget: (budget: BudgetFormData) => Promise<void>;
+	addDraftBudget: (budget: BudgetFormData) => Promise<void>;
 	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
 	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
+	publishBudget: (id: string) => Promise<void>;
 	deleteBudget: (id: string) => Promise<void>;
 	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
 	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];

--- a/src/controllers/BudgetsController.ts
+++ b/src/controllers/BudgetsController.ts
@@ -2,27 +2,44 @@ import { useBudgets } from '../hooks/useBudgets';
 import { Budget, BudgetProgress, DateRange, Transaction } from '../types';
 import { calculateBudgetUsage } from '../models/BudgetModel';
 
+type BudgetFormData = Omit<
+	Budget,
+	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
+>;
+
 interface BudgetsControllerReturn {
 	budgets: Budget[];
 	loading: boolean;
-	addBudget: (budget: Omit<Budget, 'id' | 'createdAt' | 'userId'>) => Promise<void>;
+	addBudget: (budget: BudgetFormData) => Promise<void>;
+	addDraftBudget: (budget: BudgetFormData) => Promise<void>;
 	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
 	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
+	publishBudget: (id: string) => Promise<void>;
 	deleteBudget: (id: string) => Promise<void>;
 	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
 	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];
 }
 
 export const useBudgetsController = (): BudgetsControllerReturn => {
-	const { budgets, addBudget, updateBudget, startBudget, deleteBudget, loading } =
-		useBudgets();
+	const {
+		budgets,
+		addBudget,
+		addDraftBudget,
+		updateBudget,
+		startBudget,
+		publishBudget,
+		deleteBudget,
+		loading,
+	} = useBudgets();
 
 	return {
 		budgets,
 		loading,
 		addBudget,
+		addDraftBudget,
 		updateBudget,
 		startBudget,
+		publishBudget,
 		deleteBudget,
 		getBudgetProgress: (budgetId, transactions) => {
 			const budget = budgets.find((b) => b.id === budgetId);

--- a/src/hooks/__tests__/useBudgets.test.ts
+++ b/src/hooks/__tests__/useBudgets.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useBudgets } from '../useBudgets';
+import { auth } from '../../services/firebase';
+
+const mockAddDoc = jest.fn();
+const mockUpdateDoc = jest.fn();
+const mockDeleteDoc = jest.fn();
+const mockOnSnapshot = jest.fn();
+
+jest.mock('firebase/firestore', () => ({
+	collection: jest.fn((...path: string[]) => ({ path })),
+	addDoc: (...args: unknown[]) => mockAddDoc(...args),
+	deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
+	updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+	doc: jest.fn((...path: string[]) => ({ path })),
+	query: jest.fn((collectionRef: unknown) => collectionRef),
+	onSnapshot: (...args: unknown[]) => mockOnSnapshot(...args),
+	Timestamp: {
+		now: jest.fn(() => 'timestamp-now'),
+	},
+}));
+
+const mockUser = { uid: 'user-1' };
+
+describe('useBudgets', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		Object.defineProperty(auth, 'currentUser', {
+			value: mockUser,
+			writable: true,
+		});
+		(auth.onAuthStateChanged as jest.Mock).mockImplementation(
+			(callback: (user: unknown) => void) => {
+				callback(mockUser);
+				return jest.fn();
+			}
+		);
+		mockOnSnapshot.mockImplementation(
+			(_queryRef: unknown, next: (snapshot: unknown) => void) => {
+				next({
+					docs: [
+						{
+							id: 'draft-1',
+							data: () => ({
+								category: 'groceries',
+								amount: 1000,
+								period: 'monthly',
+								status: 'draft',
+								plannedStartDate: '2026-05-01',
+								plannedEndDate: '2026-05-31',
+							}),
+						},
+						{
+							id: 'published-1',
+							data: () => ({
+								category: 'groceries',
+								amount: 500,
+								period: 'monthly',
+								status: 'published',
+								plannedStartDate: '2026-05-01',
+								plannedEndDate: '2026-05-31',
+							}),
+						},
+					],
+				});
+				return jest.fn();
+			}
+		);
+	});
+
+	it('creates draft budgets with draft status', async () => {
+		const { result } = renderHook(() => useBudgets());
+
+		await act(async () => {
+			await result.current.addDraftBudget({
+				category: 'groceries',
+				amount: 1000,
+				period: 'monthly',
+				plannedStartDate: '2026-05-01',
+				plannedEndDate: '2026-05-31',
+			});
+		});
+
+		expect(mockAddDoc).toHaveBeenCalledWith(expect.anything(), {
+			category: 'groceries',
+			amount: 1000,
+			period: 'monthly',
+			plannedStartDate: '2026-05-01',
+			plannedEndDate: '2026-05-31',
+			status: 'draft',
+			userId: 'user-1',
+			createdAt: 'timestamp-now',
+		});
+	});
+
+	it('publishes a draft by updating status and using the planned period', async () => {
+		const { result } = renderHook(() => useBudgets());
+
+		await waitFor(() => {
+			expect(result.current.budgets).toHaveLength(2);
+		});
+
+		await act(async () => {
+			await result.current.publishBudget('draft-1');
+		});
+
+		expect(mockUpdateDoc).toHaveBeenCalledWith(expect.anything(), {
+			status: 'published',
+			actualStartDate: '2026-05-01',
+			actualEndDate: '2026-05-31',
+		});
+		expect(mockAddDoc).not.toHaveBeenCalled();
+		expect(mockDeleteDoc).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -14,6 +14,11 @@ import {
 import { Budget, DateRange } from '../types';
 import { normalizeBudget } from '../models/BudgetModel';
 
+type BudgetFormData = Omit<
+	Budget,
+	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
+>;
+
 export const useBudgets = () => {
 	const [budgets, setBudgets] = useState<Budget[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -51,12 +56,25 @@ export const useBudgets = () => {
 		return () => unsubscribe();
 	}, [user]);
 
-	const addBudget = async (budget: Omit<Budget, 'id' | 'createdAt' | 'userId'>) => {
+	const addBudget = async (budget: BudgetFormData) => {
 		if (!user) throw new Error('User not authenticated');
 
 		const col = collection(db, 'users', user.uid, 'budgets');
 		await addDoc(col, {
 			...budget,
+			status: 'published',
+			userId: user.uid,
+			createdAt: Timestamp.now(),
+		});
+	};
+
+	const addDraftBudget = async (budget: BudgetFormData) => {
+		if (!user) throw new Error('User not authenticated');
+
+		const col = collection(db, 'users', user.uid, 'budgets');
+		await addDoc(col, {
+			...budget,
+			status: 'draft',
 			userId: user.uid,
 			createdAt: Timestamp.now(),
 		});
@@ -81,6 +99,20 @@ export const useBudgets = () => {
 		});
 	};
 
+	const publishBudget = async (id: string) => {
+		if (!user) throw new Error('User not authenticated');
+
+		const budget = budgets.find((item) => item.id === id);
+		if (!budget) throw new Error('Budget not found');
+
+		const ref = doc(db, 'users', user.uid, 'budgets', id);
+		await updateDoc(ref, {
+			status: 'published',
+			actualStartDate: budget.plannedStartDate,
+			actualEndDate: budget.plannedEndDate,
+		});
+	};
+
 	const deleteBudget = async (id: string) => {
 		if (!user) throw new Error('User not authenticated');
 		const ref = doc(db, 'users', user.uid, 'budgets', id);
@@ -90,8 +122,10 @@ export const useBudgets = () => {
 	return {
 		budgets,
 		addBudget,
+		addDraftBudget,
 		updateBudget,
 		startBudget,
+		publishBudget,
 		deleteBudget,
 		loading,
 	};

--- a/src/models/BudgetModel.ts
+++ b/src/models/BudgetModel.ts
@@ -36,6 +36,7 @@ type BudgetDoc = {
 	category?: string;
 	amount?: number;
 	period?: Budget['period'];
+	status?: Budget['status'];
 	plannedStartDate?: string;
 	plannedEndDate?: string;
 	actualStartDate?: string;
@@ -52,6 +53,7 @@ export const normalizeBudget = (doc: BudgetDoc): Budget => {
 		category: doc.category ?? '',
 		amount: doc.amount ?? 0,
 		period: doc.period ?? 'monthly',
+		status: doc.status ?? 'published',
 		plannedStartDate: doc.plannedStartDate ?? legacyRange.startDate,
 		plannedEndDate: doc.plannedEndDate ?? legacyRange.endDate,
 		actualStartDate: doc.actualStartDate ?? undefined,
@@ -72,37 +74,44 @@ export const calculateBudgetUsage = (
 	budget: Budget,
 	transactions: Transaction[]
 ): BudgetProgress => {
+	const isDraft = budget.status === 'draft';
 	const started = Boolean(budget.actualStartDate && budget.actualEndDate);
-	const actualRange: DateRange = {
-		startDate: budget.actualStartDate ?? '',
-		endDate: budget.actualEndDate ?? '',
+	const calculating = isDraft || started;
+	const comparisonRange: DateRange = {
+		startDate: isDraft ? budget.plannedStartDate : budget.actualStartDate ?? '',
+		endDate: isDraft ? budget.plannedEndDate : budget.actualEndDate ?? '',
 	};
 
-	const actualSpent = started
+	const actualSpent = calculating
 		? filterTransactionsByDateRangeObject(
 				transactions.filter(
 					(transaction) =>
 						transaction.type === 'expense' && transaction.category === budget.category
-					),
-				actualRange
+				),
+				comparisonRange
 		  ).reduce((sum, transaction) => sum + transaction.amount, 0)
 		: 0;
 
-	const remaining = started ? Math.max(0, budget.amount - actualSpent) : budget.amount;
-	const overBudget = started ? Math.max(0, actualSpent - budget.amount) : 0;
+	const remaining = calculating ? Math.max(0, budget.amount - actualSpent) : budget.amount;
+	const overBudget = calculating ? Math.max(0, actualSpent - budget.amount) : 0;
 	const percent =
-		started && budget.amount > 0
+		calculating && budget.amount > 0
 			? Math.min(100, (actualSpent / budget.amount) * 100)
 			: 0;
 
 	return {
 		budget,
+		status: budget.status,
+		isDraft,
 		plannedAmount: budget.amount,
 		plannedStartDate: budget.plannedStartDate,
 		plannedEndDate: budget.plannedEndDate,
 		actualStartDate: budget.actualStartDate,
 		actualEndDate: budget.actualEndDate,
+		comparisonStartDate: comparisonRange.startDate,
+		comparisonEndDate: comparisonRange.endDate,
 		started,
+		calculating,
 		actualSpent,
 		remaining,
 		overBudget,

--- a/src/models/__tests__/BudgetModel.test.ts
+++ b/src/models/__tests__/BudgetModel.test.ts
@@ -1,0 +1,114 @@
+import { calculateBudgetUsage, normalizeBudget } from '../BudgetModel';
+import { Budget, Transaction } from '../../types';
+
+const makeBudget = (overrides: Partial<Budget> = {}): Budget => ({
+	id: 'budget-1',
+	category: 'groceries',
+	amount: 1000,
+	period: 'monthly',
+	status: 'published',
+	plannedStartDate: '2026-05-01',
+	plannedEndDate: '2026-05-31',
+	...overrides,
+});
+
+const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+	id: 'transaction-1',
+	accountId: 'account-1',
+	title: 'Groceries',
+	amount: 250,
+	type: 'expense',
+	category: 'groceries',
+	date: new Date('2026-05-10T12:00:00Z'),
+	...overrides,
+});
+
+describe('BudgetModel', () => {
+	describe('normalizeBudget', () => {
+		it('defaults legacy budgets to published status', () => {
+			const budget = normalizeBudget({
+				id: 'legacy-budget',
+				category: 'groceries',
+				amount: 1000,
+				plannedStartDate: '2026-05-01',
+				plannedEndDate: '2026-05-31',
+			});
+
+			expect(budget.status).toBe('published');
+		});
+
+		it('preserves draft status', () => {
+			const budget = normalizeBudget({
+				id: 'draft-budget',
+				category: 'groceries',
+				amount: 1000,
+				status: 'draft',
+				plannedStartDate: '2026-05-01',
+				plannedEndDate: '2026-05-31',
+			});
+
+			expect(budget.status).toBe('draft');
+		});
+	});
+
+	describe('calculateBudgetUsage', () => {
+		it('uses the planned range for draft live calculations', () => {
+			const budget = makeBudget({ status: 'draft' });
+			const progress = calculateBudgetUsage(budget, [
+				makeTransaction(),
+				makeTransaction({
+					id: 'outside-range',
+					amount: 300,
+					date: new Date('2026-06-01T12:00:00Z'),
+				}),
+			]);
+
+			expect(progress.isDraft).toBe(true);
+			expect(progress.comparisonStartDate).toBe('2026-05-01');
+			expect(progress.comparisonEndDate).toBe('2026-05-31');
+			expect(progress.actualSpent).toBe(250);
+			expect(progress.remaining).toBe(750);
+		});
+
+		it('uses the active actual range for published calculations', () => {
+			const budget = makeBudget({
+				actualStartDate: '2026-06-01',
+				actualEndDate: '2026-06-30',
+			});
+			const progress = calculateBudgetUsage(budget, [
+				makeTransaction({
+					id: 'planned-range-only',
+					amount: 250,
+					date: new Date('2026-05-10T12:00:00Z'),
+				}),
+				makeTransaction({
+					id: 'actual-range',
+					amount: 400,
+					date: new Date('2026-06-10T12:00:00Z'),
+				}),
+			]);
+
+			expect(progress.isDraft).toBe(false);
+			expect(progress.started).toBe(true);
+			expect(progress.comparisonStartDate).toBe('2026-06-01');
+			expect(progress.comparisonEndDate).toBe('2026-06-30');
+			expect(progress.actualSpent).toBe(400);
+			expect(progress.remaining).toBe(600);
+		});
+
+		it('returns zero spend and the full remaining amount when nothing matches', () => {
+			const budget = makeBudget({ status: 'draft' });
+			const progress = calculateBudgetUsage(budget, [
+				makeTransaction({
+					category: 'transport',
+					amount: 500,
+				}),
+			]);
+
+			expect(progress.actualSpent).toBe(0);
+			expect(progress.remaining).toBe(1000);
+			expect(progress.overBudget).toBe(0);
+			expect(progress.percent).toBe(0);
+		});
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,12 +67,15 @@ export interface Transaction {
 }
 
 // Budget
+export type BudgetStatus = 'draft' | 'published';
+
 export interface Budget {
 	id?: string;
 	userId?: string;
 	category: string;
 	amount: number;
 	period: 'monthly';
+	status: BudgetStatus;
 	plannedStartDate: string;
 	plannedEndDate: string;
 	actualStartDate?: string;
@@ -82,12 +85,17 @@ export interface Budget {
 
 export interface BudgetProgress {
 	budget: Budget;
+	status: BudgetStatus;
+	isDraft: boolean;
 	plannedAmount: number;
 	plannedStartDate: string;
 	plannedEndDate: string;
 	actualStartDate?: string;
 	actualEndDate?: string;
+	comparisonStartDate: string;
+	comparisonEndDate: string;
 	started: boolean;
+	calculating: boolean;
 	actualSpent: number;
 	remaining: number;
 	overBudget: number;

--- a/src/views/Budgets/BudgetForm.tsx
+++ b/src/views/Budgets/BudgetForm.tsx
@@ -30,7 +30,7 @@ interface BudgetFormProps {
 }
 
 const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
-	const { addBudget, updateBudget } = useBudgetsContext();
+	const { addDraftBudget, updateBudget } = useBudgetsContext();
 	const { categoryOptions } = useCategoriesContext();
 
 	const [category, setCategory] = useState('');
@@ -90,7 +90,7 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 			if (budget?.id) {
 				await updateBudget(budget.id, data);
 			} else {
-				await addBudget(data);
+				await addDraftBudget(data);
 			}
 			onClose();
 		} catch (err: unknown) {
@@ -105,12 +105,12 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 			<div className="w-full max-w-md rounded-2xl border bg-card p-8 shadow-xl">
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">
-						{budget ? 'Edit Budget' : 'New Budget'}
+						{budget ? 'Edit Budget' : 'New Draft Budget'}
 					</h2>
 					<p className="mt-1.5 text-sm text-muted-foreground">
 						{budget
 							? 'Update your planned budget amount and date range'
-							: 'Set a planned budget amount and date range for a category'}
+							: 'Plan an amount and date range before publishing it'}
 					</p>
 				</div>
 
@@ -172,8 +172,8 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 					</div>
 
 					<div className="rounded-xl border bg-muted/30 p-3 text-sm text-muted-foreground">
-						Use the budget screen filter to choose an actual date range, then click
-						Start on a budget to compare that period against this plan.
+						Draft budgets show live spend for this planned period. Publish when
+						you are ready to make the period active.
 					</div>
 
 					<div className="flex gap-3 pt-2">
@@ -182,7 +182,7 @@ const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
 								? 'Saving...'
 								: budget
 									? 'Update Budget'
-									: 'Create Budget'}
+									: 'Create Draft'}
 						</Button>
 						<Button type="button" variant="outline" onClick={onClose}>
 							Cancel

--- a/src/views/Budgets/BudgetsList.tsx
+++ b/src/views/Budgets/BudgetsList.tsx
@@ -7,6 +7,7 @@ import {
 	FiPlus,
 	FiTarget,
 	FiTrash2,
+	FiUploadCloud,
 } from 'react-icons/fi';
 import { useBudgetsContext } from '../../context/BudgetsContext';
 import { useTransactionsContext } from '../../context/TransactionsContext';
@@ -37,7 +38,8 @@ const getBarColour = (percent: number): string => {
 };
 
 const BudgetsList: React.FC = () => {
-	const { budgets, deleteBudget, getAllBudgetProgress, startBudget } = useBudgetsContext();
+	const { budgets, deleteBudget, getAllBudgetProgress, publishBudget, startBudget } =
+		useBudgetsContext();
 	const { getCategoryLabel } = useCategoriesContext();
 	const { transactions } = useTransactionsContext();
 
@@ -48,12 +50,24 @@ const BudgetsList: React.FC = () => {
 	const [dateRange, setDateRange] = useState<DateRange>({ startDate: '', endDate: '' });
 	const [actionError, setActionError] = useState('');
 	const [startingBudgetId, setStartingBudgetId] = useState<string | null>(null);
+	const [publishingBudgetId, setPublishingBudgetId] = useState<string | null>(null);
 
 	const allProgress: BudgetProgress[] = getAllBudgetProgress(transactions);
-	const startedBudgets = useMemo(
-		() => allProgress.filter((progress) => progress.started),
+	const draftProgress = useMemo(
+		() => allProgress.filter((progress) => progress.isDraft),
 		[allProgress]
 	);
+	const publishedProgress = useMemo(
+		() => allProgress.filter((progress) => !progress.isDraft),
+		[allProgress]
+	);
+	const activePublishedBudgets = useMemo(
+		() => publishedProgress.filter((progress) => progress.started),
+		[publishedProgress]
+	);
+	const draftCount = draftProgress.length;
+	const publishedCount = publishedProgress.length;
+	const startedBudgets = activePublishedBudgets;
 	const hasSelectedRange = Boolean(dateRange.startDate && dateRange.endDate);
 
 	const handleEdit = (budget: Budget) => {
@@ -96,6 +110,23 @@ const BudgetsList: React.FC = () => {
 			);
 		} finally {
 			setStartingBudgetId(null);
+		}
+	};
+
+	const handlePublishBudget = async (budgetId: string) => {
+		setActionError('');
+		setPublishingBudgetId(budgetId);
+
+		try {
+			await publishBudget(budgetId);
+		} catch (error) {
+			setActionError(
+				error instanceof Error
+					? error.message
+					: 'Unable to publish this budget right now. Please try again.'
+			);
+		} finally {
+			setPublishingBudgetId(null);
 		}
 	};
 
@@ -147,20 +178,20 @@ const BudgetsList: React.FC = () => {
 					<div>
 						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">Budgets</h1>
 						<p className="mt-1 text-sm text-muted-foreground">
-							Plan a budget period, then capture an actual comparison period from
-							the filter below.
+							Plan draft budgets with live spend, then publish them when the period
+							is ready.
 						</p>
 					</div>
 					<Button onClick={() => setShowForm(true)}>
 						<FiPlus className="mr-2 h-4 w-4" />
-						New Budget
+						New Draft
 					</Button>
 				</div>
 
 				<div className="mb-6 rounded-xl border bg-card p-4">
 					<div className="mb-3 flex items-center gap-2">
 						<FiCalendar className="h-4 w-4 text-muted-foreground" />
-						<p className="text-sm font-medium">Actual Budget Period</p>
+						<p className="text-sm font-medium">Published Budget Period Override</p>
 					</div>
 					<DateRangeFilter
 						dateRange={dateRange}
@@ -171,12 +202,12 @@ const BudgetsList: React.FC = () => {
 						}}
 					/>
 					<p className="mt-3 text-xs text-muted-foreground">
-						Set the actual date range here, then click Start on a budget card to
-						capture that period.
+						Published budgets use their published period by default. Choose a range
+						here only when you need to update a published budget comparison period.
 					</p>
 					{!hasSelectedRange && (
 						<div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
-							Select a start and end date to enable budget start tracking.
+							Select a start and end date to enable published period updates.
 						</div>
 					)}
 					{actionError && (
@@ -211,8 +242,8 @@ const BudgetsList: React.FC = () => {
 					</div>
 				) : budgets.length > 0 ? (
 					<div className="mb-8 rounded-xl border border-dashed bg-card px-4 py-5 text-sm text-muted-foreground">
-						No budgets have started yet. Pick an actual date range above and click
-						Start on any budget to compare plan vs actual.
+						No published budgets have an active comparison period yet. Drafts will
+						become active automatically when published.
 					</div>
 				) : null}
 
@@ -223,23 +254,25 @@ const BudgetsList: React.FC = () => {
 						</div>
 						<h3 className="text-lg font-semibold">No budgets yet</h3>
 						<p className="mt-1 text-sm text-muted-foreground">
-							Create a budget to track a custom planned period by category
+							Create a draft budget to plan a custom period by category
 						</p>
 						<Button className="mt-4" onClick={() => setShowForm(true)}>
-							Create Budget
+							Create Draft
 						</Button>
 					</div>
 				) : (
 					<div className="space-y-4">
-						{allProgress.map((progress) => {
+						{[...draftProgress, ...publishedProgress].map((progress, index) => {
 							const {
 								budget,
 								plannedAmount,
 								plannedStartDate,
 								plannedEndDate,
-								actualStartDate,
-								actualEndDate,
 								started,
+								isDraft,
+								calculating,
+								comparisonStartDate,
+								comparisonEndDate,
 								actualSpent,
 								remaining,
 								overBudget,
@@ -249,7 +282,7 @@ const BudgetsList: React.FC = () => {
 							const isOverBudget = overBudget > 0;
 							const barColour = getBarColour(percent);
 							const matchingTransactions =
-								started && actualStartDate && actualEndDate
+								calculating && comparisonStartDate && comparisonEndDate
 									? filterTransactionsByDateRangeObject(
 											transactions.filter(
 												(transaction) =>
@@ -257,8 +290,8 @@ const BudgetsList: React.FC = () => {
 													transaction.category === budget.category
 											),
 											{
-												startDate: actualStartDate,
-												endDate: actualEndDate,
+												startDate: comparisonStartDate,
+												endDate: comparisonEndDate,
 											}
 									  ).sort((left, right) => {
 											const leftDate = parseDbDate(left.date ?? left.createdAt);
@@ -268,35 +301,82 @@ const BudgetsList: React.FC = () => {
 									: [];
 
 							return (
-								<div key={budget.id} className="group rounded-2xl border bg-card p-5">
-									<div className="mb-4 flex items-start justify-between gap-3">
-										<div className="min-w-0 flex-1">
-											<div className="flex items-center gap-2">
-												<h3 className="truncate font-semibold">{label}</h3>
-												{isOverBudget && (
-													<FiAlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
-												)}
+								<React.Fragment key={budget.id}>
+									{index === 0 && draftCount > 0 && (
+										<div className="flex items-center justify-between border-b pb-2">
+											<div>
+												<h2 className="text-lg font-semibold">Draft Budgets</h2>
+												<p className="text-sm text-muted-foreground">
+													Plan with live calculations before publishing.
+												</p>
 											</div>
-											<p className="mt-0.5 text-xs text-muted-foreground">
-												Plan vs actual budget tracking
-											</p>
+											<span className="text-sm text-muted-foreground">
+												{draftCount}
+											</span>
 										</div>
-										<div className="flex flex-shrink-0 items-center gap-1">
-											<Button
-												type="button"
-												size="sm"
-												variant={started ? 'outline' : 'default'}
-												className="h-8"
-												onClick={() => budget.id && handleStartBudget(budget.id)}
-												disabled={!hasSelectedRange || startingBudgetId === budget.id}
-											>
-												<FiPlay className="mr-1.5 h-3.5 w-3.5" />
-												{startingBudgetId === budget.id
-													? 'Starting...'
-													: started
-														? 'Restart'
-														: 'Start'}
-											</Button>
+									)}
+									{index === draftCount && publishedCount > 0 && (
+										<div className="flex items-center justify-between border-b pb-2 pt-4">
+											<div>
+												<h2 className="text-lg font-semibold">Published Budgets</h2>
+												<p className="text-sm text-muted-foreground">
+													Active budget periods and historical comparisons.
+												</p>
+											</div>
+											<span className="text-sm text-muted-foreground">
+												{publishedCount}
+											</span>
+										</div>
+									)}
+									<div className="group rounded-2xl border bg-card p-5">
+										<div className="mb-4 flex items-start justify-between gap-3">
+											<div className="min-w-0 flex-1">
+												<div className="flex items-center gap-2">
+													<h3 className="truncate font-semibold">{label}</h3>
+													<span className="rounded-full border px-2 py-0.5 text-xs capitalize text-muted-foreground">
+														{isDraft ? 'Draft' : 'Published'}
+													</span>
+													{isOverBudget && (
+														<FiAlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
+													)}
+												</div>
+												<p className="mt-0.5 text-xs text-muted-foreground">
+													{isDraft
+														? 'Live draft calculations for the planned period'
+														: 'Published budget tracking'}
+												</p>
+											</div>
+											<div className="flex flex-shrink-0 items-center gap-1">
+												{isDraft ? (
+													<Button
+														type="button"
+														size="sm"
+														className="h-8"
+														onClick={() => budget.id && handlePublishBudget(budget.id)}
+														disabled={publishingBudgetId === budget.id}
+													>
+														<FiUploadCloud className="mr-1.5 h-3.5 w-3.5" />
+														{publishingBudgetId === budget.id
+															? 'Publishing...'
+															: 'Publish'}
+													</Button>
+												) : (
+													<Button
+														type="button"
+														size="sm"
+														variant="outline"
+														className="h-8"
+														onClick={() => budget.id && handleStartBudget(budget.id)}
+														disabled={!hasSelectedRange || startingBudgetId === budget.id}
+													>
+														<FiPlay className="mr-1.5 h-3.5 w-3.5" />
+														{startingBudgetId === budget.id
+															? 'Updating...'
+															: started
+																? 'Update period'
+																: 'Set period'}
+													</Button>
+												)}
 											<Button
 												variant="ghost"
 												size="icon"
@@ -340,18 +420,18 @@ const BudgetsList: React.FC = () => {
 											<div className="mb-1 flex items-center gap-2">
 												<FiCalendar className="h-4 w-4 text-primary" />
 												<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-													Actual
+													{isDraft ? 'Live Spend' : 'Actual'}
 												</p>
 											</div>
-											{started ? (
+											{calculating ? (
 												<>
 													<p className="text-lg font-semibold">
 														{formatCurrency(actualSpent)}
 													</p>
 													<p className="mt-1 text-sm text-muted-foreground">
 														{formatDateRange({
-															startDate: actualStartDate ?? '',
-															endDate: actualEndDate ?? '',
+															startDate: comparisonStartDate,
+															endDate: comparisonEndDate,
 														})}
 													</p>
 												</>
@@ -359,7 +439,7 @@ const BudgetsList: React.FC = () => {
 												<>
 													<p className="text-lg font-semibold">Not started</p>
 													<p className="mt-1 text-sm text-muted-foreground">
-														Use the date filter and click Start.
+														Use the date filter to set a comparison period.
 													</p>
 												</>
 											)}
@@ -373,7 +453,7 @@ const BudgetsList: React.FC = () => {
 										/>
 									</div>
 
-									{started ? (
+									{calculating ? (
 										<>
 											<div className="flex items-center justify-between text-sm">
 												<span className="text-muted-foreground">
@@ -410,7 +490,7 @@ const BudgetsList: React.FC = () => {
 												{matchingTransactions.length === 0 ? (
 													<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
 														No transactions matched this budget category in the
-														selected actual period.
+														selected period.
 													</div>
 												) : (
 													<div className="space-y-2">
@@ -451,11 +531,12 @@ const BudgetsList: React.FC = () => {
 										</>
 									) : (
 										<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
-											This budget has a planned amount and period, but no actual
+											This budget has a planned amount and period, but no active
 											comparison period yet.
 										</div>
 									)}
 								</div>
+								</React.Fragment>
 							);
 						})}
 					</div>

--- a/src/views/Budgets/__tests__/BudgetsList.test.tsx
+++ b/src/views/Budgets/__tests__/BudgetsList.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BudgetsList from '../BudgetsList';
+import { BudgetProgress, Transaction } from '../../../types';
+
+const mockPublishBudget = jest.fn();
+
+const mockDraftProgress: BudgetProgress = {
+	budget: {
+		id: 'draft-1',
+		category: 'groceries',
+		amount: 1000,
+		period: 'monthly',
+		status: 'draft',
+		plannedStartDate: '2026-05-01',
+		plannedEndDate: '2026-05-31',
+	},
+	status: 'draft',
+	isDraft: true,
+	plannedAmount: 1000,
+	plannedStartDate: '2026-05-01',
+	plannedEndDate: '2026-05-31',
+	comparisonStartDate: '2026-05-01',
+	comparisonEndDate: '2026-05-31',
+	started: false,
+	calculating: true,
+	actualSpent: 250,
+	remaining: 750,
+	overBudget: 0,
+	percent: 25,
+};
+
+const mockPublishedProgress: BudgetProgress = {
+	budget: {
+		id: 'published-1',
+		category: 'transport',
+		amount: 500,
+		period: 'monthly',
+		status: 'published',
+		plannedStartDate: '2026-05-01',
+		plannedEndDate: '2026-05-31',
+		actualStartDate: '2026-05-01',
+		actualEndDate: '2026-05-31',
+	},
+	status: 'published',
+	isDraft: false,
+	plannedAmount: 500,
+	plannedStartDate: '2026-05-01',
+	plannedEndDate: '2026-05-31',
+	actualStartDate: '2026-05-01',
+	actualEndDate: '2026-05-31',
+	comparisonStartDate: '2026-05-01',
+	comparisonEndDate: '2026-05-31',
+	started: true,
+	calculating: true,
+	actualSpent: 100,
+	remaining: 400,
+	overBudget: 0,
+	percent: 20,
+};
+
+const mockTransactions: Transaction[] = [
+	{
+		id: 'transaction-1',
+		accountId: 'account-1',
+		title: 'Supermarket',
+		amount: 250,
+		type: 'expense',
+		category: 'groceries',
+		date: new Date('2026-05-10T12:00:00Z'),
+	},
+];
+
+jest.mock('../../../context/BudgetsContext', () => ({
+	useBudgetsContext: () => ({
+		budgets: [mockDraftProgress.budget, mockPublishedProgress.budget],
+		loading: false,
+		addBudget: jest.fn(),
+		addDraftBudget: jest.fn(),
+		updateBudget: jest.fn(),
+		startBudget: jest.fn(),
+		publishBudget: mockPublishBudget,
+		deleteBudget: jest.fn(),
+		getBudgetProgress: jest.fn(),
+		getAllBudgetProgress: jest.fn(() => [mockDraftProgress, mockPublishedProgress]),
+	}),
+}));
+
+jest.mock('../../../context/TransactionsContext', () => ({
+	useTransactionsContext: () => ({
+		transactions: mockTransactions,
+	}),
+}));
+
+jest.mock('../../../context/CategoriesContext', () => ({
+	useCategoriesContext: () => ({
+		getCategoryLabel: (category: string) =>
+			category === 'groceries' ? 'Groceries' : 'Transport',
+		categoryOptions: [
+			{ value: 'groceries', label: 'Groceries' },
+			{ value: 'transport', label: 'Transport' },
+		],
+	}),
+}));
+
+describe('BudgetsList draft publishing', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('separates draft and published budgets and shows live draft calculations', () => {
+		render(<BudgetsList />);
+
+		expect(screen.getByText('Draft Budgets')).toBeInTheDocument();
+		expect(screen.getByText('Published Budgets')).toBeInTheDocument();
+		expect(screen.getByText('Live draft calculations for the planned period')).toBeInTheDocument();
+		expect(screen.getByText(/250,00 actual spend/)).toBeInTheDocument();
+		expect(screen.getByText('Supermarket')).toBeInTheDocument();
+	});
+
+	it('publishes a draft without replacing existing published budgets', async () => {
+		const user = userEvent.setup();
+		render(<BudgetsList />);
+
+		await user.click(screen.getByRole('button', { name: /publish/i }));
+
+		await waitFor(() => {
+			expect(mockPublishBudget).toHaveBeenCalledWith('draft-1');
+		});
+		expect(screen.getByText('Published Budgets')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- add draft/published status support for budgets with legacy published normalization
- create draft budgets by default and publish them into active comparison periods
- show draft and published budget sections with live draft calculations

## Tests
- npm test -- --runInBand src/models/__tests__/BudgetModel.test.ts src/hooks/__tests__/useBudgets.test.ts src/views/Budgets/__tests__/BudgetsList.test.tsx
- npm run build
- npm run lint (passes with existing fast-refresh warnings)