### PR TITLE
[codex] Add month-first reports and bulk category editing

### DIFF
--- a/src/features/categories/utils/__tests__/categories.test.ts
+++ b/src/features/categories/utils/__tests__/categories.test.ts
@@ -1,4 +1,5 @@
 import {
+	buildCategoryPathOptions,
 	getCategoryPathLabel,
 	getSubcategoryLabel,
 	normalizeCategoryDefinition,
@@ -48,5 +49,43 @@ describe('category utilities', () => {
 				{ value: 'groceries', label: 'Duplicate Groceries' },
 			])
 		).toEqual([{ value: 'groceries', label: 'Duplicate Groceries' }]);
+	});
+
+	it('builds category and subcategory path options for quick editing', () => {
+		expect(
+			buildCategoryPathOptions([
+				{
+					value: 'food',
+					label: 'Food',
+					subcategories: [
+						{ value: 'groceries', label: 'Groceries' },
+						{ value: 'takeaways_eating_out', label: 'Takeaways / Eating Out' },
+					],
+				},
+				{
+					value: 'transfer',
+					label: 'Transfer',
+					subcategories: [],
+				},
+			])
+		).toEqual([
+			{
+				value: 'food',
+				category: 'food',
+				label: 'Food',
+			},
+			{
+				value: 'food/groceries',
+				category: 'food',
+				subcategory: 'groceries',
+				label: 'Food / Groceries',
+			},
+			{
+				value: 'food/takeaways_eating_out',
+				category: 'food',
+				subcategory: 'takeaways_eating_out',
+				label: 'Food / Takeaways / Eating Out',
+			},
+		]);
 	});
 });

--- a/src/features/categories/utils/categories.ts
+++ b/src/features/categories/utils/categories.ts
@@ -2,6 +2,13 @@ import { Category, CategoryDefinition } from '@/types';
 import { DEFAULT_CATEGORY_TEMPLATES, TRANSFER_CATEGORY_VALUE } from '@/features/categories/constants/categories';
 import { parseDbDateOrNull } from '@/utils/date';
 
+export interface CategoryPathOption {
+	value: string;
+	category: string;
+	subcategory?: string;
+	label: string;
+}
+
 export const slugifyCategoryLabel = (label: string): string =>
 	label
 		.trim()
@@ -140,6 +147,28 @@ export const getCategoryPathLabel = (
 
 	return subcategoryLabel ? `${categoryLabel} / ${subcategoryLabel}` : categoryLabel;
 };
