### PR TITLE
Feat[codex]: Redesign dashboard shell

### DIFF
--- a/src/features/ai/components/AIChatbot.tsx
+++ b/src/features/ai/components/AIChatbot.tsx
@@ -24,7 +24,11 @@ const createMessage = (
 	createdAt: Date.now(),
 });
 
-const AIChatbot: React.FC = () => {
+interface AIChatbotProps {
+	variant?: 'floating' | 'docked';
+}
+
+const AIChatbot: React.FC<AIChatbotProps> = ({ variant = 'floating' }) => {
 	const { currentUser } = useAuth();
 	const { askQuestion } = useAIChatController();
 
@@ -32,6 +36,9 @@ const AIChatbot: React.FC = () => {
 	const [inputValue, setInputValue] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
 	const [messages, setMessages] = useState<AIChatMessage[]>([]);
+	const [isDockedMobile, setIsDockedMobile] = useState(
+		() => window.innerWidth < 1280
+	);
 
 	const messagesRef = useRef<HTMLDivElement | null>(null);
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -43,9 +50,9 @@ const AIChatbot: React.FC = () => {
 	);
 
 	useEffect(() => {
-		if (!isOpen) return;
+		if (!isOpen && variant === 'floating') return;
 		inputRef.current?.focus();
-	}, [isOpen]);
+	}, [isOpen, variant]);
 
 	useEffect(() => {
 		const container = messagesRef.current;
@@ -66,6 +73,14 @@ const AIChatbot: React.FC = () => {
 		return () => window.removeEventListener('keydown', handleEscape);
 	}, [isOpen]);
 
+	useEffect(() => {
+		if (variant !== 'docked') return;
+
+		const handleResize = () => setIsDockedMobile(window.innerWidth < 1280);
+		window.addEventListener('resize', handleResize);
+		return () => window.removeEventListener('resize', handleResize);
+	}, [variant]);
+
 	const appendMessage = (message: AIChatMessage) => {
 		setMessages((prev) => [...prev, message]);
 	};
@@ -79,11 +94,9 @@ const AIChatbot: React.FC = () => {
 
 		if (!currentUser?.uid) {
 			appendMessage(
-				createMessage(
-					'assistant',
-					'Please log in to use the AI assistant.',
-					{ isError: true }
-				)
+				createMessage('assistant', 'Please log in to use the AI assistant.', {
+					isError: true,
+				})
 			);
 			return;
 		}
@@ -130,128 +143,176 @@ const AIChatbot: React.FC = () => {
 		inputRef.current?.focus();
 	};
 
+	const renderMessages = () => (
+		<div ref={messagesRef} className="flex-1 space-y-3 overflow-y-auto p-4">
+			{messages.length === 0 ? (
+				<div className="space-y-2">
+					<p className="text-xs font-medium text-muted-foreground">Try asking:</p>
+					<div className="flex flex-wrap gap-2">
+						{SUGGESTED_PROMPTS.map((prompt) => (
+							<Button
+								key={prompt}
+								type="button"
+								variant="outline"
+								size="sm"
+								className="h-auto whitespace-normal py-1.5 text-left text-xs"
+								onClick={() => void handleSend(prompt)}
+								disabled={!isAuthenticated || isLoading}
+							>
+								{prompt}
+							</Button>
+						))}
+					</div>
+					{!isAuthenticated && (
+						<p className="pt-1 text-xs text-destructive">
+							Please log in to use the AI assistant.
+						</p>
+					)}
+				</div>
+			) : (
+				messages.map((message) => (
+					<div
+						key={message.id}
+						data-testid={`chat-message-${message.role}`}
+						className={`flex ${
+							message.role === 'user' ? 'justify-end' : 'justify-start'
+						}`}
+					>
+						<div
+							className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+								message.role === 'user'
+									? 'bg-primary text-primary-foreground'
+									: message.isError
+										? 'border border-destructive/30 bg-destructive/10 text-destructive'
+										: 'bg-muted text-foreground'
+							}`}
+						>
+							{message.content}
+						</div>
+					</div>
+				))
+			)}
+
+			{isLoading && (
+				<div className="flex justify-start">
+					<div className="rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground">
+						AI is thinking...
+					</div>
+				</div>
+			)}
+		</div>
+	);
+
+	const renderComposer = () => (
+		<div className="border-t p-3">
+			<div className="flex items-end gap-2">
+				<Textarea
+					ref={inputRef}
+					value={inputValue}
+					onChange={(event) => setInputValue(event.target.value)}
+					onKeyDown={handleInputKeyDown}
+					placeholder="Ask a question about your finances..."
+					className="min-h-[44px] max-h-32 resize-none"
+					rows={2}
+					disabled={!isAuthenticated || isLoading}
+				/>
+				<Button
+					type="button"
+					size="icon"
+					onClick={() => void handleSend()}
+					disabled={!canSend}
+					aria-label="Send message"
+				>
+					<FiSend className="h-4 w-4" />
+				</Button>
+			</div>
+			{!isAuthenticated && (
+				<p className="mt-2 text-xs text-destructive">
+					Please log in to use the AI assistant.
+				</p>
+			)}
+		</div>
+	);
+
+	const renderPanel = (options?: { onClose?: () => void; docked?: boolean }) => (
+		<section
+			aria-label="AI assistant"
+			className={`flex flex-col overflow-hidden border bg-card ${
+				options?.docked
+					? 'h-full min-h-0 rounded-lg'
+					: 'h-[min(32rem,calc(var(--vh-screen)-6rem))] w-[calc(100vw-2rem)] max-w-md rounded-2xl shadow-2xl'
+			}`}
+		>
+			<div className="flex items-center justify-between border-b px-4 py-3">
+				<div>
+					<h2 className="text-sm font-semibold">AI Assistant</h2>
+					<p className="text-xs text-muted-foreground">
+						Ask about your spending, accounts, and budgets
+					</p>
+				</div>
+				<div className="flex items-center gap-1">
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						onClick={clearChat}
+						aria-label="Clear chat"
+						disabled={messages.length === 0 && !inputValue}
+					>
+						<FiTrash2 className="h-4 w-4" />
+					</Button>
+					{options?.onClose && (
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							onClick={options.onClose}
+							aria-label="Close AI assistant"
+						>
+							<FiX className="h-4 w-4" />
+						</Button>
+					)}
+				</div>
+			</div>
+			{renderMessages()}
+			{renderComposer()}
+		</section>
+	);
+
+	if (variant === 'docked') {
+		if (!isDockedMobile) {
+			return renderPanel({ docked: true });
+		}
+
+		return (
+			<div className="fixed bottom-4 right-4 z-[70]">
+				{isOpen && (
+					<div className="mb-3">
+						{renderPanel({ onClose: () => setIsOpen(false) })}
+					</div>
+				)}
+				<Button
+					type="button"
+					size="icon"
+					className="h-12 w-12 rounded-full shadow-xl"
+					onClick={() => setIsOpen((prev) => !prev)}
+					aria-label={isOpen ? 'Close AI assistant' : 'Open AI assistant'}
+				>
+					{isOpen ? (
+						<FiX className="h-5 w-5" />
+					) : (
+						<FiMessageCircle className="h-5 w-5" />
+					)}
+				</Button>
+			</div>
+		);
+	}
+
 	return (
 		<div className="fixed bottom-4 right-4 z-[70] md:bottom-6 md:right-6">
 			{isOpen && (
-				<div className="mb-3 flex h-[min(32rem,calc(var(--vh-screen)-6rem))] w-[calc(100vw-2rem)] max-w-md flex-col overflow-hidden rounded-2xl border bg-card shadow-2xl">
-					<div className="flex items-center justify-between border-b px-4 py-3">
-						<div>
-							<h2 className="text-sm font-semibold">AI Assistant</h2>
-							<p className="text-xs text-muted-foreground">
-								Ask about your spending, accounts, and budgets
-							</p>
-						</div>
-						<div className="flex items-center gap-1">
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								onClick={clearChat}
-								aria-label="Clear chat"
-								disabled={messages.length === 0 && !inputValue}
-							>
-								<FiTrash2 className="h-4 w-4" />
-							</Button>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								onClick={() => setIsOpen(false)}
-								aria-label="Close AI assistant"
-							>
-								<FiX className="h-4 w-4" />
-							</Button>
-						</div>
-					</div>
-
-					<div ref={messagesRef} className="flex-1 space-y-3 overflow-y-auto p-4">
-						{messages.length === 0 ? (
-							<div className="space-y-2">
-								<p className="text-xs font-medium text-muted-foreground">
-									Try asking:
-								</p>
-								<div className="flex flex-wrap gap-2">
-									{SUGGESTED_PROMPTS.map((prompt) => (
-										<Button
-											key={prompt}
-											type="button"
-											variant="outline"
-											size="sm"
-											className="h-auto whitespace-normal py-1.5 text-left text-xs"
-											onClick={() => void handleSend(prompt)}
-											disabled={!isAuthenticated || isLoading}
-										>
-											{prompt}
-										</Button>
-									))}
-								</div>
-								{!isAuthenticated && (
-									<p className="pt-1 text-xs text-destructive">
-										Please log in to use the AI assistant.
-									</p>
-								)}
-							</div>
-						) : (
-							messages.map((message) => (
-								<div
-									key={message.id}
-									data-testid={`chat-message-${message.role}`}
-									className={`flex ${
-										message.role === 'user' ? 'justify-end' : 'justify-start'
-									}`}
-								>
-									<div
-										className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
-											message.role === 'user'
-												? 'bg-primary text-primary-foreground'
-												: message.isError
-													? 'border border-destructive/30 bg-destructive/10 text-destructive'
-													: 'bg-muted text-foreground'
-										}`}
-									>
-										{message.content}
-									</div>
-								</div>
-							))
-						)}
-
-						{isLoading && (
-							<div className="flex justify-start">
-								<div className="rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground">
-									AI is thinking...
-								</div>
-							</div>
-						)}
-					</div>
-
-					<div className="border-t p-3">
-						<div className="flex items-end gap-2">
-							<Textarea
-								ref={inputRef}
-								value={inputValue}
-								onChange={(event) => setInputValue(event.target.value)}
-								onKeyDown={handleInputKeyDown}
-								placeholder="Ask a question about your finances..."
-								className="min-h-[44px] max-h-32 resize-none"
-								rows={2}
-								disabled={!isAuthenticated || isLoading}
-							/>
-							<Button
-								type="button"
-								size="icon"
-								onClick={() => void handleSend()}
-								disabled={!canSend}
-								aria-label="Send message"
-							>
-								<FiSend className="h-4 w-4" />
-							</Button>
-						</div>
-						{!isAuthenticated && (
-							<p className="mt-2 text-xs text-destructive">
-								Please log in to use the AI assistant.
-							</p>
-						)}
-					</div>
+				<div className="mb-3">
+					{renderPanel({ onClose: () => setIsOpen(false) })}
 				</div>
 			)}
 