+
+export const buildCategoryPathOptions = (
+	categories: Pick<CategoryDefinition, 'value' | 'label' | 'subcategories'>[]
+): CategoryPathOption[] =>
+	categories
+		.filter((category) => category.value !== TRANSFER_CATEGORY_VALUE)
+		.flatMap((category) => {
+			const categoryOption: CategoryPathOption = {
+				value: category.value,
+				category: category.value,
+				label: category.label,
+			};
+
+			const subcategoryOptions = category.subcategories.map((subcategory) => ({
+				value: `${category.value}/${subcategory.value}`,
+				category: category.value,
+				subcategory: subcategory.value,
+				label: `${category.label} / ${subcategory.label}`,
+			}));
+
+			return [categoryOption, ...subcategoryOptions];
+		});
 
 export const getDefaultCategories = (): Array<Pick<CategoryDefinition, 'value' | 'label' | 'subcategories'>> =>
 	DEFAULT_CATEGORY_TEMPLATES.map((category) => ({

--- a/src/features/dashboard/components/SettingsModal.tsx
+++ b/src/features/dashboard/components/SettingsModal.tsx
@@ -523,6 +523,39 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 											</div>
 										</div>
 									</div>
+
+									{/* Reports */}
+									<div>
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+											Reports
+										</h3>
+										<div className="space-y-3 rounded-lg border p-4 sm:p-5">
+											{(
+												[
+													['dateRange', 'Date range filter'],
+													['summaryCards', 'Summary cards'],
+													['incomeExpenseTrend', 'Income vs expenses trend'],
+													['categoryBreakdown', 'Spending by category'],
+													['subcategoryBreakdown', 'Spending by subcategory'],
+													['accountActivity', 'Activity by account'],
+													['netWorth', 'Net worth breakdown'],
+												] as [keyof FilterPreferences['reports'], string][]
+											).map(([key, label]) => (
+												<div key={key} className="flex items-center justify-between gap-4">
+													<Label htmlFor={`rep-${key}`} className="cursor-pointer">
+														{label}
+													</Label>
+													<Switch
+														id={`rep-${key}`}
+														checked={prefs.reports[key]}
+														onCheckedChange={(checked: boolean) =>
+															setFilterVisible('reports', key, checked)
+														}
+													/>
+												</div>
+											))}
+										</div>
+									</div>
 								</div>
 							)}
 

--- a/src/features/dashboard/components/Sidebar.tsx
+++ b/src/features/dashboard/components/Sidebar.tsx
@@ -35,18 +35,20 @@ interface SidebarProps {
 	toggleSidebar: () => void;
 	onOpenSettings?: () => void;
 	onOpenLogin?: () => void;
+	onOpenHistory?: () => void;
 	onViewChange: (view: ViewType) => void;
 	activeView: ViewType;
 }
 
 interface NavItem {
-	id: ViewType;
+	id: ViewType | 'history';
 	label: string;
 	icon: React.ElementType;
 }
 
 const NAV_ITEMS: NavItem[] = [
 	{ id: 'dashboard', label: 'Dashboard', icon: FiGrid },
+	{ id: 'history', label: 'All Transactions', icon: FiList },
 	{ id: 'accounts', label: 'Accounts', icon: FiList },
 	{ id: 'budgets', label: 'Budgets', icon: FiTarget },
 	{ id: 'recurring', label: 'Recurring', icon: FiRefreshCw },
@@ -62,6 +64,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 	toggleSidebar,
 	onOpenSettings,
 	onOpenLogin,
+	onOpenHistory,
 	onViewChange,
 	activeView,
 }) => {
@@ -99,11 +102,15 @@ const Sidebar: React.FC<SidebarProps> = ({
 	}, [onCreate, toggleSidebar]);
 
 	const handleViewClick = useCallback(
-		(view: ViewType) => {
-			onViewChange(view);
+		(view: NavItem['id']) => {
+			if (view === 'history') {
+				onOpenHistory?.();
+			} else {
+				onViewChange(view);
+			}
 			if (window.innerWidth < 768) toggleSidebar();
 		},
-		[onViewChange, toggleSidebar]
+		[onOpenHistory, onViewChange, toggleSidebar]
 	);
 
 	const handleTransactionClick = useCallback(
@@ -236,7 +243,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 								</p>
 								<div className="space-y-1">
 									{NAV_ITEMS.map(({ id, label, icon: Icon }) => {
-										const isActive = activeView === id;
+										const isActive =
+											id === 'history'
+												? activeView === 'table' || activeView === 'list'
+												: activeView === id;
 										return (
 											<button
 												key={id}

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -253,7 +253,7 @@ const Dashboard: React.FC = () => {
 			case 'recurring':
 				return <RecurringTransactionsView onOpenSettings={() => handleOpenSettings('filters')} />;
 			case 'reports':
-				return <ReportsView />;
+				return <ReportsView onOpenSettings={() => handleOpenSettings('filters')} />;
 			default:
 				return (
 					<div className="flex flex-1 items-center justify-center px-4 py-8 md:px-6">
@@ -440,6 +440,7 @@ const Dashboard: React.FC = () => {
 				onViewChange={handleViewChange}
 				onOpenLogin={() => setAuthModalOpen(true)}
 				onOpenSettings={() => handleOpenSettings('general')}
+				onOpenHistory={handleOpenHistory}
 			/>
 
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>

--- a/src/features/filters/context/FilterPreferencesContext.tsx
+++ b/src/features/filters/context/FilterPreferencesContext.tsx
@@ -1,4 +1,8 @@
 import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import {
+	DEFAULT_FILTER_PREFS,
+	mergeFilterPreferences,
+} from '@/features/filters/utils/filterPreferences';
 
 export interface FilterPreferences {
 	recurring: {
@@ -18,43 +22,27 @@ export interface FilterPreferences {
 	transactionsList: {
 		search: boolean;
 	};
+	reports: {
+		dateRange: boolean;
+		summaryCards: boolean;
+		incomeExpenseTrend: boolean;
+		categoryBreakdown: boolean;
+		subcategoryBreakdown: boolean;
+		accountActivity: boolean;
+		netWorth: boolean;
+	};
 }
-
-const DEFAULT_PREFS: FilterPreferences = {
-	recurring: {
-		frequency: true,
-		category: true,
-		type: true,
-		date: true,
-		sortBy: true,
-	},
-	transactionsTable: {
-		search: true,
-		type: true,
-		category: true,
-		month: true,
-		dateRange: true,
-	},
-	transactionsList: {
-		search: true,
-	},
-};
 
 const STORAGE_KEY = 'cashflow_filter_prefs';
 
 function loadPrefs(): FilterPreferences {
 	try {
 		const raw = localStorage.getItem(STORAGE_KEY);
-		if (!raw) return DEFAULT_PREFS;
-		const parsed = JSON.parse(raw) as Partial<FilterPreferences>;
-		// Deep-merge with defaults so new keys are always present
-		return {
-			recurring: { ...DEFAULT_PREFS.recurring, ...parsed.recurring },
-			transactionsTable: { ...DEFAULT_PREFS.transactionsTable, ...parsed.transactionsTable },
-			transactionsList: { ...DEFAULT_PREFS.transactionsList, ...parsed.transactionsList },
-		};
+		if (!raw) return DEFAULT_FILTER_PREFS;
+		const parsed = JSON.parse(raw);
+		return mergeFilterPreferences(parsed);
 	} catch {
-		return DEFAULT_PREFS;
+		return DEFAULT_FILTER_PREFS;
 	}
 }
 
@@ -99,7 +87,7 @@ export const FilterPreferencesProvider: React.FC<{ children: ReactNode }> = ({ c
 
 	const resetPrefs = useCallback(() => {
 		localStorage.removeItem(STORAGE_KEY);
-		setPrefs(DEFAULT_PREFS);
+		setPrefs(DEFAULT_FILTER_PREFS);
 	}, []);
 
 	return (

--- a/src/features/filters/context/__tests__/FilterPreferencesContext.test.ts
+++ b/src/features/filters/context/__tests__/FilterPreferencesContext.test.ts
@@ -1,0 +1,44 @@
+import { mergeFilterPreferences } from '@/features/filters/utils/filterPreferences';
+
+describe('FilterPreferencesContext', () => {
+	it('merges report defaults into older stored preferences', () => {
+		expect(
+			mergeFilterPreferences({
+				transactionsTable: {
+					search: false,
+					type: true,
+					category: true,
+					month: true,
+					dateRange: true,
+				},
+			}).reports
+		).toEqual({
+			dateRange: true,
+			summaryCards: true,
+			incomeExpenseTrend: true,
+			categoryBreakdown: true,
+			subcategoryBreakdown: true,
+			accountActivity: true,
+			netWorth: true,
+		});
+	});
+
+	it('preserves stored report preferences while filling missing keys', () => {
+		expect(
+			mergeFilterPreferences({
+				reports: {
+					dateRange: false,
+					summaryCards: false,
+				},
+			}).reports
+		).toEqual({
+			dateRange: false,
+			summaryCards: false,
+			incomeExpenseTrend: true,
+			categoryBreakdown: true,
+			subcategoryBreakdown: true,
+			accountActivity: true,
+			netWorth: true,
+		});
+	});
+});

--- a/src/features/filters/utils/filterPreferences.ts
+++ b/src/features/filters/utils/filterPreferences.ts
@@ -1,0 +1,51 @@
+import type { FilterPreferences } from '@/features/filters/context/FilterPreferencesContext';
+
+export const DEFAULT_FILTER_PREFS: FilterPreferences = {
+	recurring: {
+		frequency: true,
+		category: true,
+		type: true,
+		date: true,
+		sortBy: true,
+	},
+	transactionsTable: {
+		search: true,
+		type: true,
+		category: true,
+		month: true,
+		dateRange: true,
+	},
+	transactionsList: {
+		search: true,
+	},
+	reports: {
+		dateRange: true,
+		summaryCards: true,
+		incomeExpenseTrend: true,
+		categoryBreakdown: true,
+		subcategoryBreakdown: true,
+		accountActivity: true,
+		netWorth: true,
+	},
+};
+
+type PartialFilterPreferences = {
+	[V in keyof FilterPreferences]?: Partial<FilterPreferences[V]>;
+};
+
+export function mergeFilterPreferences(
+	parsed: PartialFilterPreferences = {}
+): FilterPreferences {
+	return {
+		recurring: { ...DEFAULT_FILTER_PREFS.recurring, ...parsed.recurring },
+		transactionsTable: {
+			...DEFAULT_FILTER_PREFS.transactionsTable,
+			...parsed.transactionsTable,
+		},
+		transactionsList: {
+			...DEFAULT_FILTER_PREFS.transactionsList,
+			...parsed.transactionsList,
+		},
+		reports: { ...DEFAULT_FILTER_PREFS.reports, ...parsed.reports },
+	};
+}

--- a/src/features/reports/controllers/ReportsController.ts
+++ b/src/features/reports/controllers/ReportsController.ts
@@ -1,4 +1,16 @@
-import { Transaction, Account, DateRange, CategoryReport, AccountReport, MonthlyTrend, NetWorthData } from '@/types';
+import {
+	Account,
+	AccountReport,
+	CategoryBreakdownReport,
+	CategoryReport,
+	DateRange,
+	MonthlyAccountSummary,
+	MonthlyCategorySummary,
+	MonthlyTrend,
+	NetWorthData,
+	SubcategoryReport,
+	Transaction,
+} from '@/types';
 import { parseDbDateOrNull } from '@/utils/date';
 
 const CHART_COLORS = [
@@ -19,6 +31,13 @@ const getTransactionDate = (t: Transaction): Date => {
 	return d ?? new Date();
 };
 
+const formatDateInput = (date: Date): string => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+};
+
 const isInDateRange = (date: Date, range: DateRange): boolean => {
 	if (!range.startDate && !range.endDate) return true;
 	if (range.startDate && date < new Date(range.startDate)) return false;
@@ -28,6 +47,66 @@ const isInDateRange = (date: Date, range: DateRange): boolean => {
 		if (date > end) return false;
 	}
 	return true;
+};
+
+const NO_SUBCATEGORY_KEY = '__none__';
+
+const getSubcategoryKey = (subcategory?: string): string =>
+	subcategory?.trim() || NO_SUBCATEGORY_KEY;
+
+const getSubcategoryValue = (subcategoryKey: string): string | undefined =>
+	subcategoryKey === NO_SUBCATEGORY_KEY ? undefined : subcategoryKey;
+
+type CurrentCategoryBucket = {
+	amount: number;
+	transactionCount: number;
+	subcategories: Record<string, { amount: number; transactionCount: number }>;
+};
+
+type PreviousCategoryBucket = {
+	amount: number;
+	subcategories: Record<string, number>;
+};
+
+export const getMonthDateRange = (year: number, monthIndex: number): DateRange => {
+	const start = new Date(year, monthIndex, 1);
+	const end = new Date(year, monthIndex + 1, 0);
+
+	return {
+		startDate: formatDateInput(start),
+		endDate: formatDateInput(end),
+	};
+};
+
+export const getCurrentMonthDateRange = (today = new Date()): DateRange => ({
+	startDate: formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1)),
+	endDate: formatDateInput(today),
+});
+
+export const getPreviousMonthDateRange = (dateRange: DateRange): DateRange => {
+	const start = dateRange.startDate ? new Date(dateRange.startDate) : new Date();
+	const end = dateRange.endDate ? new Date(dateRange.endDate) : start;
+	const previousMonthIndex = start.getMonth() - 1;
+	const previousMonthLastDay = new Date(
+		start.getFullYear(),
+		previousMonthIndex + 1,
+		0
+	).getDate();
+	const previousStart = new Date(
+		start.getFullYear(),
+		previousMonthIndex,
+		Math.min(start.getDate(), previousMonthLastDay)
+	);
+	const previousEnd = new Date(
+		start.getFullYear(),
+		previousMonthIndex,
+		Math.min(end.getDate(), previousMonthLastDay)
+	);
+
+	return {
+		startDate: formatDateInput(previousStart),
+		endDate: formatDateInput(previousEnd),
+	};
 };
 
 export const getSpendingByCategory = (
@@ -48,6 +127,202 @@ export const getSpendingByCategory = (
 		amount,
 		color: CHART_COLORS[index % CHART_COLORS.length],
 	}));
+};
+
+export const getSpendingBySubcategory = (
+	transactions: Transaction[],
+	dateRange: DateRange
+): SubcategoryReport[] => {
+	const map: Record<string, { category: string; subcategoryKey: string; amount: number }> = {};
+
+	transactions
+		.filter((t) => t.type === 'expense')
+		.filter((t) => isInDateRange(getTransactionDate(t), dateRange))
+		.forEach((t) => {
+			const subcategoryKey = getSubcategoryKey(t.subcategory);
+			const key = `${t.category}::${subcategoryKey}`;
+			if (!map[key]) {
+				map[key] = { category: t.category, subcategoryKey, amount: 0 };
+			}
+			map[key].amount += t.amount;
+		});
+
+	return Object.values(map)
+		.sort((left, right) => right.amount - left.amount)
+		.map((item, index) => ({
+			category: item.category,
+			subcategory: getSubcategoryValue(item.subcategoryKey),
+			amount: item.amount,
+			color: CHART_COLORS[index % CHART_COLORS.length],
+		}));
+};
+
+export const getCategoryBreakdown = (
+	transactions: Transaction[],
+	dateRange: DateRange
+): CategoryBreakdownReport[] => {
+	const map: Record<
+		string,
+		{ amount: number; subcategories: Record<string, number> }
+	> = {};
+
+	transactions
+		.filter((t) => t.type === 'expense')
+		.filter((t) => isInDateRange(getTransactionDate(t), dateRange))
+		.forEach((t) => {
+			if (!map[t.category]) {
+				map[t.category] = { amount: 0, subcategories: {} };
+			}
+
+			const subcategoryKey = getSubcategoryKey(t.subcategory);
+			map[t.category].amount += t.amount;
+			map[t.category].subcategories[subcategoryKey] =
+				(map[t.category].subcategories[subcategoryKey] ?? 0) + t.amount;
+		});
+
+	return Object.entries(map)
+		.sort(([, left], [, right]) => right.amount - left.amount)
+		.map(([category, data], index) => ({
+			category,
+			amount: data.amount,
+			color: CHART_COLORS[index % CHART_COLORS.length],
+			subcategories: Object.entries(data.subcategories)
+				.sort(([, leftAmount], [, rightAmount]) => rightAmount - leftAmount)
+				.map(([subcategoryKey, amount]) => ({
+					category,
+					subcategory: getSubcategoryValue(subcategoryKey),
+					amount,
+					percentage: data.amount > 0 ? (amount / data.amount) * 100 : 0,
+				})),
+		}));
+};
+
+export const getMonthlyCategorySummaries = (
+	transactions: Transaction[],
+	dateRange: DateRange,
+	previousDateRange: DateRange = getPreviousMonthDateRange(dateRange)
+): MonthlyCategorySummary[] => {
+	const currentTotals: Record<string, CurrentCategoryBucket> = {};
+	const previousTotals: Record<string, PreviousCategoryBucket> = {};
+
+	transactions
+		.filter((transaction) => transaction.type === 'expense')
+		.forEach((transaction) => {
+			const date = getTransactionDate(transaction);
+			const category = transaction.category;
+			const subcategoryKey = getSubcategoryKey(transaction.subcategory);
+
+			if (isInDateRange(date, dateRange)) {
+				if (!currentTotals[category]) {
+					currentTotals[category] = {
+						amount: 0,
+						transactionCount: 0,
+						subcategories: {},
+					};
+				}
+				if (!currentTotals[category].subcategories[subcategoryKey]) {
+					currentTotals[category].subcategories[subcategoryKey] = {
+						amount: 0,
+						transactionCount: 0,
+					};
+				}
+				currentTotals[category].amount += transaction.amount;
+				currentTotals[category].transactionCount += 1;
+				currentTotals[category].subcategories[subcategoryKey].amount += transaction.amount;
+				currentTotals[category].subcategories[subcategoryKey].transactionCount += 1;
+			}
+
+			if (isInDateRange(date, previousDateRange)) {
+				if (!previousTotals[category]) {
+					previousTotals[category] = { amount: 0, subcategories: {} };
+				}
+				previousTotals[category].amount += transaction.amount;
+				previousTotals[category].subcategories[subcategoryKey] =
+					(previousTotals[category].subcategories[subcategoryKey] ?? 0) +
+					transaction.amount;
+			}
+		});
+
+	const totalExpense = Object.values(currentTotals).reduce(
+		(sum, category) => sum + category.amount,
+		0
+	);
+
+	return Object.entries(currentTotals)
+		.sort(([, left], [, right]) => right.amount - left.amount)
+		.map(([category, data], index) => ({
+			category,
+			amount: data.amount,
+			percentage: totalExpense > 0 ? (data.amount / totalExpense) * 100 : 0,
+			transactionCount: data.transactionCount,
+			previousAmount: previousTotals[category]?.amount ?? 0,
+			deltaAmount: data.amount - (previousTotals[category]?.amount ?? 0),
+			color: CHART_COLORS[index % CHART_COLORS.length],
+			subcategories: Object.entries(data.subcategories)
+				.sort(([, left], [, right]) => right.amount - left.amount)
+				.map(([subcategoryKey, subcategory]) => ({
+					category,
+					subcategory: getSubcategoryValue(subcategoryKey),
+					amount: subcategory.amount,
+					percentage: data.amount > 0 ? (subcategory.amount / data.amount) * 100 : 0,
+					transactionCount: subcategory.transactionCount,
+					previousAmount:
+						previousTotals[category]?.subcategories[subcategoryKey] ?? 0,
+					deltaAmount:
+						subcategory.amount -
+						(previousTotals[category]?.subcategories[subcategoryKey] ?? 0),
+				})),
+		}));
+};
+
+export const getMonthlyAccountSummaries = (
+	transactions: Transaction[],
+	accounts: Account[],
+	dateRange: DateRange,
+	accountId?: string
+): MonthlyAccountSummary[] => {
+	const summaries = new Map<string, MonthlyAccountSummary>();
+
+	for (const account of accounts) {
+		if (!account.id) continue;
+		if (accountId && account.id !== accountId) continue;
+		summaries.set(account.id, {
+			accountId: account.id,
+			accountName: account.name,
+			color: account.color ?? CHART_COLORS[summaries.size % CHART_COLORS.length],
+			income: 0,
+			expense: 0,
+			net: 0,
+			transactionCount: 0,
+		});
+	}
+
+	transactions
+		.filter((transaction) => isInDateRange(getTransactionDate(transaction), dateRange))
+		.filter((transaction) => !accountId || transaction.accountId === accountId)
+		.forEach((transaction) => {
+			if (!summaries.has(transaction.accountId)) {
+				summaries.set(transaction.accountId, {
+					accountId: transaction.accountId,
+					accountName: 'Unknown',
+					color: CHART_COLORS[summaries.size % CHART_COLORS.length],
+					income: 0,
+					expense: 0,
+					net: 0,
+					transactionCount: 0,
+				});
+			}
+
+			const summary = summaries.get(transaction.accountId)!;
+			if (transaction.type === 'income') summary.income += transaction.amount;
+			if (transaction.type === 'expense') summary.expense += transaction.amount;
+			summary.net = summary.income - summary.expense;
+			summary.transactionCount += 1;
+		});
+
+	return Array.from(summaries.values()).sort((left, right) =>
+		right.transactionCount - left.transactionCount || right.expense - left.expense
+	);
 };
 
 export const getSpendingByAccount = (

--- a/src/features/reports/controllers/__tests__/ReportsController.test.ts
+++ b/src/features/reports/controllers/__tests__/ReportsController.test.ts
@@ -1,0 +1,255 @@
+import {
+	getCategoryBreakdown,
+	getCurrentMonthDateRange,
+	getMonthDateRange,
+	getMonthlyAccountSummaries,
+	getMonthlyCategorySummaries,
+	getPreviousMonthDateRange,
+	getSpendingBySubcategory,
+} from '../ReportsController';
+import { Account, Transaction } from '@/types';
+
+const baseTransaction: Transaction = {
+	id: 'tx-1',
+	accountId: 'account-1',
+	title: 'Transaction',
+	amount: 100,
+	type: 'expense',
+	category: 'food',
+	date: new Date('2026-05-10T12:00:00Z'),
+};
+
+describe('ReportsController', () => {
+	it('builds a current month range from day 1 through today', () => {
+		expect(getCurrentMonthDateRange(new Date('2026-05-14T12:00:00Z'))).toEqual({
+			startDate: '2026-05-01',
+			endDate: '2026-05-14',
+		});
+	});
+
+	it('builds full calendar month ranges', () => {
+		expect(getMonthDateRange(2026, 1)).toEqual({
+			startDate: '2026-02-01',
+			endDate: '2026-02-28',
+		});
+		expect(getMonthDateRange(2024, 1)).toEqual({
+			startDate: '2024-02-01',
+			endDate: '2024-02-29',
+		});
+	});
+
+	it('builds previous month ranges across month boundaries', () => {
+		expect(
+			getPreviousMonthDateRange({
+				startDate: '2026-03-31',
+				endDate: '2026-03-31',
+			})
+		).toEqual({
+			startDate: '2026-02-28',
+			endDate: '2026-02-28',
+		});
+		expect(
+			getPreviousMonthDateRange({
+				startDate: '2026-05-01',
+				endDate: '2026-05-14',
+			})
+		).toEqual({
+			startDate: '2026-04-01',
+			endDate: '2026-04-14',
+		});
+	});
+
+	it('groups spending by category and subcategory', () => {
+		const result = getSpendingBySubcategory(
+			[
+				{ ...baseTransaction, id: 'tx-1', subcategory: 'groceries', amount: 120 },
+				{ ...baseTransaction, id: 'tx-2', subcategory: 'groceries', amount: 80 },
+				{ ...baseTransaction, id: 'tx-3', subcategory: 'takeaways_eating_out', amount: 50 },
+			],
+			{ startDate: '', endDate: '' }
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				category: 'food',
+				subcategory: 'groceries',
+				amount: 200,
+			}),
+			expect.objectContaining({
+				category: 'food',
+				subcategory: 'takeaways_eating_out',
+				amount: 50,
+			}),
+		]);
+	});
+
+	it('uses an undefined subcategory bucket when transactions have no subcategory', () => {
+		const result = getSpendingBySubcategory(
+			[
+				{ ...baseTransaction, id: 'tx-1', amount: 40 },
+				{ ...baseTransaction, id: 'tx-2', subcategory: '   ', amount: 60 },
+			],
+			{ startDate: '', endDate: '' }
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				category: 'food',
+				subcategory: undefined,
+				amount: 100,
+			}),
+		]);
+	});
+
+	it('keeps main category totals while exposing subcategory rows', () => {
+		const result = getCategoryBreakdown(
+			[
+				{ ...baseTransaction, id: 'tx-1', subcategory: 'groceries', amount: 75 },
+				{ ...baseTransaction, id: 'tx-2', subcategory: 'takeaways_eating_out', amount: 25 },
+			],
+			{ startDate: '', endDate: '' }
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				category: 'food',
+				amount: 100,
+				subcategories: [
+					{
+						category: 'food',
+						subcategory: 'groceries',
+						amount: 75,
+						percentage: 75,
+					},
+					{
+						category: 'food',
+						subcategory: 'takeaways_eating_out',
+						amount: 25,
+						percentage: 25,
+					},
+				],
+			}),
+		]);
+	});
+
+	it('applies date range filtering to subcategory reports', () => {
+		const result = getSpendingBySubcategory(
+			[
+				{
+					...baseTransaction,
+					id: 'tx-1',
+					subcategory: 'groceries',
+					amount: 120,
+					date: new Date('2026-05-10T12:00:00Z'),
+				},
+				{
+					...baseTransaction,
+					id: 'tx-2',
+					subcategory: 'groceries',
+					amount: 80,
+					date: new Date('2026-04-10T12:00:00Z'),
+				},
+			],
+			{ startDate: '2026-05-01', endDate: '2026-05-31' }
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				category: 'food',
+				subcategory: 'groceries',
+				amount: 120,
+			}),
+		]);
+	});
+
+	it('summarizes monthly category rows with percentages, counts, and deltas', () => {
+		const result = getMonthlyCategorySummaries(
+			[
+				{ ...baseTransaction, id: 'tx-1', category: 'food', subcategory: 'groceries', amount: 150 },
+				{ ...baseTransaction, id: 'tx-2', category: 'food', subcategory: 'takeaways_eating_out', amount: 50 },
+				{ ...baseTransaction, id: 'tx-3', category: 'travel', amount: 100 },
+				{
+					...baseTransaction,
+					id: 'tx-4',
+					category: 'food',
+					subcategory: 'groceries',
+					amount: 80,
+					date: new Date('2026-04-10T12:00:00Z'),
+				},
+			],
+			{ startDate: '2026-05-01', endDate: '2026-05-31' },
+			{ startDate: '2026-04-01', endDate: '2026-04-30' }
+		);
+
+		expect(result[0]).toEqual(
+			expect.objectContaining({
+				category: 'food',
+				amount: 200,
+				percentage: expect.closeTo(66.67, 2),
+				transactionCount: 2,
+				previousAmount: 80,
+				deltaAmount: 120,
+			})
+		);
+		expect(result[0].subcategories).toEqual([
+			expect.objectContaining({
+				category: 'food',
+				subcategory: 'groceries',
+				amount: 150,
+				percentage: 75,
+				transactionCount: 1,
+				previousAmount: 80,
+				deltaAmount: 70,
+			}),
+			expect.objectContaining({
+				category: 'food',
+				subcategory: 'takeaways_eating_out',
+				amount: 50,
+				percentage: 25,
+				transactionCount: 1,
+			}),
+		]);
+	});
+
+	it('summarizes monthly account activity and filters by account', () => {
+		const accounts: Account[] = [
+			{ id: 'account-1', name: 'Cheque', type: 'debit', balance: 1000 },
+			{ id: 'account-2', name: 'Savings', type: 'savings', balance: 500 },
+		];
+
+		const result = getMonthlyAccountSummaries(
+			[
+				{ ...baseTransaction, id: 'tx-1', accountId: 'account-1', amount: 120 },
+				{
+					...baseTransaction,
+					id: 'tx-2',
+					accountId: 'account-1',
+					type: 'income',
+					amount: 500,
+				},
+				{ ...baseTransaction, id: 'tx-3', accountId: 'account-2', amount: 40 },
+				{
+					...baseTransaction,
+					id: 'tx-4',
+					accountId: 'account-1',
+					amount: 60,
+					date: new Date('2026-04-10T12:00:00Z'),
+				},
+			],
+			accounts,
+			{ startDate: '2026-05-01', endDate: '2026-05-31' },
+			'account-1'
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				accountId: 'account-1',
+				accountName: 'Cheque',
+				income: 500,
+				expense: 120,
+				net: 380,
+				transactionCount: 2,
+			}),
+		]);
+	});
+});

--- a/src/features/reports/views/ReportsView.tsx
+++ b/src/features/reports/views/ReportsView.tsx
@@ -1,395 +1,710 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
-	AreaChart,
 	Area,
-	BarChart,
-	Bar,
-	PieChart,
-	Pie,
-	Cell,
+	AreaChart,
+	CartesianGrid,
+	Legend,
+	Line,
+	ResponsiveContainer,
+	Tooltip,
 	XAxis,
 	YAxis,
-	CartesianGrid,
-	Tooltip,
-	Legend,
-	ResponsiveContainer,
 } from 'recharts';
+import { FiChevronLeft, FiChevronRight, FiSettings, FiX } from 'react-icons/fi';
 import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
 import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/features/categories/context/CategoriesContext';
-import { DateRange } from '@/types';
+import { DateRange, MonthlyCategorySummary, Transaction } from '@/types';
 import {
-	getSpendingByCategory,
-	getSpendingByAccount,
+	getCurrentMonthDateRange,
+	getMonthlyAccountSummaries,
+	getMonthlyCategorySummaries,
+	getMonthDateRange,
 	getMonthlyTrend,
 	getNetWorth,
+	getPreviousMonthDateRange,
 } from '@/features/reports/controllers/ReportsController';
 import { filterTransactionsByDateRangeObject } from '@/features/filters/utils/dateRangeFilter';
+import { compareTransactionsByDateDesc } from '@/utils/date';
 import { formatCurrency } from '@/utils/formatCurrency';
 import DateRangeFilter from '@/features/filters/components/DateRangeFilter';