--- a/src/features/ai/components/__tests__/AIChatbot.test.tsx
+++ b/src/features/ai/components/__tests__/AIChatbot.test.tsx
@@ -137,4 +137,20 @@ describe('AIChatbot', () => {
 		expect(screen.getAllByText('Please log in to use the AI assistant.').length).toBeGreaterThan(0);
 		expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
 	});
+
+	it('renders docked mode inline on desktop without the floating launcher', () => {
+		Object.defineProperty(window, 'innerWidth', {
+			configurable: true,
+			writable: true,
+			value: 1440,
+		});
+
+		render(<AIChatbot variant="docked" />);
+
+		expect(screen.getByRole('region', { name: /ai assistant/i })).toBeInTheDocument();
+		expect(screen.getByText('AI Assistant')).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: /open ai assistant/i })
+		).not.toBeInTheDocument();
+	});
 });

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { auth } from '@/services/firebase';
 import AIChatbot from '@/features/ai/components/AIChatbot';
@@ -9,8 +9,10 @@ interface ProtectedRouteProps {
 }
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+	const location = useLocation();
 	const [user, setUser] = useState<User | null>(null);
 	const [loading, setLoading] = useState(true);
+	const shouldRenderFloatingAssistant = location.pathname !== '/dashboard';
 
 	useEffect(() => {
 		const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
@@ -58,7 +60,7 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
 	return (
 		<>
 			{children}
-			<AIChatbot />
+			{shouldRenderFloatingAssistant && <AIChatbot />}
 		</>
 	);
 }

--- a/src/features/dashboard/components/AccountBalanceStrip.tsx
+++ b/src/features/dashboard/components/AccountBalanceStrip.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { FiArrowDownRight, FiArrowUpRight, FiCreditCard, FiPlus } from 'react-icons/fi';
+import { ACCOUNT_TYPE_LABELS } from '@/features/accounts/models/AccountModel';
+import { Account } from '@/types';
+import { formatCurrency } from '@/utils/formatCurrency';
+
+interface AccountBalanceStripProps {
+	accounts: Account[];
+	onOpenAccounts: () => void;
+}
+
+const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
+	accounts,
+	onOpenAccounts,
+}) => {
+	const hasOverflow = accounts.length > 4;
+	const displayAccounts = accounts.slice(0, hasOverflow ? 3 : 4);
+	const remainingCount = Math.max(0, accounts.length - displayAccounts.length);
+	const totalBalance = accounts.reduce((sum, account) => {
+		if (account.type === 'credit') return sum - Math.abs(account.balance);
+		return sum + account.balance;
+	}, 0);
+
+	return (
+		<section
+			aria-label="Account balances"
+			className="overflow-hidden rounded-lg border bg-card"
+		>
+			<div className="flex items-center justify-between gap-3 border-b px-3 py-2">
+				<div className="min-w-0">
+					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+						Accounts
+					</p>
+					<p className="truncate text-xs text-muted-foreground">
+						{accounts.length > 0
+							? `${accounts.length} linked - net ${formatCurrency(totalBalance)}`
+							: 'No accounts linked yet'}
+					</p>
+				</div>
+				<button
+					type="button"
+					onClick={onOpenAccounts}
+					className="flex-shrink-0 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+				>
+					View all
+				</button>
+			</div>
+
+			<div className="grid gap-px bg-border sm:grid-cols-2 xl:grid-cols-4">
+				{displayAccounts.length === 0 ? (
+					<button
+						type="button"
+						onClick={onOpenAccounts}
+						className="flex min-h-16 items-center gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 sm:col-span-2 xl:col-span-4"
+					>
+						<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+							<FiPlus className="h-4 w-4" />
+						</span>
+						<span className="min-w-0 flex-1">
+							<span className="block font-medium">Create your first account</span>
+							<span className="block text-sm text-muted-foreground">
+								Accounts anchor balances for transactions and transfers.
+							</span>
+						</span>
+					</button>
+				) : (
+					<>
+						{displayAccounts.map((account) => {
+							const isNegative =
+								account.balance < 0 || account.type === 'credit';
+							const BalanceIcon = isNegative ? FiArrowDownRight : FiArrowUpRight;
+							const balanceTone = isNegative
+								? 'text-red-600 dark:text-red-400'
+								: 'text-foreground';
+
+							return (
+								<button
+									key={account.id ?? account.name}
+									type="button"
+									onClick={onOpenAccounts}
+									className="group relative flex min-h-16 min-w-0 items-center justify-between gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+								>
+									<span
+										className="absolute inset-y-2 left-0 w-1 rounded-r-full"
+										style={{ backgroundColor: account.color ?? '#6366f1' }}
+									/>
+									<span className="ml-2 flex min-w-0 flex-1 items-center gap-2">
+										<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+											<FiCreditCard className="h-4 w-4" />
+										</span>
+										<span className="min-w-0">
+											<span className="block truncate text-sm font-medium">
+												{account.name}
+											</span>
+											<span className="block truncate text-xs text-muted-foreground">
+												{account.bank
+													? `${account.bank} - ${ACCOUNT_TYPE_LABELS[account.type]}`
+													: ACCOUNT_TYPE_LABELS[account.type]}
+											</span>
+										</span>
+									</span>
+									<span className="flex min-w-0 flex-shrink-0 flex-col items-end">
+										<span
+											className={`max-w-[8rem] truncate text-right text-sm font-semibold tabular-nums sm:max-w-[9rem] ${balanceTone}`}
+										>
+											{formatCurrency(account.balance)}
+										</span>
+										<span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+											<BalanceIcon className="h-3 w-3" />
+											{isNegative ? 'Owing' : 'Available'}
+										</span>
+									</span>
+								</button>
+							);
+						})}
+
+						{hasOverflow && (
+							<button
+								type="button"
+								onClick={onOpenAccounts}
+								className="flex min-h-16 min-w-0 items-center justify-between gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+							>
+								<span className="min-w-0">
+									<span className="block text-sm font-medium">
+										{remainingCount} more account{remainingCount === 1 ? '' : 's'}
+									</span>
+									<span className="block truncate text-xs text-muted-foreground">
+										Open accounts to review every balance.
+									</span>
+								</span>
+								<span className="rounded-full border px-2 py-1 text-xs font-medium text-muted-foreground">
+									View
+								</span>
+							</button>
+						)}
+					</>
+				)}
+			</div>
+		</section>
+	);
+};
+
+export default AccountBalanceStrip;

--- a/src/features/dashboard/components/DashboardOverview.tsx
+++ b/src/features/dashboard/components/DashboardOverview.tsx
@@ -1,0 +1,115 @@
+import React, { useMemo } from 'react';
+import { FiEye, FiSearch, FiSettings } from 'react-icons/fi';
+import AIChatbot from '@/features/ai/components/AIChatbot';
+import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
+import { useCategoriesContext } from '@/features/categories/context/CategoriesContext';
+import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
+import { Button } from '@/components/app/ui/button';
+import { Transaction } from '@/types';
+import { formatCurrency } from '@/utils/formatCurrency';
+import AccountBalanceStrip from '@/features/dashboard/components/AccountBalanceStrip';
+import MonthlyDigest from '@/features/dashboard/components/MonthlyDigest';
+import QuickTransactionPanel from '@/features/dashboard/components/QuickTransactionPanel';
+import RecentTransactionsPanel from '@/features/dashboard/components/RecentTransactionsPanel';
+import { calculateDashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
+
+interface DashboardOverviewProps {
+	onCreateAccount: () => void;
+	onOpenAccounts: () => void;
+	onOpenHistory: () => void;
+	onOpenSettings: () => void;
+	onSelectTransaction: (transaction: Transaction) => void;
+}
+
+const DashboardOverview: React.FC<DashboardOverviewProps> = ({
+	onCreateAccount,
+	onOpenAccounts,
+	onOpenHistory,
+	onOpenSettings,
+	onSelectTransaction,
+}) => {
+	const { transactions } = useTransactionsContext();
+	const { accounts } = useAccountsContext();
+	const { getCategoryPathLabel } = useCategoriesContext();
+	const summary = useMemo(
+		() => calculateDashboardSummary(transactions, accounts),
+		[accounts, transactions]
+	);
+	const netWorthTone =
+		summary.saved >= 0
+			? 'text-green-600 dark:text-green-400'
+			: 'text-red-600 dark:text-red-400';
+
+	return (
+		<div className="flex h-full min-h-0 flex-col bg-background">
+			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-5 md:px-6 lg:px-8 xl:overflow-hidden">
+				<header className="mb-4 flex flex-shrink-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<h1 className="text-3xl font-semibold tracking-tight">Dashboard</h1>
+						<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+							<span>Net worth {formatCurrency(summary.netWorth)}</span>
+							<span className={netWorthTone}>
+								{summary.saved >= 0 ? '+' : ''}
+								{formatCurrency(summary.saved)} this month
+							</span>
+						</div>
+					</div>
+					<div className="flex items-center gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={onOpenHistory}
+							aria-label="Search transactions"
+						>
+							<FiSearch className="h-4 w-4" />
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={onOpenSettings}
+							aria-label="Open dashboard settings"
+						>
+							<FiSettings className="h-4 w-4" />
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={onOpenAccounts}
+							aria-label="View accounts"
+						>
+							<FiEye className="h-4 w-4" />
+						</Button>
+					</div>
+				</header>
+
+				<div className="flex min-h-0 flex-1 flex-col gap-4">
+					<MonthlyDigest summary={summary} />
+
+					<div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.95fr)_minmax(320px,0.9fr)]">
+						<RecentTransactionsPanel
+							transactions={transactions}
+							accounts={accounts}
+							getCategoryPathLabel={getCategoryPathLabel}
+							onSelect={onSelectTransaction}
+							onOpenHistory={onOpenHistory}
+						/>
+						<QuickTransactionPanel onCreateAccount={onCreateAccount} />
+						<AIChatbot variant="docked" />
+					</div>
+
+					<div className="flex-shrink-0">
+						<AccountBalanceStrip
+							accounts={accounts}
+							onOpenAccounts={onOpenAccounts}
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default DashboardOverview;

--- a/src/features/dashboard/components/MonthlyDigest.tsx
+++ b/src/features/dashboard/components/MonthlyDigest.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { DashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
+import { formatCurrency } from '@/utils/formatCurrency';
+
+interface MonthlyDigestProps {
+	summary: DashboardSummary;
+}
+
+const MonthlyDigest: React.FC<MonthlyDigestProps> = ({ summary }) => {
+	const savedTone =
+		summary.saved >= 0
+			? 'text-green-600 dark:text-green-400'
+			: 'text-red-600 dark:text-red-400';
+
+	return (
+		<section className="flex-shrink-0 rounded-lg border bg-card p-4">
+			<div className="mb-4 flex items-center justify-between gap-3">
+				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+					{summary.monthLabel} digest
+				</p>
+				<p className="text-xs text-muted-foreground">
+					{summary.transactionCount} transactions
+				</p>
+			</div>
+			<div className="grid gap-4 sm:grid-cols-3">
+				<div>
+					<p className="text-sm text-muted-foreground">Income</p>
+					<p className="mt-1 text-2xl font-semibold text-primary">
+						{formatCurrency(summary.income)}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Current month inflow
+					</p>
+				</div>
+				<div>
+					<p className="text-sm text-muted-foreground">Spent</p>
+					<p className="mt-1 text-2xl font-semibold text-red-600 dark:text-red-400">
+						{formatCurrency(summary.expense)}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Tracked expenses
+					</p>
+				</div>
+				<div>
+					<p className="text-sm text-muted-foreground">Saved</p>
+					<p className={`mt-1 text-2xl font-semibold ${savedTone}`}>
+						{formatCurrency(summary.saved)}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{summary.income > 0
+							? `${Math.round(summary.progressPercent)}% of income retained`
+							: 'Add income to track retention'}
+					</p>
+				</div>
+			</div>
+			<div className="mt-4 h-1.5 overflow-hidden rounded-full bg-muted">
+				<div
+					className="h-full rounded-full bg-primary transition-all"
+					style={{ width: `${summary.progressPercent}%` }}
+				/>
+			</div>
+		</section>
+	);
+};
+
+export default MonthlyDigest;

--- a/src/features/dashboard/components/QuickTransactionPanel.tsx
+++ b/src/features/dashboard/components/QuickTransactionPanel.tsx
@@ -1,0 +1,375 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FiCreditCard, FiPlus } from 'react-icons/fi';
+import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
+import { useCategoriesContext } from '@/features/categories/context/CategoriesContext';
+import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
+import { Button } from '@/components/app/ui/button';
+import { Input } from '@/components/app/ui/input';
+import { Label } from '@/components/app/ui/label';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/app/ui/select';
+import { Textarea } from '@/components/app/ui/textarea';
+import { useToast } from '@/components/app/ui/use-toast';
+import { TransactionType } from '@/types';
+import { mergeCategoryOptions } from '@/features/categories/utils/categories';
+
+interface QuickTransactionPanelProps {
+	onCreateAccount: () => void;
+}
+
+const formatToday = () => new Date().toISOString().split('T')[0];
+
+const QuickTransactionPanel: React.FC<QuickTransactionPanelProps> = ({
+	onCreateAccount,
+}) => {
+	const { addTransaction, addTransfer } = useTransactionsContext();
+	const { accounts, loading: accountsLoading } = useAccountsContext();
+	const { categories, categoryOptions } = useCategoriesContext();
+	const { toast } = useToast();
+
+	const [type, setType] = useState<TransactionType>('expense');
+	const [amount, setAmount] = useState('');
+	const [title, setTitle] = useState('');
+	const [accountId, setAccountId] = useState('');
+	const [transferAccountId, setTransferAccountId] = useState('');
+	const [category, setCategory] = useState('');
+	const [subcategory, setSubcategory] = useState('');
+	const [date, setDate] = useState(formatToday());
+	const [description, setDescription] = useState('');
+	const [error, setError] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const availableCategories = useMemo(
+		() => mergeCategoryOptions(categoryOptions, [category || 'other']),
+		[category, categoryOptions]
+	);
+	const selectedCategory = useMemo(
+		() => categories.find((item) => item.value === category),
+		[categories, category]
+	);
+	const availableSubcategories = useMemo(
+		() => selectedCategory?.subcategories ?? [],
+		[selectedCategory]
+	);
+	const availableTransferAccounts = useMemo(
+		() => accounts.filter((account) => account.id && account.id !== accountId),
+		[accountId, accounts]
+	);
+
+	useEffect(() => {
+		if (!accountId && accounts[0]?.id) setAccountId(accounts[0].id);
+	}, [accountId, accounts]);
+
+	useEffect(() => {
+		if (!category && availableCategories[0]?.value) {
+			setCategory(availableCategories[0].value);
+		}
+	}, [availableCategories, category]);
+
+	useEffect(() => {
+		if (type !== 'transfer') return;
+		if (!transferAccountId && availableTransferAccounts[0]?.id) {
+			setTransferAccountId(availableTransferAccounts[0].id);
+		}
+		if (transferAccountId === accountId) {
+			setTransferAccountId(availableTransferAccounts[0]?.id ?? '');
+		}
+	}, [accountId, availableTransferAccounts, transferAccountId, type]);
+
+	useEffect(() => {
+		if (!subcategory) return;
+		if (!availableSubcategories.some((item) => item.value === subcategory)) {
+			setSubcategory('');
+		}
+	}, [availableSubcategories, subcategory]);
+
+	const resetForm = () => {
+		setAmount('');
+		setTitle('');
+		setDescription('');
+		setDate(formatToday());
+		setError('');
+	};
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		setError('');
+
+		const parsedAmount = Number(amount);
+		if (!accountId) {
+			setError('Choose an account first.');
+			return;
+		}
+		if (!title.trim()) {
+			setError('Add a short description.');
+			return;
+		}
+		if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+			setError('Enter an amount greater than zero.');
+			return;
+		}
+		if (type === 'transfer' && !transferAccountId) {
+			setError('Choose a destination account.');
+			return;
+		}
+
+		setIsSubmitting(true);
+		try {
+			if (type === 'transfer') {
+				await addTransfer({
+					fromAccountId: accountId,
+					toAccountId: transferAccountId,
+					amount: parsedAmount,
+					title: title.trim(),
+					description,
+					date: date ? new Date(date) : new Date(),
+				});
+			} else {
+				await addTransaction({
+					accountId,
+					amount: parsedAmount,
+					title: title.trim(),
+					type,
+					category: category || 'other',
+					subcategory: subcategory || undefined,
+					description,
+					date: date ? new Date(date) : new Date(),
+				});
+			}
+
+			toast({
+				title: 'Transaction added',
+				description: `${title.trim()} was added to CashFlow.`,
+			});
+			resetForm();
+		} catch (submitError) {
+			setError(
+				submitError instanceof Error
+					? submitError.message
+					: 'Unable to add the transaction right now.'
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	if (!accountsLoading && accounts.length === 0) {
+		return (
+			<section className="flex h-full min-h-[22rem] flex-col items-center justify-center rounded-lg border bg-card p-6 text-center xl:min-h-0">
+				<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+					<FiCreditCard className="h-6 w-6 text-primary" />
+				</div>
+				<h2 className="text-lg font-semibold">Start with an account</h2>
+				<p className="mt-2 max-w-sm text-sm text-muted-foreground">
+					Create one bank, cash, savings, or credit account before adding
+					transactions.
+				</p>
+				<Button className="mt-5" onClick={onCreateAccount}>
+					<FiPlus className="mr-2 h-4 w-4" />
+					Add account
+				</Button>
+			</section>
+		);
+	}
+
+	return (
+		<section className="flex h-full min-h-[22rem] flex-col overflow-hidden rounded-lg border bg-card p-4 xl:min-h-0">
+			<div className="mb-4 flex-shrink-0">
+				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+					New transaction
+				</p>
+			</div>
+
+			<form
+				id="quick-transaction-form"
+				onSubmit={handleSubmit}
+				className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+			>
+				<div className="grid grid-cols-3 gap-2">
+					{(['income', 'expense', 'transfer'] as TransactionType[]).map((item) => (
+						<Button
+							key={item}
+							type="button"
+							variant={type === item ? 'default' : 'outline'}
+							onClick={() => {
+								setType(item);
+								setError('');
+							}}
+							className="h-10 capitalize"
+						>
+							{item}
+						</Button>
+					))}
+				</div>
+
+				{error && (
+					<div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+						{error}
+					</div>
+				)}
+
+				<div className="space-y-1.5">
+					<Label htmlFor="quick-amount">Amount</Label>
+					<Input
+						id="quick-amount"
+						type="number"
+						inputMode="decimal"
+						min="0.01"
+						step="0.01"
+						value={amount}
+						onChange={(event) => setAmount(event.target.value)}
+						placeholder="R 0.00"
+						className="h-12 text-xl"
+						disabled={accountsLoading || isSubmitting}
+					/>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label htmlFor="quick-title">Description</Label>
+					<Input
+						id="quick-title"
+						value={title}
+						onChange={(event) => setTitle(event.target.value)}
+						placeholder="What was this for?"
+						disabled={accountsLoading || isSubmitting}
+					/>
+				</div>
+
+				<div className="grid gap-3 sm:grid-cols-2">
+					{type !== 'transfer' && (
+						<div className="space-y-1.5">
+							<Label>Category</Label>
+							<Select
+								value={category}
+								onValueChange={(value) => {
+									setCategory(value);
+									setSubcategory('');
+								}}
+								disabled={accountsLoading || isSubmitting}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder="Category" />
+								</SelectTrigger>
+								<SelectContent>
+									{availableCategories.map((item) => (
+										<SelectItem key={item.value} value={item.value}>
+											{item.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					)}
+
+					<div className="space-y-1.5">
+						<Label>{type === 'transfer' ? 'From account' : 'Account'}</Label>
+						<Select
+							value={accountId}
+							onValueChange={setAccountId}
+							disabled={accountsLoading || isSubmitting}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Account" />
+							</SelectTrigger>
+							<SelectContent>
+								{accounts.map((account) => (
+									<SelectItem key={account.id} value={account.id!}>
+										{account.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+
+				{type === 'transfer' ? (
+					<div className="space-y-1.5">
+						<Label>To account</Label>
+						<Select
+							value={transferAccountId}
+							onValueChange={setTransferAccountId}
+							disabled={accountsLoading || isSubmitting}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Destination account" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableTransferAccounts.map((account) => (
+									<SelectItem key={account.id} value={account.id!}>
+										{account.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				) : (
+					availableSubcategories.length > 0 && (
+						<div className="space-y-1.5">
+							<Label>Subcategory</Label>
+							<Select
+								value={subcategory || '__none__'}
+								onValueChange={(value) =>
+									setSubcategory(value === '__none__' ? '' : value)
+								}
+								disabled={accountsLoading || isSubmitting}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder="Subcategory" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="__none__">No subcategory</SelectItem>
+									{availableSubcategories.map((item) => (
+										<SelectItem key={item.value} value={item.value}>
+											{item.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					)
+				)}
+
+				<div className="space-y-1.5">
+					<Label htmlFor="quick-date">Date</Label>
+					<Input
+						id="quick-date"
+						type="date"
+						value={date}
+						onChange={(event) => setDate(event.target.value)}
+						disabled={accountsLoading || isSubmitting}
+					/>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label htmlFor="quick-notes">Notes</Label>
+					<Textarea
+						id="quick-notes"
+						value={description}
+						onChange={(event) => setDescription(event.target.value)}
+						placeholder="Optional notes"
+						rows={2}
+						disabled={accountsLoading || isSubmitting}
+					/>
+				</div>
+
+			</form>
+			<div className="mt-3 flex-shrink-0">
+				<Button
+					type="submit"
+					form="quick-transaction-form"
+					className="h-12 w-full"
+					disabled={accountsLoading || isSubmitting}
+				>
+					{isSubmitting ? 'Adding...' : 'Add transaction'}
+				</Button>
+			</div>
+		</section>
+	);
+};
+
+export default QuickTransactionPanel;

--- a/src/features/dashboard/components/RecentTransactionsPanel.tsx
+++ b/src/features/dashboard/components/RecentTransactionsPanel.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react';
+import {
+	FiArrowDown,
+	FiArrowUp,
+	FiCreditCard,
+	FiDollarSign,
+	FiHome,
+	FiShoppingCart,
+} from 'react-icons/fi';
+import { Account, Transaction } from '@/types';
+import { parseDbDate } from '@/utils/date';
+import { formatCurrency } from '@/utils/formatCurrency';
+
+interface RecentTransactionsPanelProps {
+	transactions: Transaction[];
+	accounts: Account[];
+	getCategoryPathLabel: (category: string, subcategory?: string) => string;
+	onSelect: (transaction: Transaction) => void;
+	onOpenHistory: () => void;
+}
+
+const getTransactionIcon = (transaction: Transaction) => {
+	if (transaction.type === 'income') return FiArrowUp;
+	if (transaction.type === 'transfer') return FiCreditCard;
+	if (transaction.category === 'food') return FiShoppingCart;
+	if (transaction.category === 'personal') return FiHome;
+	return FiArrowDown;
+};
+
+const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
+	transactions,
+	accounts,
+	getCategoryPathLabel,
+	onSelect,
+	onOpenHistory,
+}) => {
+	const accountColorMap = useMemo(() => {
+		const map = new Map<string, string>();
+		accounts.forEach((account) => {
+			if (account.id) map.set(account.id, account.color ?? '#6366f1');
+		});
+		return map;
+	}, [accounts]);
+
+	const recentTransactions = useMemo(
+		() =>
+			[...transactions]
+				.sort((left, right) => {
+					const leftDate = parseDbDate(left.date ?? left.createdAt);
+					const rightDate = parseDbDate(right.date ?? right.createdAt);
+					return rightDate.getTime() - leftDate.getTime();
+				})
+				.slice(0, 6),
+		[transactions]
+	);
+
+	return (
+		<section className="flex h-full min-h-[22rem] flex-col rounded-lg border bg-card p-4 xl:min-h-0">
+			<div className="mb-4 flex flex-shrink-0 items-center justify-between gap-3">
+				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+					Recent
+				</p>
+				<button
+					type="button"
+					onClick={onOpenHistory}
+					className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+				>
+					View all
+				</button>
+			</div>
+
+			{recentTransactions.length === 0 ? (
+				<div className="flex flex-1 flex-col items-center justify-center text-center">
+					<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+						<FiDollarSign className="h-5 w-5 text-primary" />
+					</div>
+					<p className="font-medium">No transactions yet</p>
+					<p className="mt-1 max-w-xs text-sm text-muted-foreground">
+						Add your first transaction and this feed will start filling in.
+					</p>
+				</div>
+			) : (
+				<div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1">
+					{recentTransactions.map((transaction) => {
+						const Icon = getTransactionIcon(transaction);
+						const isPositive = transaction.type === 'income';
+						const isTransfer = transaction.type === 'transfer';
+						const amountPrefix = isPositive ? '+' : isTransfer ? '' : '-';
+						const amountTone = isPositive
+							? 'text-green-600 dark:text-green-400'
+							: isTransfer
+								? 'text-muted-foreground'
+								: 'text-red-600 dark:text-red-400';
+						const date = parseDbDate(transaction.date ?? transaction.createdAt);
+						const color = accountColorMap.get(transaction.accountId) ?? '#6366f1';
+
+						return (
+							<button
+								key={transaction.id ?? `${transaction.title}-${date.toISOString()}`}
+								type="button"
+								onClick={() => onSelect(transaction)}
+								className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-3 text-left transition-colors hover:border-border hover:bg-muted/60"
+							>
+								<span
+									className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+									style={{ boxShadow: `inset 3px 0 0 ${color}` }}
+								>
+									<Icon className="h-4 w-4" />
+								</span>
+								<span className="min-w-0 flex-1">
+									<span className="block truncate text-sm font-medium">
+										{transaction.title}
+									</span>
+									<span className="block truncate text-xs text-muted-foreground">
+										{isTransfer
+											? 'Transfer'
+											: getCategoryPathLabel(
+													transaction.category,
+													transaction.subcategory
+												)}{' '}
+										-{' '}
+										{date.toLocaleDateString('en-ZA', {
+											day: 'numeric',
+											month: 'short',
+										})}
+									</span>
+								</span>
+								<span className={`text-sm font-semibold ${amountTone}`}>
+									{amountPrefix}
+									{formatCurrency(transaction.amount)}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			)}
+		</section>
+	);
+};
+
+export default RecentTransactionsPanel;

--- a/src/features/dashboard/components/Sidebar.tsx
+++ b/src/features/dashboard/components/Sidebar.tsx
@@ -9,9 +9,11 @@ import {
 	FiGrid,
 	FiTarget,
 	FiBarChart2,
+	FiChevronDown,
 	FiList,
 	FiRefreshCw,
 	FiChevronLeft,
+	FiChevronRight,
 } from 'react-icons/fi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Transaction, ViewType } from '@/types';
@@ -74,6 +76,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 	const { accounts, calculateTotalBalance, loading: accountsLoading } = useAccountsContext();
 	const [searchTerm, setSearchTerm] = useState('');
 	const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+	const [transactionsExpanded, setTransactionsExpanded] = useState(false);
 
 	useEffect(() => {
 		const handleResize = () => setIsMobile(window.innerWidth < 768);
@@ -265,8 +268,32 @@ const Sidebar: React.FC<SidebarProps> = ({
 								</div>
 							</div>
 
-							{/* Search */}
 							<div className="border-b p-2">
+								<button
+									type="button"
+									onClick={() => setTransactionsExpanded((current) => !current)}
+									className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+									aria-expanded={transactionsExpanded}
+									aria-controls="sidebar-transactions"
+								>
+									<span className="flex items-center gap-3">
+										<FiList className="h-4 w-4 flex-shrink-0" />
+										<span>Sidebar transactions</span>
+									</span>
+									<span className="flex items-center gap-2">
+										<span className="text-xs">{transactions.length}</span>
+										{transactionsExpanded ? (
+											<FiChevronDown className="h-4 w-4" />
+										) : (
+											<FiChevronRight className="h-4 w-4" />
+										)}
+									</span>
+								</button>
+							</div>
+
+							{/* Search */}
+							{transactionsExpanded && (
+								<div className="border-b p-2">
 								<div className="relative">
 									<FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 									<Input
@@ -287,108 +314,116 @@ const Sidebar: React.FC<SidebarProps> = ({
 									)}
 								</div>
 							</div>
+							)}
 						</>
 					)}
 
 					{/* Transaction list */}
-					<div className="flex-1 overflow-y-auto p-2 scroll-smooth">
-						{filteredTransactions.length > 0 ? (
-							<div className="space-y-4">
-								{Object.entries(groupedTransactions).map(([date, txs]) => (
-									<div key={date} className="space-y-1">
-										<div className="sticky top-0 z-10 bg-card px-2 py-1 text-xs font-semibold text-muted-foreground bg-opacity-95 backdrop-blur-sm border-b">
-											{date}
-										</div>
-										<div className="space-y-2 pt-1">
-											{txs.map((tx) => {
-												const acctColor =
-													accountColorMap[tx.accountId] ?? '#6366f1';
-												return (
-													<div
-														key={tx.id}
-														onClick={() =>
-															handleTransactionClick(tx)
-														}
-														onKeyDown={(e) => {
-															if (
-																e.key === 'Enter' ||
-																e.key === ' '
-															)
-																handleTransactionClick(tx);
-														}}
-														role="button"
-														tabIndex={0}
-														className={`group flex cursor-pointer items-center justify-between rounded-lg border p-2 md:p-3 transition-colors ${
-															selectedId === tx.id
-																? 'border-primary bg-accent'
-																: 'border-border bg-background hover:bg-muted'
-														}`}
-													>
-														<div className="flex items-center gap-2 flex-1 min-w-0">
-															<span
-																className="h-2 w-2 rounded-full flex-shrink-0"
-																style={{
-																	backgroundColor: acctColor,
-																}}
-															/>
-															<div className="flex-1 min-w-0">
-																<h4 className="truncate font-medium text-sm md:text-base">
-																	{tx.title}
-																</h4>
-																<div className="mt-0.5 flex items-center gap-1 text-xs">
-																	<span
-																		className={`font-medium ${
-																			tx.type === 'income'
-																				? 'text-green-600 dark:text-green-400'
-																				: tx.type ===
-																					  'transfer'
-																					? 'text-blue-500'
-																					: 'text-red-600 dark:text-red-400'
-																		}`}
-																	>
-																		{tx.type === 'income' ? (
-																			<FiArrowUp className="inline h-3 w-3" />
-																		) : tx.type ===
-																		  'transfer' ? (
-																			<span>&#8644;</span>
-																		) : (
-																			<FiArrowDown className="inline h-3 w-3" />
-																		)}
-																		{' '}
-																		{formatCurrency(
-																			tx.amount
-																		)}
-																	</span>
+					<div
+						id="sidebar-transactions"
+						className="min-h-0 flex-1 overflow-hidden"
+						hidden={!transactionsExpanded}
+					>
+						<div className="h-full overflow-y-auto p-2 scroll-smooth">
+							{filteredTransactions.length > 0 ? (
+								<div className="space-y-4">
+									{Object.entries(groupedTransactions).map(([date, txs]) => (
+										<div key={date} className="space-y-1">
+											<div className="sticky top-0 z-10 bg-card px-2 py-1 text-xs font-semibold text-muted-foreground bg-opacity-95 backdrop-blur-sm border-b">
+												{date}
+											</div>
+											<div className="space-y-2 pt-1">
+												{txs.map((tx) => {
+													const acctColor =
+														accountColorMap[tx.accountId] ?? '#6366f1';
+													return (
+														<div
+															key={tx.id}
+															onClick={() =>
+																handleTransactionClick(tx)
+															}
+															onKeyDown={(e) => {
+																if (
+																	e.key === 'Enter' ||
+																	e.key === ' '
+																)
+																	handleTransactionClick(tx);
+															}}
+															role="button"
+															tabIndex={0}
+															className={`group flex cursor-pointer items-center justify-between rounded-lg border p-2 md:p-3 transition-colors ${
+																selectedId === tx.id
+																	? 'border-primary bg-accent'
+																	: 'border-border bg-background hover:bg-muted'
+															}`}
+														>
+															<div className="flex items-center gap-2 flex-1 min-w-0">
+																<span
+																	className="h-2 w-2 rounded-full flex-shrink-0"
+																	style={{
+																		backgroundColor: acctColor,
+																	}}
+																/>
+																<div className="flex-1 min-w-0">
+																	<h4 className="truncate font-medium text-sm md:text-base">
+																		{tx.title}
+																	</h4>
+																	<div className="mt-0.5 flex items-center gap-1 text-xs">
+																		<span
+																			className={`font-medium ${
+																				tx.type === 'income'
+																					? 'text-green-600 dark:text-green-400'
+																					: tx.type ===
+																						  'transfer'
+																						? 'text-blue-500'
+																						: 'text-red-600 dark:text-red-400'
+																			}`}
+																		>
+																			{tx.type === 'income' ? (
+																				<FiArrowUp className="inline h-3 w-3" />
+																			) : tx.type ===
+																			  'transfer' ? (
+																				<span>&#8644;</span>
+																			) : (
+																				<FiArrowDown className="inline h-3 w-3" />
+																			)}
+																			{' '}
+																			{formatCurrency(
+																				tx.amount
+																			)}
+																		</span>
+																	</div>
 																</div>
 															</div>
+															<button
+																onClick={(e) => {
+																	e.stopPropagation();
+																	if (tx.id) onDelete(tx.id);
+																}}
+																className="ml-2 opacity-0 transition-opacity group-hover:opacity-100"
+																aria-label="Delete transaction"
+															>
+																<FiX className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+															</button>
 														</div>
-														<button
-															onClick={(e) => {
-																e.stopPropagation();
-																if (tx.id) onDelete(tx.id);
-															}}
-															className="ml-2 opacity-0 transition-opacity group-hover:opacity-100"
-															aria-label="Delete transaction"
-														>
-															<FiX className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-														</button>
-													</div>
-												);
-											})}
+													);
+												})}
+											</div>
 										</div>
-									</div>
-								))}
-							</div>
-						) : (
-							<div className="py-8 text-center text-xs md:text-sm text-muted-foreground">
-								{searchTerm
-									? 'No matching transactions'
-									: hasNoAccounts
-										? 'Create an account to begin tracking transactions'
-										: 'No transactions yet'}
-							</div>
-						)}
+									))}
+								</div>
+							) : (
+								<div className="py-8 text-center text-xs md:text-sm text-muted-foreground">
+									{searchTerm
+										? 'No matching transactions'
+										: hasNoAccounts
+											? 'Create an account to begin tracking transactions'
+											: 'No transactions yet'}
+								</div>
+							)}
+						</div>
 					</div>
+					{!transactionsExpanded && <div className="flex-1" />}
 
 					{/* New Transaction Button */}
 					{!collapsed && (

--- a/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
+++ b/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AccountBalanceStrip from '@/features/dashboard/components/AccountBalanceStrip';
+import { Account } from '@/types';
+
+describe('AccountBalanceStrip', () => {
+	const accounts: Account[] = [
+		{
+			id: 'cheque',
+			name: 'FNB Cheque',
+			bank: 'FNB',
+			type: 'debit',
+			balance: 2410,
+			color: '#3b82f6',
+		},
+		{
+			id: 'savings',
+			name: 'Emergency Savings',
+			type: 'savings',
+			balance: 1872,
+			color: '#22c55e',
+		},
+		{
+			id: 'cash',
+			name: 'Cash',
+			type: 'cash',
+			balance: 700,
+			color: '#71717a',
+		},
+		{
+			id: 'credit',
+			name: 'Credit Card',
+			type: 'credit',
+			balance: -350,
+			color: '#ef4444',
+		},
+		{
+			id: 'travel',
+			name: 'Travel Wallet',
+			type: 'debit',
+			balance: 120,
+			color: '#8b5cf6',
+		},
+	];
+
+	it('renders compact account cards, total context, and overflow affordance', () => {
+		render(<AccountBalanceStrip accounts={accounts} onOpenAccounts={jest.fn()} />);
+
+		expect(
+			screen.getByRole('region', { name: /account balances/i })
+		).toBeInTheDocument();
+		expect(screen.getByText('Accounts')).toBeInTheDocument();
+		expect(screen.getByText(/5 linked - net/i)).toBeInTheDocument();
+		expect(screen.getByText('FNB Cheque')).toBeInTheDocument();
+		expect(screen.getByText('FNB - Debit')).toBeInTheDocument();
+		expect(screen.getByText('2 more accounts')).toBeInTheDocument();
+		expect(screen.getAllByText('Available').length).toBeGreaterThan(0);
+	});
+
+	it('opens the accounts view from the strip actions', async () => {
+		const user = userEvent.setup();
+		const onOpenAccounts = jest.fn();
+
+		render(<AccountBalanceStrip accounts={accounts} onOpenAccounts={onOpenAccounts} />);
+
+		await user.click(screen.getByRole('button', { name: /view all/i }));
+
+		expect(onOpenAccounts).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders an empty state that opens account creation', async () => {
+		const user = userEvent.setup();
+		const onOpenAccounts = jest.fn();
+
+		render(<AccountBalanceStrip accounts={[]} onOpenAccounts={onOpenAccounts} />);
+
+		await user.click(
+			screen.getByRole('button', { name: /create your first account/i })
+		);
+
+		expect(onOpenAccounts).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/features/dashboard/components/__tests__/DashboardOverview.test.tsx
+++ b/src/features/dashboard/components/__tests__/DashboardOverview.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DashboardOverview from '@/features/dashboard/components/DashboardOverview';
+
+const mockAddTransaction = jest.fn();
+const mockAddTransfer = jest.fn();
+const mockOnCreateAccount = jest.fn();
+const mockOnOpenAccounts = jest.fn();
+const mockOnOpenHistory = jest.fn();
+const mockOnOpenSettings = jest.fn();
+const mockOnSelectTransaction = jest.fn();
+
+jest.mock('@/features/ai/components/AIChatbot', () => ({
+	__esModule: true,
+	default: ({ variant }: { variant?: string }) => (
+		<div data-testid="assistant-variant">{variant}</div>
+	),
+}));
+
+jest.mock('@/features/transactions/context/TransactionsContext', () => ({
+	useTransactionsContext: () => ({
+		transactions: [
+			{
+				id: 'salary',
+				accountId: 'acc-1',
+				title: 'Salary',
+				amount: 8500,
+				type: 'income',
+				category: 'personal',
+				date: new Date(),
+			},
+			{
+				id: 'groceries',
+				accountId: 'acc-1',
+				title: 'Checkers',
+				amount: 480,
+				type: 'expense',
+				category: 'food',
+				subcategory: 'groceries',
+				date: new Date(),
+			},
+		],
+		addTransaction: mockAddTransaction,
+		addTransfer: mockAddTransfer,
+	}),
+}));
+
+jest.mock('@/features/accounts/context/AccountsContext', () => ({
+	useAccountsContext: () => ({
+		accounts: [
+			{
+				id: 'acc-1',
+				name: 'FNB Cheque',
+				type: 'debit',
+				balance: 2410,
+				color: '#3b82f6',
+			},
+			{
+				id: 'acc-2',
+				name: 'Savings',
+				type: 'savings',
+				balance: 1872,
+				color: '#22c55e',
+			},
+		],
+		loading: false,
+	}),
+}));
+
+jest.mock('@/features/categories/context/CategoriesContext', () => ({
+	useCategoriesContext: () => ({
+		categories: [
+			{
+				id: 'food',
+				value: 'food',
+				label: 'Food',
+				subcategories: [{ value: 'groceries', label: 'Groceries' }],
+			},
+			{
+				id: 'personal',
+				value: 'personal',
+				label: 'Personal',
+				subcategories: [],
+			},
+		],
+		categoryOptions: [
+			{ value: 'food', label: 'Food' },
+			{ value: 'personal', label: 'Personal' },
+		],
+		getCategoryPathLabel: (category: string, subcategory?: string) =>
+			subcategory ? `${category} / ${subcategory}` : category,
+	}),
+}));
+
+describe('DashboardOverview', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockAddTransaction.mockResolvedValue(undefined);
+		mockAddTransfer.mockResolvedValue(undefined);
+	});
+
+	it('renders the reference-style dashboard panels with a docked assistant', () => {
+		render(
+			<DashboardOverview
+				onCreateAccount={mockOnCreateAccount}
+				onOpenAccounts={mockOnOpenAccounts}
+				onOpenHistory={mockOnOpenHistory}
+				onOpenSettings={mockOnOpenSettings}
+				onSelectTransaction={mockOnSelectTransaction}
+			/>
+		);
+
+		expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+		expect(screen.getByText(/digest/i)).toBeInTheDocument();
+		expect(screen.getByText('Recent')).toBeInTheDocument();
+		expect(screen.getByText('New transaction')).toBeInTheDocument();
+		expect(screen.getByTestId('assistant-variant')).toHaveTextContent('docked');
+	});
+
+	it('submits a quick expense through the transaction context', async () => {
+		const user = userEvent.setup();
+		render(
+			<DashboardOverview
+				onCreateAccount={mockOnCreateAccount}
+				onOpenAccounts={mockOnOpenAccounts}
+				onOpenHistory={mockOnOpenHistory}
+				onOpenSettings={mockOnOpenSettings}
+				onSelectTransaction={mockOnSelectTransaction}
+			/>
+		);
+
+		await user.type(screen.getByLabelText('Amount'), '123.45');
+		await user.type(screen.getByLabelText('Description'), 'Lunch');
+		await user.click(screen.getByRole('button', { name: 'Add transaction' }));
+
+		await waitFor(() => {
+			expect(mockAddTransaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					accountId: 'acc-1',
+					amount: 123.45,
+					title: 'Lunch',
+					type: 'expense',
+					category: 'food',
+				})
+			);
+		});
+	});
+});

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -1,16 +1,9 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import {
-	FiBarChart2,
-	FiCreditCard,
-	FiList,
-	FiMenu,
-	FiPlus,
-	FiRefreshCw,
-	FiTarget,
-} from 'react-icons/fi';
+import { FiMenu } from 'react-icons/fi';
 import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
 import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
 import { Transaction, ViewType } from '@/types';
+import DashboardOverview from '@/features/dashboard/components/DashboardOverview';
 import Sidebar from '@/features/dashboard/components/Sidebar';
 import SettingsModal from '@/features/dashboard/components/SettingsModal';
 import TransactionForm from '@/features/transactions/views/TransactionForm';
@@ -32,7 +25,6 @@ import {
 	DialogTitle,
 } from '@/components/app/ui/dialog';
 import { Button } from '@/components/app/ui/button';
-import HelpTip from '@/components/app/ui/help-tip';
 import { useToast } from '@/components/app/ui/use-toast';
 import { Toaster } from '@/components/app/ui/toaster';
 import {
@@ -190,33 +182,6 @@ const Dashboard: React.FC = () => {
 	};
 
 	const renderMainContent = () => {
-		const hasAccounts = accounts.length > 0;
-		const hasTransactions = transactions.length > 0;
-		const primaryAction = accountsLoading
-			? {
-					title: 'Checking accounts',
-					description: 'Loading your account data',
-					onClick: handleCreate,
-					icon: FiCreditCard,
-					disabled: true,
-				}
-			: hasAccounts
-			? {
-					title: 'New transaction',
-					description: 'Track income, expense, or a transfer',
-					onClick: handleCreate,
-					icon: FiPlus,
-					disabled: false,
-				}
-			: {
-					title: 'Create your first account',
-					description: 'Add a bank, cash, savings, or credit account',
-					onClick: handleCreateAccount,
-					icon: FiCreditCard,
-					disabled: false,
-				};
-		const PrimaryIcon = primaryAction.icon;
-
 		switch (activeView) {
 			case 'transaction':
 				return (
@@ -256,172 +221,13 @@ const Dashboard: React.FC = () => {
 				return <ReportsView onOpenSettings={() => handleOpenSettings('filters')} />;
 			default:
 				return (
-					<div className="flex flex-1 items-center justify-center px-4 py-8 md:px-6">
-						<div className="w-full max-w-5xl text-center">
-							<div className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-								<span className="text-primary text-lg">&#10022;</span>
-							</div>
-							<h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-2">
-								CashFlow
-							</h1>
-							<div className="mx-auto mb-8 flex max-w-xl items-center justify-center gap-2 text-muted-foreground">
-								<p>
-									{hasAccounts
-										? 'Keep the basics close.'
-										: accountsLoading
-											? 'Loading your accounts.'
-										: 'Start with one account.'}
-								</p>
-								<HelpTip
-									label={
-										hasAccounts
-											? 'Add activity, review balances, then explore budgets, recurring transactions, and reports when they become useful.'
-											: accountsLoading
-												? 'CashFlow is checking for existing accounts before showing first-run guidance.'
-											: 'After one account exists, transactions, history, and budgets will make sense right away.'
-									}
-								/>
-							</div>
-							<div className="mb-6">
-								<Button
-									size="lg"
-									onClick={primaryAction.onClick}
-									disabled={primaryAction.disabled}
-									className="w-full h-14 rounded-2xl px-6 text-left flex items-center justify-between"
-								>
-									<div className="flex items-center gap-3">
-										<PrimaryIcon className="h-5 w-5 flex-shrink-0" />
-										<div>
-											<div className="font-medium">{primaryAction.title}</div>
-											<div className="text-sm text-primary-foreground/80">
-												{primaryAction.description}
-											</div>
-										</div>
-									</div>
-									<span className="text-lg">&#8594;</span>
-								</Button>
-							</div>
-
-							<div className="mb-6 grid grid-cols-1 gap-3 text-left sm:grid-cols-3">
-								<div className="rounded-2xl border bg-background p-4">
-									<div className="mb-2 flex items-center gap-2">
-										<span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-											1
-										</span>
-										<span className="font-medium">Accounts</span>
-										<HelpTip label="Accounts are the foundation. Create one before adding income, expenses, transfers, or imports." />
-									</div>
-									<p className="text-sm text-muted-foreground">
-										Add the places your money lives.
-									</p>
-								</div>
-								<div
-									className={`rounded-2xl border bg-background p-4 ${
-										hasAccounts || accountsLoading ? '' : 'opacity-70'
-									}`}
-								>
-									<div className="mb-2 flex items-center gap-2">
-										<span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-											2
-										</span>
-										<span className="font-medium">Transactions</span>
-										<HelpTip label="Transactions update account balances automatically, so they become useful once an account exists." />
-									</div>
-									<p className="text-sm text-muted-foreground">
-										Log income, spending, and transfers.
-									</p>
-								</div>
-								<div
-									className={`rounded-2xl border bg-background p-4 ${
-										hasTransactions ? '' : 'opacity-70'
-									}`}
-								>
-									<div className="mb-2 flex items-center gap-2">
-										<span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-											3
-										</span>
-										<span className="font-medium">Review</span>
-										<HelpTip label="History, budgets, and reports are most helpful after at least one transaction has been added." />
-									</div>
-									<p className="text-sm text-muted-foreground">
-										Check history, budgets, and reports.
-									</p>
-								</div>
-							</div>
-
-							{hasAccounts && (
-								<div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-									<button
-										onClick={() => setActiveView('accounts')}
-										className="rounded-2xl border bg-background p-4 text-left transition-colors hover:bg-muted/50"
-									>
-										<div className="flex items-center gap-2 mb-1">
-											<FiCreditCard className="h-4 w-4" />
-											<span className="font-medium">Accounts</span>
-										</div>
-										<div className="text-sm text-muted-foreground">
-											{accounts.length} ready
-										</div>
-										<p className="text-sm text-muted-foreground">
-											Manage balances
-										</p>
-									</button>
-									<button
-										onClick={() => setActiveView('budgets')}
-										title="Optional: use budgets once you want a spending plan."
-										className="rounded-2xl border bg-background p-4 text-left transition-colors hover:bg-muted/50"
-									>
-										<div className="flex items-center gap-2 mb-1">
-											<FiTarget className="h-4 w-4" />
-											<span className="font-medium">Budgets</span>
-										</div>
-										<p className="text-sm text-muted-foreground">
-											Optional spending plan
-										</p>
-									</button>
-									<button
-										onClick={handleOpenHistory}
-										title={
-											hasTransactions
-												? 'Review all transactions.'
-												: 'Add one transaction first so history has something to show.'
-										}
-										className="rounded-2xl border bg-background p-4 text-left transition-colors hover:bg-muted/50"
-									>
-										<div className="flex items-center gap-2 mb-1">
-											<FiList className="h-4 w-4" />
-											<span className="font-medium">History</span>
-										</div>
-										<p className="text-sm text-muted-foreground">
-											{hasTransactions ? 'All transactions' : 'Ready after your first entry'}
-										</p>
-									</button>
-									<button
-										onClick={() => setActiveView('recurring')}
-										title="Optional: save repeat income or expenses as templates."
-										className="rounded-2xl border bg-background p-4 text-left transition-colors hover:bg-muted/50"
-									>
-										<div className="flex items-center gap-2 mb-1">
-											<FiRefreshCw className="h-4 w-4" />
-											<span className="font-medium">Recurring</span>
-										</div>
-										<p className="text-sm text-muted-foreground">
-											Optional templates
-										</p>
-									</button>
-								</div>
-							)}
-							{hasTransactions && (
-								<button
-									onClick={() => setActiveView('reports')}
-									className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-								>
-									<FiBarChart2 className="h-4 w-4" />
-									View reports when you want a bigger picture
-								</button>
-							)}
-						</div>
-					</div>
+					<DashboardOverview
+						onCreateAccount={handleCreateAccount}
+						onOpenAccounts={() => setActiveView('accounts')}
+						onOpenHistory={handleOpenHistory}
+						onOpenSettings={() => handleOpenSettings('general')}
+						onSelectTransaction={handleSelect}
+					/>
 				);
 		}
 	};

--- a/src/features/dashboard/utils/__tests__/dashboardSummary.test.ts
+++ b/src/features/dashboard/utils/__tests__/dashboardSummary.test.ts
@@ -1,0 +1,90 @@
+import { Account, Transaction } from '@/types';
+import { calculateDashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
+
+describe('calculateDashboardSummary', () => {
+	const accounts: Account[] = [
+		{
+			id: 'cheque',
+			name: 'FNB Cheque',
+			type: 'debit',
+			balance: 2410,
+		},
+		{
+			id: 'savings',
+			name: 'Savings',
+			type: 'savings',
+			balance: 1872,
+		},
+		{
+			id: 'credit',
+			name: 'Credit Card',
+			type: 'credit',
+			balance: -700,
+		},
+	];
+
+	it('totals current-month income, expenses, saved amount, and net worth', () => {
+		const transactions: Transaction[] = [
+			{
+				id: 'salary',
+				accountId: 'cheque',
+				title: 'Salary',
+				amount: 8500,
+				type: 'income',
+				category: 'personal',
+				date: new Date('2026-05-01T10:00:00'),
+			},
+			{
+				id: 'groceries',
+				accountId: 'cheque',
+				title: 'Groceries',
+				amount: 480,
+				type: 'expense',
+				category: 'food',
+				date: new Date('2026-05-05T10:00:00'),
+			},
+			{
+				id: 'transfer',
+				accountId: 'cheque',
+				title: 'Savings transfer',
+				amount: 1500,
+				type: 'transfer',
+				category: 'transfer',
+				date: new Date('2026-05-06T10:00:00'),
+			},
+			{
+				id: 'old',
+				accountId: 'cheque',
+				title: 'April expense',
+				amount: 100,
+				type: 'expense',
+				category: 'food',
+				date: new Date('2026-04-30T10:00:00'),
+			},
+		];
+
+		const summary = calculateDashboardSummary(
+			transactions,
+			accounts,
+			new Date('2026-05-14T12:00:00')
+		);
+
+		expect(summary.income).toBe(8500);
+		expect(summary.expense).toBe(480);
+		expect(summary.saved).toBe(8020);
+		expect(summary.transactionCount).toBe(3);
+		expect(summary.netWorth).toBe(3582);
+		expect(summary.progressPercent).toBeCloseTo(94.35, 2);
+	});
+
+	it('returns empty-state totals when there is no current-month activity', () => {
+		const summary = calculateDashboardSummary([], [], new Date('2026-05-14T12:00:00'));
+
+		expect(summary.income).toBe(0);
+		expect(summary.expense).toBe(0);
+		expect(summary.saved).toBe(0);
+		expect(summary.transactionCount).toBe(0);
+		expect(summary.netWorth).toBe(0);
+		expect(summary.progressPercent).toBe(0);
+	});
+});

--- a/src/features/dashboard/utils/dashboardSummary.ts
+++ b/src/features/dashboard/utils/dashboardSummary.ts
@@ -1,0 +1,73 @@
+import { Account, Transaction } from '@/types';
+import { parseDbDateOrNull } from '@/utils/date';
+
+export interface DashboardSummary {
+	income: number;
+	expense: number;
+	saved: number;
+	transactionCount: number;
+	netWorth: number;
+	monthLabel: string;
+	progressPercent: number;
+}
+
+const formatDateInput = (date: Date): string => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+};
+
+const getCurrentMonthDateRange = (today = new Date()) => ({
+	startDate: formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1)),
+	endDate: formatDateInput(today),
+});
+
+const getTransactionDate = (transaction: Transaction): Date | null =>
+	parseDbDateOrNull(transaction.date) ?? parseDbDateOrNull(transaction.createdAt);
+
+const isInDateRange = (date: Date, startDate: string, endDate: string): boolean => {
+	const start = new Date(startDate);
+	const end = new Date(endDate);
+	end.setHours(23, 59, 59, 999);
+
+	return date >= start && date <= end;
+};
+
+export const calculateDashboardSummary = (
+	transactions: Transaction[],
+	accounts: Account[],
+	today = new Date()
+): DashboardSummary => {
+	const { startDate, endDate } = getCurrentMonthDateRange(today);
+	const monthTransactions = transactions.filter((transaction) => {
+		const date = getTransactionDate(transaction);
+		return date ? isInDateRange(date, startDate, endDate) : false;
+	});
+
+	const income = monthTransactions
+		.filter((transaction) => transaction.type === 'income')
+		.reduce((sum, transaction) => sum + transaction.amount, 0);
+	const expense = monthTransactions
+		.filter((transaction) => transaction.type === 'expense')
+		.reduce((sum, transaction) => sum + transaction.amount, 0);
+	const netWorth = accounts.reduce((sum, account) => {
+		if (account.type === 'credit') return sum - Math.abs(account.balance);
+		return sum + account.balance;
+	}, 0);
+	const progressPercent =
+		income > 0 ? Math.min(100, Math.max(0, ((income - expense) / income) * 100)) : 0;
+
+	return {
+		income,
+		expense,
+		saved: income - expense,
+		transactionCount: monthTransactions.length,
+		netWorth,
+		monthLabel: today.toLocaleDateString('en-ZA', {
+			month: 'long',
+			year: 'numeric',
+		}),
+		progressPercent,
+	};
+};


### PR DESCRIPTION
## Summary

Redesigns the authenticated `/dashboard` landing experience into a dense, reference-style workspace while preserving the existing CashFlow color tokens, ZAR formatting, and light/dark theme support.

## What changed

- Replaced the previous dashboard landing content with a new dashboard workspace composed from focused components:
  - monthly digest summary
  - recent transactions panel
  - inline quick transaction form
  - docked AI assistant
  - responsive account balance strip
- Added a dashboard summary utility for current-month income, expenses, saved/net amount, transaction count, net worth, and retained-income progress.
- Converted `AIChatbot` into a reusable component with `floating` and `docked` variants.
- Prevented duplicate assistants by skipping the global floating assistant on `/dashboard`, where the docked dashboard assistant is now responsible for that flow.
- Updated the sidebar so its transaction feed is collapsed by default and only expands when the user toggles `Sidebar transactions` open.
- Improved the account balance strip into a responsive account dock with account count, net balance, color rails, account metadata, overflow handling, and an empty-state CTA.
- Preserved existing detail screens for Accounts, Budgets, Recurring, Reports, and full transaction history.

## User impact

- Dashboard users can now see summary metrics, recent activity, quick entry, assistant chat, and account balances in one workspace.
- Account balances stay visible at the bottom of the dashboard on desktop; dense content scrolls inside its own panels instead of pushing the accounts below the fold.
- Sidebar transactions no longer crowd the navigation by default, but remain available on demand.
- Mobile/tablet layouts remain stacked and responsive, with the assistant falling back to a launcher-style panel when there is not enough width for the docked column.

## Validation

- `npm test -- --runInBand` passed: 85 tests
- `npm run lint` passed with existing Fast Refresh warnings only
- `npm run build` passed

## Notes

- This PR is opened as a draft for visual review of the redesigned dashboard shell before merge.
- The local `gh` token is invalid, so the PR was created through the connected GitHub app after pushing the branch with git.