+import { useFilterPreferences } from '@/features/filters/context/FilterPreferencesContext';
+import { Button } from '@/components/app/ui/button';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/app/ui/select';
 
-const ReportsView: React.FC = () => {
+interface ReportsViewProps {
+	onOpenSettings?: () => void;
+}
+
+type ReportMode = 'expense' | 'income' | 'net';
+type PeriodMode = 'month' | 'custom';
+
+const getInitialSelectedMonth = () => {
+	const today = new Date();
+	return new Date(today.getFullYear(), today.getMonth(), 1);
+};
+
+const getMonthLabel = (month: Date) =>
+	month.toLocaleDateString('en-ZA', { month: 'long', year: 'numeric' });
+
+const getTransactionDate = (transaction: Transaction): Date | null => {
+	const value = transaction.date ?? transaction.createdAt;
+	if (!value) return null;
+	return value instanceof Date ? value : value.toDate();
+};
+
+const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 	const { transactions } = useTransactionsContext();
 	const { accounts } = useAccountsContext();
-	const { getCategoryLabel } = useCategoriesContext();
+	const { getCategoryLabel, getCategoryPathLabel } = useCategoriesContext();
+	const { prefs } = useFilterPreferences();
+	const reportPrefs = prefs.reports;
 
-	const [dateRange, setDateRange] = useState<DateRange>({ startDate: '', endDate: '' });
-
-	const filteredTransactions = useMemo(
-		() => filterTransactionsByDateRangeObject(transactions, dateRange),
-		[transactions, dateRange]
+	const [periodMode, setPeriodMode] = useState<PeriodMode>('month');
+	const [selectedMonth, setSelectedMonth] = useState<Date>(getInitialSelectedMonth);
+	const [customDateRange, setCustomDateRange] = useState<DateRange>(() =>
+		getCurrentMonthDateRange()
 	);
+	const [reportMode, setReportMode] = useState<ReportMode>('expense');
+	const [selectedAccountId, setSelectedAccountId] = useState('all');
+	const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+	const [selectedSubcategory, setSelectedSubcategory] = useState<string | null>(null);
 
-	const monthlyTrend = useMemo(() => getMonthlyTrend(transactions, 6), [transactions]);
+	const activeDateRange = useMemo(() => {
+		if (periodMode === 'custom') return customDateRange;
+		const today = new Date();
+		if (
+			selectedMonth.getFullYear() === today.getFullYear() &&
+			selectedMonth.getMonth() === today.getMonth()
+		) {
+			return getCurrentMonthDateRange(today);
+		}
+		return getMonthDateRange(selectedMonth.getFullYear(), selectedMonth.getMonth());
+	}, [customDateRange, periodMode, selectedMonth]);
 
-	const categoryData = useMemo(
-		() => getSpendingByCategory(filteredTransactions, dateRange),
-		[filteredTransactions, dateRange]
+	const previousDateRange = useMemo(
+		() => getPreviousMonthDateRange(activeDateRange),
+		[activeDateRange]
 	);
-	const labeledCategoryData = useMemo(
+	const accountScopedTransactions = useMemo(
 		() =>
-			categoryData.map((entry) => ({
+			selectedAccountId === 'all'
+				? transactions
+				: transactions.filter((transaction) => transaction.accountId === selectedAccountId),
+		[selectedAccountId, transactions]
+	);
+	const filteredTransactions = useMemo(
+		() => filterTransactionsByDateRangeObject(accountScopedTransactions, activeDateRange),
+		[accountScopedTransactions, activeDateRange]
+	);
+
+	const monthlyTrend = useMemo(
+		() =>
+			getMonthlyTrend(transactions, 6).map((entry) => ({
 				...entry,
-				displayCategory: getCategoryLabel(entry.category),
+				net: entry.income - entry.expense,
 			})),
-		[categoryData, getCategoryLabel]
+		[transactions]
 	);
-
-	const accountData = useMemo(
-		() => getSpendingByAccount(filteredTransactions, accounts, dateRange),
-		[filteredTransactions, accounts, dateRange]
+	const categorySummaries = useMemo(
+		() =>
+			getMonthlyCategorySummaries(
+				accountScopedTransactions,
+				activeDateRange,
+				previousDateRange
+			),
+		[accountScopedTransactions, activeDateRange, previousDateRange]
 	);
-
+	const accountSummaries = useMemo(
+		() =>
+			getMonthlyAccountSummaries(
+				transactions,
+				accounts,
+				activeDateRange,
+				selectedAccountId === 'all' ? undefined : selectedAccountId
+			),
+		[accounts, activeDateRange, selectedAccountId, transactions]
+	);
 	const netWorth = useMemo(() => getNetWorth(accounts), [accounts]);
 
 	const totalIncome = useMemo(
 		() =>
 			filteredTransactions
-				.filter((t) => t.type === 'income')
-				.reduce((s, t) => s + t.amount, 0),
+				.filter((transaction) => transaction.type === 'income')
+				.reduce((sum, transaction) => sum + transaction.amount, 0),
 		[filteredTransactions]
 	);
-
 	const totalExpense = useMemo(
 		() =>
 			filteredTransactions
-				.filter((t) => t.type === 'expense')
-				.reduce((s, t) => s + t.amount, 0),
+				.filter((transaction) => transaction.type === 'expense')
+				.reduce((sum, transaction) => sum + transaction.amount, 0),
 		[filteredTransactions]
 	);
 
+	const focusedTransactions = useMemo(() => {
+		if (!selectedCategory) return [];
+
+		return filteredTransactions
+			.filter((transaction) => {
+				if (transaction.type !== 'expense') return false;
+				if (transaction.category !== selectedCategory) return false;
+				if (selectedSubcategory === null) return true;
+				return (transaction.subcategory ?? '') === selectedSubcategory;
+			})
+			.sort(compareTransactionsByDateDesc)
+			.slice(0, 6);
+	}, [filteredTransactions, selectedCategory, selectedSubcategory]);
+
+	const biggestCategory = categorySummaries[0];
+	const biggestSubcategory = categorySummaries
+		.flatMap((category) => category.subcategories)
+		.sort((left, right) => right.amount - left.amount)[0];
+	const netPosition = totalIncome - totalExpense;
+
+	const getSubcategoryDisplayLabel = useCallback(
+		(category: string, subcategory?: string) =>
+			subcategory
+				? getCategoryPathLabel(category, subcategory)
+				: `${getCategoryLabel(category)} / No subcategory`,
+		[getCategoryLabel, getCategoryPathLabel]
+	);
 	const formatTick = (value: number) => {
-		if (value >= 1000) return `R${(value / 1000).toFixed(0)}k`;
+		if (Math.abs(value) >= 1000) return `R${(value / 1000).toFixed(0)}k`;
 		return `R${value}`;
 	};
+	const formatDate = (transaction: Transaction) => {
+		const date = getTransactionDate(transaction);
+		if (!date) return 'No date';
+		return date.toLocaleDateString('en-ZA', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+		});
+	};
+	const accountNameMap = useMemo(
+		() =>
+			Object.fromEntries(
+				accounts
+					.filter((account) => account.id)
+					.map((account) => [account.id, account.name])
+			),
+		[accounts]
+	);
+	const hasVisibleReportSections =
+		reportPrefs.summaryCards ||
+		reportPrefs.incomeExpenseTrend ||
+		reportPrefs.categoryBreakdown ||
+		reportPrefs.subcategoryBreakdown ||
+		reportPrefs.accountActivity ||
+		reportPrefs.netWorth;
+	const moveMonth = (offset: number) => {
+		setSelectedMonth(
+			(current) => new Date(current.getFullYear(), current.getMonth() + offset, 1)
+		);
+		setPeriodMode('month');
+		setSelectedCategory(null);
+		setSelectedSubcategory(null);
+	};
+	const resetToCurrentMonth = () => {
+		setSelectedMonth(getInitialSelectedMonth());
+		setPeriodMode('month');
+		setSelectedCategory(null);
+		setSelectedSubcategory(null);
+	};
+	const handleCustomDateRangeChange = (range: DateRange) => {
+		setCustomDateRange(range);
+		setPeriodMode('custom');
+		setSelectedCategory(null);
+		setSelectedSubcategory(null);
+	};
+	const selectCategory = (category: MonthlyCategorySummary) => {
+		setSelectedCategory((current) => (current === category.category ? null : category.category));
+		setSelectedSubcategory(null);
+	};
+	const selectedSubcategoryLabel =
+		selectedCategory && selectedSubcategory !== null
+			? getSubcategoryDisplayLabel(selectedCategory, selectedSubcategory || undefined)
+			: null;
 
 	return (
-		<div className="flex flex-col min-h-screen bg-background">
+		<div className="flex min-h-screen flex-col bg-background">
 			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				{/* Header */}
-				<div className="mb-6">
-					<h1 className="text-2xl md:text-3xl font-bold tracking-tight">Reports</h1>
-					<p className="mt-1 text-sm text-muted-foreground">
-						Visual overview of your financial activity
-					</p>
-				</div>
-
-				{/* Date range filter */}
-				<div className="mb-6 rounded-xl border bg-card p-4">
-					<DateRangeFilter
-						dateRange={dateRange}
-						onDateRangeChange={setDateRange}
-						onClear={() => setDateRange({ startDate: '', endDate: '' })}
-					/>
-				</div>
-
-				{/* Summary cards */}
-				<div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-					<div className="rounded-xl border bg-card p-4">
-						<p className="text-xs text-muted-foreground">Income</p>
-						<p className="mt-1 text-lg font-bold text-green-600 dark:text-green-400">
-							{formatCurrency(totalIncome)}
+				<div className="mb-6 flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+					<div>
+						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+							Monthly Reports
+						</h1>
+						<p className="mt-1 text-sm text-muted-foreground">
+							A month-first view with visible amounts, category decisions, and account review.
 						</p>
 					</div>
-					<div className="rounded-xl border bg-card p-4">
-						<p className="text-xs text-muted-foreground">Expenses</p>
-						<p className="mt-1 text-lg font-bold text-red-600 dark:text-red-400">
-							{formatCurrency(totalExpense)}
-						</p>
-					</div>
-					<div className="rounded-xl border bg-card p-4">
-						<p className="text-xs text-muted-foreground">Net</p>
-						<p
-							className={`mt-1 text-lg font-bold ${
-								totalIncome - totalExpense >= 0
-									? 'text-green-600 dark:text-green-400'
-									: 'text-red-600 dark:text-red-400'
-							}`}
-						>
-							{formatCurrency(totalIncome - totalExpense)}
-						</p>
-					</div>
-					<div className="rounded-xl border bg-card p-4">
-						<p className="text-xs text-muted-foreground">Net Worth</p>
-						<p
-							className={`mt-1 text-lg font-bold ${
-								netWorth.netWorth >= 0
-									? 'text-green-600 dark:text-green-400'
-									: 'text-red-600 dark:text-red-400'
-							}`}
-						>
-							{formatCurrency(netWorth.netWorth)}
-						</p>
-					</div>
-				</div>
-
-				{/* Income vs Expense trend */}
-				<div className="mb-6 rounded-2xl border bg-card p-5">
-					<h2 className="mb-4 text-base font-semibold">
-						6-Month Income vs Expenses
-					</h2>
-					{monthlyTrend.length > 0 ? (
-						<ResponsiveContainer width="100%" height={260}>
-							<AreaChart
-								data={monthlyTrend}
-								margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
-							>
-								<defs>
-									<linearGradient
-										id="incomeGrad"
-										x1="0"
-										y1="0"
-										x2="0"
-										y2="1"
-									>
-										<stop
-											offset="5%"
-											stopColor="#22c55e"
-											stopOpacity={0.3}
-										/>
-										<stop
-											offset="95%"
-											stopColor="#22c55e"
-											stopOpacity={0}
-										/>
-									</linearGradient>
-									<linearGradient
-										id="expenseGrad"
-										x1="0"
-										y1="0"
-										x2="0"
-										y2="1"
-									>
-										<stop
-											offset="5%"
-											stopColor="#ef4444"
-											stopOpacity={0.3}
-										/>
-										<stop
-											offset="95%"
-											stopColor="#ef4444"
-											stopOpacity={0}
-										/>
-									</linearGradient>
-								</defs>
-								<CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-								<XAxis
-									dataKey="month"
-									tick={{ fontSize: 12 }}
-									className="fill-muted-foreground"
-								/>
-								<YAxis
-									tickFormatter={formatTick}
-									tick={{ fontSize: 12 }}
-									className="fill-muted-foreground"
-								/>
-								<Tooltip
-									formatter={(value: number) => formatCurrency(value)}
-									contentStyle={{
-										borderRadius: '8px',
-										fontSize: '12px',
-									}}
-								/>
-								<Legend />
-								<Area
-									type="monotone"
-									dataKey="income"
-									name="Income"
-									stroke="#22c55e"
-									fill="url(#incomeGrad)"
-									strokeWidth={2}
-								/>
-								<Area
-									type="monotone"
-									dataKey="expense"
-									name="Expenses"
-									stroke="#ef4444"
-									fill="url(#expenseGrad)"
-									strokeWidth={2}
-								/>
-							</AreaChart>
-						</ResponsiveContainer>
-					) : (
-						<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-							No transaction data available
-						</div>
-					)}
-				</div>
-
-				<div className="mb-6 grid gap-6 md:grid-cols-2">
-					{/* Spending by category pie chart */}
-					<div className="rounded-2xl border bg-card p-5">
-						<h2 className="mb-4 text-base font-semibold">
-							Spending by Category
-						</h2>
-						{labeledCategoryData.length > 0 ? (
-							<>
-								<ResponsiveContainer width="100%" height={220}>
-									<PieChart>
-										<Pie
-											data={labeledCategoryData}
-											dataKey="amount"
-											nameKey="displayCategory"
-											cx="50%"
-											cy="50%"
-											outerRadius={80}
-											label={({ displayCategory, percent }) =>
-												`${displayCategory} ${(percent * 100).toFixed(0)}%`
-											}
-											labelLine={false}
-										>
-											{labeledCategoryData.map((entry, index) => (
-												<Cell
-													key={`cell-${index}`}
-													fill={entry.color}
-												/>
-											))}
-										</Pie>
-										<Tooltip
-											formatter={(value: number) =>
-												formatCurrency(value)
-											}
-											contentStyle={{
-												borderRadius: '8px',
-												fontSize: '12px',
-											}}
-										/>
-									</PieChart>
-								</ResponsiveContainer>
-								<div className="mt-2 space-y-1">
-									{labeledCategoryData.slice(0, 5).map((d) => (
-										<div
-											key={d.category}
-											className="flex items-center justify-between text-sm"
-										>
-											<div className="flex items-center gap-2">
-												<span
-													className="h-2.5 w-2.5 rounded-full flex-shrink-0"
-													style={{ backgroundColor: d.color }}
-												/>
-												<span>{d.displayCategory}</span>
-											</div>
-											<span className="font-medium">
-												{formatCurrency(d.amount)}
-											</span>
-										</div>
-									))}
-								</div>
-							</>
-						) : (
-							<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-								No expense data for this period
-							</div>
-						)}
-					</div>
-
-					{/* Activity by account bar chart */}
-					<div className="rounded-2xl border bg-card p-5">
-						<h2 className="mb-4 text-base font-semibold">Activity by Account</h2>
-						{accountData.length > 0 ? (
-							<ResponsiveContainer width="100%" height={260}>
-								<BarChart
-									data={accountData}
-									margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
-								>
-									<CartesianGrid
-										strokeDasharray="3 3"
-										className="stroke-border"
-									/>
-									<XAxis
-										dataKey="accountName"
-										tick={{ fontSize: 11 }}
-										className="fill-muted-foreground"
-									/>
-									<YAxis
-										tickFormatter={formatTick}
-										tick={{ fontSize: 11 }}
-										className="fill-muted-foreground"
-									/>
-									<Tooltip
-										formatter={(value: number) => formatCurrency(value)}
-										contentStyle={{
-											borderRadius: '8px',
-											fontSize: '12px',
-										}}
-									/>
-									<Legend />
-									<Bar
-										dataKey="income"
-										name="Income"
-										fill="#22c55e"
-										radius={[4, 4, 0, 0]}
-									/>
-									<Bar
-										dataKey="expense"
-										name="Expense"
-										fill="#ef4444"
-										radius={[4, 4, 0, 0]}
-									/>
-								</BarChart>
-							</ResponsiveContainer>
-						) : (
-							<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-								No account activity for this period
-							</div>
-						)}
-					</div>
-				</div>
-
-				{/* Net Worth breakdown */}
-				{accounts.length > 0 && (
-					<div className="rounded-2xl border bg-card p-5">
-						<h2 className="mb-4 text-base font-semibold">Net Worth Breakdown</h2>
-						<div className="grid gap-4 sm:grid-cols-3">
-							<div>
-								<p className="text-xs text-muted-foreground mb-1">Assets</p>
-								<p className="text-xl font-bold text-green-600 dark:text-green-400">
-									{formatCurrency(netWorth.assets)}
-								</p>
-							</div>
-							<div>
-								<p className="text-xs text-muted-foreground mb-1">
-									Liabilities
-								</p>
-								<p className="text-xl font-bold text-red-600 dark:text-red-400">
-									{formatCurrency(netWorth.liabilities)}
-								</p>
-							</div>
-							<div>
-								<p className="text-xs text-muted-foreground mb-1">Net Worth</p>
-								<p
-									className={`text-xl font-bold ${
-										netWorth.netWorth >= 0
-											? 'text-green-600 dark:text-green-400'
-											: 'text-red-600 dark:text-red-400'
+					<div className="flex flex-wrap items-center gap-2">
+						<div className="inline-flex rounded-lg border bg-card p-1">
+							{(['expense', 'income', 'net'] as ReportMode[]).map((mode) => (
+								<button
+									key={mode}
+									type="button"
+									onClick={() => setReportMode(mode)}
+									className={`rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors ${
+										reportMode === mode
+											? 'bg-primary text-primary-foreground'
+											: 'text-muted-foreground hover:text-foreground'
 									}`}
 								>
-									{formatCurrency(netWorth.netWorth)}
-								</p>
+									{mode}
+								</button>
+							))}
+						</div>
+					</div>
+				</div>
+
+				{reportPrefs.dateRange && (
+					<div className="mb-6 space-y-3 rounded-xl border bg-card p-4">
+						<div className="flex flex-wrap items-center gap-2">
+							<Button type="button" variant="outline" size="icon" onClick={() => moveMonth(-1)}>
+								<FiChevronLeft className="h-4 w-4" />
+							</Button>
+							<div className="min-w-[210px] rounded-lg border bg-background px-4 py-2 text-sm font-semibold">
+								{periodMode === 'month' ? getMonthLabel(selectedMonth) : 'Custom period'}
 							</div>
+							<Button type="button" variant="outline" size="icon" onClick={() => moveMonth(1)}>
+								<FiChevronRight className="h-4 w-4" />
+							</Button>
+							<Button type="button" variant="outline" onClick={resetToCurrentMonth}>
+								Current month
+							</Button>
+							<Button
+								type="button"
+								variant={periodMode === 'custom' ? 'default' : 'outline'}
+								onClick={() => setPeriodMode('custom')}
+							>
+								Custom range
+							</Button>
+							<Select
+								value={selectedAccountId}
+								onValueChange={(value) => {
+									setSelectedAccountId(value);
+									setSelectedCategory(null);
+									setSelectedSubcategory(null);
+								}}
+							>
+								<SelectTrigger className="h-10 w-[190px] rounded-xl">
+									<SelectValue placeholder="Account" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="all">All accounts</SelectItem>
+									{accounts.map((account) => (
+										<SelectItem key={account.id} value={account.id!}>
+											{account.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						{periodMode === 'custom' && (
+							<DateRangeFilter
+								dateRange={customDateRange}
+								onDateRangeChange={handleCustomDateRangeChange}
+								onClear={() => handleCustomDateRangeChange(getCurrentMonthDateRange())}
+							/>
+						)}
+						<div className="text-xs text-muted-foreground">
+							Showing {activeDateRange.startDate} to {activeDateRange.endDate}
 						</div>
 					</div>
 				)}
+
+				{!hasVisibleReportSections && (
+					<div className="flex items-center gap-2 rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+						<FiSettings className="h-4 w-4 shrink-0" />
+						<span>Reports are hidden.</span>
+						<button
+							className="ml-1 underline underline-offset-2 hover:text-foreground"
+							onClick={() => onOpenSettings?.()}
+						>
+							Manage in Settings
+						</button>
+					</div>
+				)}
+
+				{reportPrefs.summaryCards && (
+					<div className="mb-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+						<div className="rounded-xl border bg-card p-4">
+							<p className="text-xs text-muted-foreground">Monthly expenses</p>
+							<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
+								{formatCurrency(totalExpense)}
+							</p>
+							<p className="text-sm text-muted-foreground">
+								{
+									filteredTransactions.filter(
+										(transaction) => transaction.type === 'expense'
+									).length
+								}{' '}
+								transactions
+							</p>
+						</div>
+						<div className="rounded-xl border bg-card p-4">
+							<p className="text-xs text-muted-foreground">Biggest category</p>
+							<p className="mt-1 truncate text-xl font-bold">
+								{biggestCategory ? getCategoryLabel(biggestCategory.category) : 'None yet'}
+							</p>
+							<p className="text-sm text-muted-foreground">
+								{biggestCategory ? formatCurrency(biggestCategory.amount) : 'No expenses'}
+							</p>
+						</div>
+						<div className="rounded-xl border bg-card p-4">
+							<p className="text-xs text-muted-foreground">Biggest subcategory</p>
+							<p className="mt-1 truncate text-xl font-bold">
+								{biggestSubcategory
+									? getSubcategoryDisplayLabel(
+											biggestSubcategory.category,
+											biggestSubcategory.subcategory
+										)
+									: 'None yet'}
+							</p>
+							<p className="text-sm text-muted-foreground">
+								{biggestSubcategory ? formatCurrency(biggestSubcategory.amount) : 'No subcategories'}
+							</p>
+						</div>
+						<div className="rounded-xl border bg-card p-4">
+							<p className="text-xs text-muted-foreground">Net position</p>
+							<p
+								className={`mt-1 text-xl font-bold ${
+									netPosition >= 0
+										? 'text-green-600 dark:text-green-400'
+										: 'text-red-600 dark:text-red-400'
+								}`}
+							>
+								{formatCurrency(netPosition)}
+							</p>
+							<p className="text-sm text-muted-foreground">
+								Income {formatCurrency(totalIncome)}
+							</p>
+						</div>
+					</div>
+				)}
+
+				<div className="mb-6 grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.65fr)]">
+					{reportPrefs.categoryBreakdown && (
+						<div className="rounded-2xl border bg-card p-5">
+							<div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+								<div>
+									<h2 className="text-base font-semibold">Monthly category breakdown</h2>
+									<p className="text-sm text-muted-foreground">
+										Amounts are visible first. Select a category to inspect the month.
+									</p>
+								</div>
+								{selectedCategory && (
+									<Button type="button" variant="outline" size="sm" onClick={() => {
+										setSelectedCategory(null);
+										setSelectedSubcategory(null);
+									}}>
+										<FiX className="mr-2 h-4 w-4" />
+										Clear focus
+									</Button>
+								)}
+							</div>
+							{categorySummaries.length > 0 ? (
+								<div className="space-y-3">
+									{categorySummaries.map((category) => {
+										const isSelected = selectedCategory === category.category;
+										const deltaTone =
+											category.deltaAmount > 0
+												? 'text-red-600 dark:text-red-400'
+												: category.deltaAmount < 0
+													? 'text-green-600 dark:text-green-400'
+													: 'text-muted-foreground';
+
+										return (
+											<div
+												key={category.category}
+												className={`rounded-xl border p-3 transition-colors ${
+													isSelected ? 'border-primary bg-muted/50' : 'bg-background'
+												}`}
+											>
+												<button
+													type="button"
+													onClick={() => selectCategory(category)}
+													className="w-full text-left"
+												>
+													<div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center">
+														<div className="min-w-0">
+															<div className="flex items-center gap-2">
+																<span
+																	className="h-2.5 w-2.5 shrink-0 rounded-full"
+																	style={{ backgroundColor: category.color }}
+																/>
+																<span className="truncate font-semibold">
+																	{getCategoryLabel(category.category)}
+																</span>
+															</div>
+															<div className="mt-2 h-2 rounded-full bg-muted">
+																<div
+																	className="h-2 rounded-full"
+																	style={{
+																		width: `${Math.min(category.percentage, 100)}%`,
+																		backgroundColor: category.color,
+																	}}
+																/>
+															</div>
+														</div>
+														<div className="text-sm text-muted-foreground">
+															{category.percentage.toFixed(0)}%
+														</div>
+														<div className="text-sm text-muted-foreground">
+															{category.transactionCount} tx
+														</div>
+														<div className="text-right">
+															<div className="font-bold">{formatCurrency(category.amount)}</div>
+															<div className={`text-xs ${deltaTone}`}>
+																{category.deltaAmount === 0
+																	? 'No change'
+																	: `${category.deltaAmount > 0 ? '+' : ''}${formatCurrency(category.deltaAmount)} vs prev`}
+															</div>
+														</div>
+													</div>
+												</button>
+
+												{isSelected && reportPrefs.subcategoryBreakdown && (
+													<div className="mt-3 space-y-2 border-t pt-3">
+														{category.subcategories.map((subcategory) => {
+															const subcategoryKey = subcategory.subcategory ?? '';
+															const isSubSelected = selectedSubcategory === subcategoryKey;
+															return (
+																<button
+																	key={`${category.category}-${subcategoryKey || 'none'}`}
+																	type="button"
+																	onClick={() =>
+																		setSelectedSubcategory((current) =>
+																			current === subcategoryKey ? null : subcategoryKey
+																		)
+																	}
+																	className={`grid w-full gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center ${
+																		isSubSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'
+																	}`}
+																>
+																	<span className="truncate">
+																		{getSubcategoryDisplayLabel(
+																			subcategory.category,
+																			subcategory.subcategory
+																		)}
+																	</span>
+																	<span className="text-muted-foreground">
+																		{subcategory.percentage.toFixed(0)}%
+																	</span>
+																	<span className="text-muted-foreground">
+																		{subcategory.transactionCount} tx
+																	</span>
+																	<span className="font-semibold">
+																		{formatCurrency(subcategory.amount)}
+																	</span>
+																</button>
+															);
+														})}
+													</div>
+												)}
+											</div>
+										);
+									})}
+								</div>
+							) : (
+								<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+									No expense data for this period
+								</div>
+							)}
+						</div>
+					)}
+
+					<div className="space-y-6">
+						{reportPrefs.subcategoryBreakdown && (
+							<div className="rounded-2xl border bg-card p-5">
+								<h2 className="text-base font-semibold">
+									{selectedSubcategoryLabel ??
+										(selectedCategory
+											? getCategoryLabel(selectedCategory)
+											: 'Focused transactions')}
+								</h2>
+								<p className="mt-1 text-sm text-muted-foreground">
+									{selectedCategory
+										? 'Latest matching expenses for the selected month.'
+										: 'Select a category to inspect matching transactions.'}
+								</p>
+								<div className="mt-4">
+									{focusedTransactions.length > 0 ? (
+										<div className="space-y-2">
+											{focusedTransactions.map((transaction) => (
+												<div
+													key={transaction.id}
+													className="rounded-lg border bg-background px-3 py-2 text-sm"
+												>
+													<div className="flex items-center justify-between gap-3">
+														<div className="min-w-0">
+															<div className="truncate font-medium">{transaction.title}</div>
+															<div className="text-xs text-muted-foreground">
+																{formatDate(transaction)} · {accountNameMap[transaction.accountId] ?? 'Unknown account'}
+															</div>
+														</div>
+														<div className="shrink-0 font-semibold text-red-600 dark:text-red-400">
+															{formatCurrency(transaction.amount)}
+														</div>
+													</div>
+												</div>
+											))}
+										</div>
+									) : (
+										<div className="flex h-28 items-center justify-center text-center text-sm text-muted-foreground">
+											No focused transactions yet.
+										</div>
+									)}
+								</div>
+							</div>
+						)}
+
+						{reportPrefs.accountActivity && (
+							<div className="rounded-2xl border bg-card p-5">
+								<h2 className="mb-4 text-base font-semibold">Monthly account review</h2>
+								{accountSummaries.length > 0 ? (
+									<div className="space-y-3">
+										{accountSummaries.map((account) => (
+											<div key={account.accountId} className="rounded-xl border bg-background p-3">
+												<div className="mb-3 flex items-center gap-2">
+													<span
+														className="h-2.5 w-2.5 rounded-full"
+														style={{ backgroundColor: account.color }}
+													/>
+													<span className="font-semibold">{account.accountName}</span>
+													<span className="ml-auto text-xs text-muted-foreground">
+														{account.transactionCount} tx
+													</span>
+												</div>
+												<div className="grid grid-cols-3 gap-2 text-sm">
+													<div>
+														<p className="text-xs text-muted-foreground">Income</p>
+														<p className="font-semibold text-green-600 dark:text-green-400">
+															{formatCurrency(account.income)}
+														</p>
+													</div>
+													<div>
+														<p className="text-xs text-muted-foreground">Expense</p>
+														<p className="font-semibold text-red-600 dark:text-red-400">
+															{formatCurrency(account.expense)}
+														</p>
+													</div>
+													<div>
+														<p className="text-xs text-muted-foreground">Net</p>
+														<p
+															className={`font-semibold ${
+																account.net >= 0
+																	? 'text-green-600 dark:text-green-400'
+																	: 'text-red-600 dark:text-red-400'
+															}`}
+														>
+															{formatCurrency(account.net)}
+														</p>
+													</div>
+												</div>
+											</div>
+										))}
+									</div>
+								) : (
+									<div className="flex h-28 items-center justify-center text-sm text-muted-foreground">
+										No account activity for this period
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+
+				<div className="grid gap-6 xl:grid-cols-2">
+					{reportPrefs.incomeExpenseTrend && (
+						<div className="rounded-2xl border bg-card p-5">
+							<div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+								<h2 className="text-base font-semibold">6-Month Money Movement</h2>
+								<p className="text-sm text-muted-foreground">
+									{reportMode === 'expense'
+										? 'Expense focus'
+										: reportMode === 'income'
+											? 'Income focus'
+											: 'Net focus'}
+								</p>
+							</div>
+							{monthlyTrend.length > 0 ? (
+								<ResponsiveContainer width="100%" height={240}>
+									<AreaChart data={monthlyTrend} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+										<defs>
+											<linearGradient id="incomeGrad" x1="0" y1="0" x2="0" y2="1">
+												<stop offset="5%" stopColor="#22c55e" stopOpacity={0.25} />
+												<stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+											</linearGradient>
+											<linearGradient id="expenseGrad" x1="0" y1="0" x2="0" y2="1">
+												<stop offset="5%" stopColor="#ef4444" stopOpacity={0.25} />
+												<stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+											</linearGradient>
+										</defs>
+										<CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+										<XAxis dataKey="month" tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+										<YAxis tickFormatter={formatTick} tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+										<Tooltip formatter={(value: number) => formatCurrency(value)} contentStyle={{ borderRadius: '8px', fontSize: '12px' }} />
+										<Legend />
+										{reportMode !== 'expense' && (
+											<Area type="monotone" dataKey="income" name="Income" stroke="#22c55e" fill="url(#incomeGrad)" strokeWidth={2} />
+										)}
+										{reportMode !== 'income' && (
+											<Area type="monotone" dataKey="expense" name="Expenses" stroke="#ef4444" fill="url(#expenseGrad)" strokeWidth={2} />
+										)}
+										{reportMode === 'net' && (
+											<Line type="monotone" dataKey="net" name="Net" stroke="#0ea5e9" strokeWidth={2} dot={false} />
+										)}
+									</AreaChart>
+								</ResponsiveContainer>
+							) : (
+								<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+									No transaction data available
+								</div>
+							)}
+						</div>
+					)}
+
+					{reportPrefs.netWorth && accounts.length > 0 && (
+						<div className="rounded-2xl border bg-card p-5">
+							<h2 className="mb-4 text-base font-semibold">Net Worth Breakdown</h2>
+							<div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
+								<div>
+									<p className="mb-1 text-xs text-muted-foreground">Assets</p>
+									<p className="text-xl font-bold text-green-600 dark:text-green-400">
+										{formatCurrency(netWorth.assets)}
+									</p>
+								</div>
+								<div>
+									<p className="mb-1 text-xs text-muted-foreground">Liabilities</p>
+									<p className="text-xl font-bold text-red-600 dark:text-red-400">
+										{formatCurrency(netWorth.liabilities)}
+									</p>
+								</div>
+								<div>
+									<p className="mb-1 text-xs text-muted-foreground">Net Worth</p>
+									<p
+										className={`text-xl font-bold ${
+											netWorth.netWorth >= 0
+												? 'text-green-600 dark:text-green-400'
+												: 'text-red-600 dark:text-red-400'
+										}`}
+									>
+										{formatCurrency(netWorth.netWorth)}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/features/transactions/context/TransactionsContext.tsx
+++ b/src/features/transactions/context/TransactionsContext.tsx
@@ -31,6 +31,11 @@ loading: boolean;
 addTransaction: (data: AddTransactionData) => Promise<void>;
 addTransfer: (data: AddTransferData) => Promise<void>;
 updateTransaction: (id: string, updates: Partial<Transaction>) => Promise<void>;
+bulkUpdateTransactionCategories: (
+ids: string[],
+category: string,
+subcategory?: string
+) => Promise<void>;
 deleteTransaction: (id: string) => Promise<void>;
 deleteAllTransactions: () => Promise<void>;
 getExpenses: () => Transaction[];

--- a/src/features/transactions/controllers/TransactionsController.ts
+++ b/src/features/transactions/controllers/TransactionsController.ts
@@ -40,6 +40,11 @@ interface TransactionsControllerReturn {
 	addTransaction: (data: AddTransactionData) => Promise<void>;
 	addTransfer: (data: AddTransferData) => Promise<void>;
 	updateTransaction: (id: string, updates: Partial<Transaction>) => Promise<void>;
+	bulkUpdateTransactionCategories: (
+		ids: string[],
+		category: string,
+		subcategory?: string
+	) => Promise<void>;
 	deleteTransaction: (id: string) => Promise<void>;
 	deleteAllTransactions: () => Promise<void>;
 	getExpenses: () => Transaction[];
@@ -61,6 +66,7 @@ export const useTransactionsController = (): TransactionsControllerReturn => {
 		addTransaction,
 		addTransfer,
 		updateTransaction,
+		bulkUpdateTransactionCategories,
 		deleteTransaction,
 		deleteAllTransactions,
 		loading,
@@ -72,6 +78,7 @@ export const useTransactionsController = (): TransactionsControllerReturn => {
 		addTransaction,
 		addTransfer,
 		updateTransaction,
+		bulkUpdateTransactionCategories,
 		deleteTransaction,
 		deleteAllTransactions,
 		getExpenses: () => filterExpenses(transactions),

--- a/src/features/transactions/hooks/__tests__/useTransactions.test.ts
+++ b/src/features/transactions/hooks/__tests__/useTransactions.test.ts
@@ -177,4 +177,65 @@ describe('useTransactions', () => {
 			})
 		);
 	});
+
+	it('bulk updates selected transaction categories with trimmed path values', async () => {
+		const { result } = renderHook(() => useTransactions());
+
+		await act(async () => {
+			await result.current.bulkUpdateTransactionCategories(
+				['transaction-1', 'transaction-2', 'transaction-1'],
+				' food ',
+				' groceries '
+			);
+		});
+
+		expect(mockBatch.update).toHaveBeenCalledTimes(2);
+		expect(mockBatch.update).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				path: expect.arrayContaining(['transactions', 'transaction-1']),
+			}),
+			{
+				category: 'food',
+				subcategory: 'groceries',
+			}
+		);
+		expect(mockBatch.update).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				path: expect.arrayContaining(['transactions', 'transaction-2']),
+			}),
+			{
+				category: 'food',
+				subcategory: 'groceries',
+			}
+		);
+		expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('deletes subcategory when bulk updating to a category-only option', async () => {
+		const { result } = renderHook(() => useTransactions());
+
+		await act(async () => {
+			await result.current.bulkUpdateTransactionCategories(['transaction-1'], 'food');
+		});
+
+		expect(mockBatch.update).toHaveBeenCalledWith(
+			expect.anything(),
+			{
+				category: 'food',
+				subcategory: '__delete_field__',
+			}
+		);
+	});
+
+	it('rejects empty category values before bulk updating', async () => {
+		const { result } = renderHook(() => useTransactions());
+
+		await expect(
+			result.current.bulkUpdateTransactionCategories(['transaction-1'], '   ')
+		).rejects.toThrow('Category is required.');
+		expect(mockBatch.update).not.toHaveBeenCalled();
+		expect(mockBatch.commit).not.toHaveBeenCalled();
+	});
 });

--- a/src/features/transactions/hooks/useTransactions.ts
+++ b/src/features/transactions/hooks/useTransactions.ts
@@ -37,6 +37,16 @@ interface AddTransferData {
 	date?: Date;
 }
 
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+	const chunks: T[][] = [];
+
+	for (let index = 0; index < items.length; index += size) {
+		chunks.push(items.slice(index, index + size));
+	}
+
+	return chunks;
+};
+
 export const useTransactions = () => {
 	const [transactions, setTransactions] = useState<Transaction[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -233,6 +243,40 @@ export const useTransactions = () => {
 		}
 	};
 
+	const bulkUpdateTransactionCategories = async (
+		ids: string[],
+		category: string,
+		subcategory?: string
+	) => {
+		if (!user) throw new Error('User not authenticated');
+
+		const trimmedCategory = category.trim();
+		const trimmedSubcategory = subcategory?.trim() ?? '';
+		const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+
+		if (!trimmedCategory) {
+			throw new Error('Category is required.');
+		}
+
+		if (uniqueIds.length === 0) {
+			return;
+		}
+
+		for (const chunk of chunkArray(uniqueIds, 400)) {
+			const batch = writeBatch(db);
+
+			for (const id of chunk) {
+				const txRef = doc(db, 'users', user.uid, 'transactions', id);
+				batch.update(txRef, {
+					category: trimmedCategory,
+					subcategory: trimmedSubcategory || deleteField(),
+				});
+			}
+
+			await batch.commit();
+		}
+	};
+
 	const deleteTransaction = async (id: string) => {
 		if (!user) throw new Error('User not authenticated');
 		try {
@@ -304,6 +348,7 @@ export const useTransactions = () => {
 		addTransaction,
 		addTransfer,
 		updateTransaction,
+		bulkUpdateTransactionCategories,
 		deleteTransaction,
 		deleteAllTransactions,
 		loading,

--- a/src/features/transactions/views/TransactionsTable.tsx
+++ b/src/features/transactions/views/TransactionsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FiTrash2, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
 import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
@@ -26,8 +26,12 @@ import {
 } from '@/components/app/ui/select';
 import { Button } from '@/components/app/ui/button';
 import { Badge } from '@/components/app/ui/badge';
+import { useToast } from '@/components/app/ui/use-toast';
 import { useFilterPreferences } from '@/features/filters/context/FilterPreferencesContext';
-import { mergeCategoryOptions } from '@/features/categories/utils/categories';
+import {
+	buildCategoryPathOptions,
+	mergeCategoryOptions,
+} from '@/features/categories/utils/categories';
 import { getCategoryColor } from '@/features/categories/utils/categoryColors';
 
 interface TransactionsTableProps {
@@ -62,10 +66,11 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 	selectedId,
 	onOpenSettings,
 }) => {
-	const { transactions } = useTransactionsContext();
+	const { transactions, bulkUpdateTransactionCategories } = useTransactionsContext();
 	const { accounts, loading: accountsLoading } = useAccountsContext();
-	const { categoryOptions, getCategoryPathLabel } = useCategoriesContext();
+	const { categories, categoryOptions, getCategoryPathLabel } = useCategoriesContext();
 	const { prefs } = useFilterPreferences();
+	const { toast } = useToast();
 	const tablePrefs = prefs.transactionsTable;
 	const [search, setSearch] = useState('');
 	const [filterType, setFilterType] = useState<'all' | 'income' | 'expense'>('all');
@@ -76,6 +81,10 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 		endDate: '',
 	});
 	const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+	const [bulkCategoryValue, setBulkCategoryValue] = useState('');
+	const [isBulkSaving, setIsBulkSaving] = useState(false);
+	const selectVisibleRef = useRef<HTMLInputElement>(null);
 	const hasNoAccounts = !accountsLoading && accounts.length === 0;
 
 	const { filtered, totals } = useMemo(() => {
@@ -122,6 +131,44 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 	);
 
 	const visibleTransactions = filtered.slice(0, visibleCount);
+	const visibleSelectableTransactions = useMemo(
+		() => visibleTransactions.filter((tx) => tx.id && tx.type !== 'transfer'),
+		[visibleTransactions]
+	);
+	const selectedCount = selectedIds.size;
+	const allVisibleSelected =
+		visibleSelectableTransactions.length > 0 &&
+		visibleSelectableTransactions.every((tx) => tx.id && selectedIds.has(tx.id));
+	const someVisibleSelected = visibleSelectableTransactions.some(
+		(tx) => tx.id && selectedIds.has(tx.id)
+	);
+	const categoryPathOptions = useMemo(
+		() => buildCategoryPathOptions(categories),
+		[categories]
+	);
+	const selectedBulkCategory = categoryPathOptions.find(
+		(option) => option.value === bulkCategoryValue
+	);
+
+	useEffect(() => {
+		setSelectedIds((previous) => {
+			const availableIds = new Set(
+				transactions
+					.filter((tx) => tx.id && tx.type !== 'transfer')
+					.map((tx) => tx.id!)
+			);
+			const next = new Set(
+				Array.from(previous).filter((id) => availableIds.has(id))
+			);
+			return next.size === previous.size ? previous : next;
+		});
+	}, [transactions]);
+
+	useEffect(() => {
+		if (selectVisibleRef.current) {
+			selectVisibleRef.current.indeterminate = someVisibleSelected && !allVisibleSelected;
+		}
+	}, [allVisibleSelected, someVisibleSelected]);
 
 	const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
 		const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
@@ -131,6 +178,71 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 	};
 
 	const resetVisibleCount = () => setVisibleCount(INITIAL_VISIBLE_COUNT);
+	const clearSelection = () => setSelectedIds(new Set());
+	const resetVisibleCountAndSelection = () => {
+		resetVisibleCount();
+		clearSelection();
+	};
+
+	const toggleTransactionSelection = (id: string) => {
+		setSelectedIds((previous) => {
+			const next = new Set(previous);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	};
+
+	const toggleVisibleSelection = () => {
+		setSelectedIds((previous) => {
+			const next = new Set(previous);
+			if (allVisibleSelected) {
+				visibleSelectableTransactions.forEach((tx) => {
+					if (tx.id) next.delete(tx.id);
+				});
+			} else {
+				visibleSelectableTransactions.forEach((tx) => {
+					if (tx.id) next.add(tx.id);
+				});
+			}
+			return next;
+		});
+	};
+
+	const handleApplyBulkCategory = async () => {
+		if (!selectedBulkCategory) return;
+
+		setIsBulkSaving(true);
+		try {
+			await bulkUpdateTransactionCategories(
+				Array.from(selectedIds),
+				selectedBulkCategory.category,
+				selectedBulkCategory.subcategory
+			);
+			clearSelection();
+			setBulkCategoryValue('');
+			toast({
+				title: 'Categories updated',
+				description: `${selectedCount} ${
+					selectedCount === 1 ? 'transaction' : 'transactions'
+				} moved to ${selectedBulkCategory.label}.`,
+			});
+		} catch (error) {
+			toast({
+				title: 'Update failed',
+				description:
+					error instanceof Error
+						? error.message
+						: 'Could not update the selected transactions.',
+				variant: 'destructive',
+			});
+		} finally {
+			setIsBulkSaving(false);
+		}
+	};
 
 	const allFiltersHidden =
 		!tablePrefs.search &&
@@ -176,7 +288,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							value={search}
 							onChange={(e) => {
 								setSearch(e.target.value);
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 							className="h-10 flex-1 min-w-[220px] border-none focus-visible:ring-0"
 						/>
@@ -187,7 +299,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							value={filterType}
 							onValueChange={(value: string) => {
 								setFilterType(value as 'all' | 'income' | 'expense');
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 						>
 							<SelectTrigger className="h-10 w-[120px] rounded-xl">
@@ -206,7 +318,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							value={filterCategory}
 							onValueChange={(value: string) => {
 								setFilterCategory(value);
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 						>
 							<SelectTrigger className="h-10 w-[150px] rounded-xl">
@@ -239,7 +351,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							value={filterMonth}
 							onValueChange={(value: string) => {
 								setFilterMonth(value);
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 						>
 							<SelectTrigger className="h-10 w-[130px] rounded-xl">
@@ -260,14 +372,56 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 							dateRange={dateRange}
 							onDateRangeChange={(newRange) => {
 								setDateRange(newRange);
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 							onClear={() => {
 								setDateRange({ startDate: '', endDate: '' });
-								resetVisibleCount();
+								resetVisibleCountAndSelection();
 							}}
 						/>
 					)}
+				</div>
+			)}
+
+			{selectedCount > 0 && (
+				<div
+					className="flex flex-wrap items-center gap-3 rounded-2xl border bg-muted/40 p-3"
+					onClick={(event) => event.stopPropagation()}
+				>
+					<div className="text-sm font-medium">
+						{selectedCount} {selectedCount === 1 ? 'transaction' : 'transactions'} selected
+					</div>
+					<Select
+						value={bulkCategoryValue}
+						onValueChange={setBulkCategoryValue}
+						disabled={isBulkSaving}
+					>
+						<SelectTrigger className="h-10 min-w-[240px] flex-1 rounded-xl sm:flex-none">
+							<SelectValue placeholder="Choose category" />
+						</SelectTrigger>
+						<SelectContent>
+							{categoryPathOptions.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<Button
+						type="button"
+						onClick={handleApplyBulkCategory}
+						disabled={!selectedBulkCategory || isBulkSaving}
+					>
+						{isBulkSaving ? 'Applying...' : 'Apply'}
+					</Button>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={clearSelection}
+						disabled={isBulkSaving}
+					>
+						Clear selection
+					</Button>
 				</div>
 			)}
 
@@ -280,6 +434,18 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 					<Table>
 						<TableHeader className="sticky top-0 z-10 bg-card/80 backdrop-blur">
 							<TableRow className="hover:bg-transparent">
+								<TableHead className="w-12">
+									<input
+										ref={selectVisibleRef}
+										type="checkbox"
+										aria-label="Select visible transactions"
+										checked={allVisibleSelected}
+										disabled={visibleSelectableTransactions.length === 0}
+										onChange={toggleVisibleSelection}
+										onClick={(event) => event.stopPropagation()}
+										className="h-4 w-4 rounded border-input accent-primary"
+									/>
+								</TableHead>
 								<TableHead>Description</TableHead>
 								<TableHead className="text-right">{amountHeader}</TableHead>
 								<TableHead className="text-right">Date</TableHead>
@@ -291,6 +457,8 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 						<TableBody>
 							{visibleTransactions.map((tx) => {
 								const categoryColor = getCategoryColor(tx.category);
+								const isSelectable = Boolean(tx.id && tx.type !== 'transfer');
+								const isSelected = Boolean(tx.id && selectedIds.has(tx.id));
 								return (
 								<TableRow
 									key={tx.id}
@@ -298,6 +466,19 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 									className={`cursor-pointer transition-colors ${tx.id === selectedId ? 'bg-muted' : 'hover:bg-muted/40'
 										}`}
 								>
+									<TableCell>
+										<input
+											type="checkbox"
+											aria-label={`Select ${tx.title}`}
+											checked={isSelected}
+											disabled={!isSelectable || isBulkSaving}
+											onChange={() => {
+												if (tx.id) toggleTransactionSelection(tx.id);
+											}}
+											onClick={(event) => event.stopPropagation()}
+											className="h-4 w-4 rounded border-input accent-primary disabled:cursor-not-allowed disabled:opacity-40"
+										/>
+									</TableCell>
 									<TableCell>
 										<div className="font-medium">{tx.title}</div>
 										<div className="text-xs text-muted-foreground">
@@ -356,7 +537,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
 							{filtered.length === 0 && (
 								<TableRow>
-									<TableCell colSpan={5} className="py-16 text-center">
+									<TableCell colSpan={6} className="py-16 text-center">
 										<div className="space-y-1">
 											<div className="text-sm font-medium">
 												{transactions.length === 0

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,12 +111,64 @@ export interface CategoryReport {
 	color: string;
 }
 
+export interface SubcategoryReport {
+	category: string;
+	subcategory?: string;
+	amount: number;
+	color: string;
+}
+
+export interface CategoryBreakdownSubcategory {
+	category: string;
+	subcategory?: string;
+	amount: number;
+	percentage: number;
+}
+
+export interface CategoryBreakdownReport {
+	category: string;
+	amount: number;
+	color: string;
+	subcategories: CategoryBreakdownSubcategory[];
+}
+
+export interface MonthlySubcategorySummary {
+	category: string;
+	subcategory?: string;
+	amount: number;
+	percentage: number;
+	transactionCount: number;
+	previousAmount: number;
+	deltaAmount: number;
+}
+
+export interface MonthlyCategorySummary {
+	category: string;
+	amount: number;
+	percentage: number;
+	transactionCount: number;
+	previousAmount: number;
+	deltaAmount: number;
+	color: string;
+	subcategories: MonthlySubcategorySummary[];
+}
+
 export interface AccountReport {
 	accountId: string;
 	accountName: string;
 	color: string;
 	income: number;
 	expense: number;
+}
+
+export interface MonthlyAccountSummary {
+	accountId: string;
+	accountName: string;
+	color: string;
+	income: number;
+	expense: number;
+	net: number;
+	transactionCount: number;
 }
 
 export interface MonthlyTrend {


### PR DESCRIPTION
## Summary

This PR adds two major workflow improvements to CashFlow:

1. A faster Transaction History bulk category editing flow so users can recategorize many transactions without opening the full transaction form one-by-one.
2. A redesigned Reports experience that defaults to a month-first, amount-first view so users can make decisions from clear totals instead of clustered charts.

The work also adds report display preferences, sidebar access to all transactions, subcategory-aware reporting, and focused tests for the new aggregation and preference behavior.

## Why

The previous reports UI became visually dense as category/subcategory counts grew. Values were mostly interpreted through chart axes and tooltips, which made it harder to answer practical questions like:

- What did I spend this month?
- Which category drove the most spend?
- Which subcategory matters inside that category?
- How does this compare to the previous month?
- Which account did this activity happen in?

This PR moves Reports toward a monthly financial review workflow: current month by default, visible amounts by default, drill-down only when useful.

## What Changed

### Transaction History quick edit

- Added selectable rows to the transaction history table.
- Added a bulk edit bar that appears when rows are selected.
- Added category path options such as `Food`, `Food / Groceries`, and `Food / Takeaways / Eating Out`.
- Added `bulkUpdateTransactionCategories(ids, category, subcategory?)` through the transaction hook, controller, and context.
- Uses Firestore batched writes and chunks updates safely.
- Trims category and subcategory values.
- Clears `subcategory` with Firestore `deleteField()` when applying a main-category-only option.
- Prevents transfer transactions from being selected for bulk category edits.

### Category utilities

- Added a reusable `buildCategoryPathOptions(...)` helper for category/subcategory picker options.
- Keeps the reserved `transfer` category out of user-facing category path options.

### Reports: subcategory-aware data model

- Added report types for:
  - subcategory spending rows
  - category breakdown rows
  - monthly category summaries
  - monthly subcategory summaries
  - monthly account summaries
- Added report aggregation helpers for:
  - spending by subcategory
  - category breakdowns with nested subcategories
  - current month date ranges
  - full month date ranges
  - previous month comparison ranges
  - monthly category rows with previous-month deltas
  - monthly account summaries filtered by account/month

### Reports: month-first redesign

- Reports now default to current month, from the first day of the month through today.
- Added month navigation:
  - previous month
  - next month
  - current month
  - custom date range mode
- Added account filtering directly in the report controls.
- Replaced the primary chart-first category area with amount-first category rows.
- Category rows now show:
  - category name
  - visible total amount
  - share of monthly expense
  - transaction count
  - previous-month delta
  - simple progress bar
- Clicking a category expands its subcategories inline.
- Subcategory rows show:
  - full category path label
  - visible total amount
  - share of parent category
  - transaction count
- Focused transaction preview now shows matching monthly transactions with:
  - title
  - date
  - account
  - amount
- Monthly account review now shows:
  - income
  - expenses
  - net
  - transaction count
- Kept the trend and net worth sections as secondary context.

### Report preferences

- Extended filter preferences with a `reports` section.
- Added Settings > Filters toggles for report sections:
  - date range / month controls
  - summary cards
  - income vs expense trend
  - category breakdown
  - subcategory breakdown
  - account activity
  - net worth
- Moved default preference merging into a small utility so old localStorage preferences are safely upgraded.

### Sidebar navigation

- Added `All Transactions` to the sidebar app map.
- It opens the existing Transaction History view:
  - table on desktop
  - list on mobile
- Existing recent transaction list remains unchanged.

## User Impact

- Users can now clean up categories in bulk, which is much faster for imported or messy transaction history.
- Reports open directly into the current month, which better matches normal financial review habits.
- Amounts are visible immediately without relying on chart axes or hover states.
- Users can drill from category to subcategory to transaction evidence without leaving Reports.
- Account-level monthly review is easier to isolate.
- Users can still customize which report sections appear through Settings.

## Technical Notes

- Firestore category bulk updates are batched and deduplicated by transaction ID.
- Subcategory deletion uses Firestore `deleteField()` instead of storing blank values.
- Report helpers use existing transaction date parsing behavior and existing category/subcategory label helpers.
- Previous-month comparison is calculated from the active report period.
- The month-first report UI separates account-scoped history from active date filtering so previous-month deltas still work when an account filter is active.

## Validation

- `npm test -- --runInBand`
  - 13 test suites passed
  - 77 tests passed
- `npm run build`
  - TypeScript build passed
  - Vite production build passed
- `npm run lint`
  - Passed with existing Fast Refresh warnings only

## Notes

The production build still emits the existing Vite chunk-size warning. This PR does not change the bundling strategy.