### PR TITLE
[codex] Add configurable dashboard digest periods

### DIFF
--- a/src/features/dashboard/components/AccountBalanceStrip.tsx
+++ b/src/features/dashboard/components/AccountBalanceStrip.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { FiArrowDownRight, FiArrowUpRight, FiCreditCard, FiPlus } from 'react-icons/fi';
-import { ACCOUNT_TYPE_LABELS } from '@/features/accounts/models/AccountModel';
+import {
+	ACCOUNT_TYPE_LABELS,
+	calculateNetWorth,
+	getAccountLiability,
+} from '@/features/accounts/models/AccountModel';
 import { Account } from '@/types';
 import { formatCurrency } from '@/utils/formatCurrency';
 
@@ -16,10 +20,7 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 	const hasOverflow = accounts.length > 4;
 	const displayAccounts = accounts.slice(0, hasOverflow ? 3 : 4);
 	const remainingCount = Math.max(0, accounts.length - displayAccounts.length);
-	const totalBalance = accounts.reduce((sum, account) => {
-		if (account.type === 'credit') return sum - Math.abs(account.balance);
-		return sum + account.balance;
-	}, 0);
+	const totalBalance = calculateNetWorth(accounts).netWorth;
 
 	return (
 		<section
@@ -46,12 +47,18 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 				</button>
 			</div>
 
-			<div className="grid gap-px bg-border sm:grid-cols-2 xl:grid-cols-4">
+			<div
+				className="grid gap-px bg-border"
+				style={{
+					gridTemplateColumns:
+						'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
+				}}
+			>
 				{displayAccounts.length === 0 ? (
 					<button
 						type="button"
 						onClick={onOpenAccounts}
-						className="flex min-h-16 items-center gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 sm:col-span-2 xl:col-span-4"
+						className="flex min-h-16 items-center gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60"
 					>
 						<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
 							<FiPlus className="h-4 w-4" />
@@ -66,8 +73,7 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 				) : (
 					<>
 						{displayAccounts.map((account) => {
-							const isNegative =
-								account.balance < 0 || account.type === 'credit';
+							const isNegative = getAccountLiability(account) > 0;
 							const BalanceIcon = isNegative ? FiArrowDownRight : FiArrowUpRight;
 							const balanceTone = isNegative
 								? 'text-red-600 dark:text-red-400'

--- a/src/features/dashboard/components/DashboardOverview.tsx
+++ b/src/features/dashboard/components/DashboardOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { FiEye, FiSearch, FiSettings } from 'react-icons/fi';
 import AIChatbot from '@/features/ai/components/AIChatbot';
 import { useAccountsContext } from '@/features/accounts/context/AccountsContext';
@@ -12,6 +12,11 @@ import MonthlyDigest from '@/features/dashboard/components/MonthlyDigest';
 import QuickTransactionPanel from '@/features/dashboard/components/QuickTransactionPanel';
 import RecentTransactionsPanel from '@/features/dashboard/components/RecentTransactionsPanel';
 import { calculateDashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
+import {
+	DashboardDigestPeriod,
+	loadDashboardDigestPeriod,
+	saveDashboardDigestPeriod,
+} from '@/features/dashboard/utils/digestPeriod';
 
 interface DashboardOverviewProps {
 	onCreateAccount: () => void;
@@ -31,9 +36,16 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 	const { transactions } = useTransactionsContext();
 	const { accounts } = useAccountsContext();
 	const { getCategoryPathLabel } = useCategoriesContext();
+	const [digestPeriod, setDigestPeriod] = useState<DashboardDigestPeriod>(() =>
+		loadDashboardDigestPeriod()
+	);
+	const handleDigestPeriodChange = useCallback((nextPeriod: DashboardDigestPeriod) => {
+		setDigestPeriod(nextPeriod);
+		saveDashboardDigestPeriod(nextPeriod);
+	}, []);
 	const summary = useMemo(
-		() => calculateDashboardSummary(transactions, accounts),
-		[accounts, transactions]
+		() => calculateDashboardSummary(transactions, accounts, new Date(), digestPeriod),
+		[accounts, digestPeriod, transactions]
 	);
 	const netWorthTone =
 		summary.saved >= 0
@@ -50,7 +62,7 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 							<span>Net worth {formatCurrency(summary.netWorth)}</span>
 							<span className={netWorthTone}>
 								{summary.saved >= 0 ? '+' : ''}
-								{formatCurrency(summary.saved)} this month
+								{formatCurrency(summary.saved)} this period
 							</span>
 						</div>
 					</div>
@@ -86,7 +98,11 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 				</header>
 
 				<div className="flex min-h-0 flex-1 flex-col gap-4">
-					<MonthlyDigest summary={summary} />
+					<MonthlyDigest
+						summary={summary}
+						period={digestPeriod}
+						onPeriodChange={handleDigestPeriodChange}
+					/>
 
 					<div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.95fr)_minmax(320px,0.9fr)]">
 						<RecentTransactionsPanel

--- a/src/features/dashboard/components/MonthlyDigest.tsx
+++ b/src/features/dashboard/components/MonthlyDigest.tsx
@@ -1,27 +1,141 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FiCalendar, FiChevronDown } from 'react-icons/fi';
+import { Button } from '@/components/app/ui/button';
+import { Input } from '@/components/app/ui/input';
+import { Label } from '@/components/app/ui/label';
 import { DashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
+import {
+	DashboardDigestCustomPeriod,
+	DashboardDigestPeriod,
+	DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD,
+	clampDigestDay,
+} from '@/features/dashboard/utils/digestPeriod';
 import { formatCurrency } from '@/utils/formatCurrency';
 
 interface MonthlyDigestProps {
 	summary: DashboardSummary;
+	period: DashboardDigestPeriod;
+	onPeriodChange: (period: DashboardDigestPeriod) => void;
 }
 
-const MonthlyDigest: React.FC<MonthlyDigestProps> = ({ summary }) => {
+const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
+	summary,
+	period,
+	onPeriodChange,
+}) => {
+	const [isPeriodOpen, setIsPeriodOpen] = useState(false);
 	const savedTone =
 		summary.saved >= 0
 			? 'text-green-600 dark:text-green-400'
 			: 'text-red-600 dark:text-red-400';
+	const isCustomPeriod = period.mode === 'customCycle';
+	const customPeriod: DashboardDigestCustomPeriod = isCustomPeriod
+		? period
+		: DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD;
+
+	const handleCustomDayChange = (field: 'startDay' | 'endDay', value: string) => {
+		onPeriodChange({
+			...customPeriod,
+			[field]: clampDigestDay(Number(value)),
+		});
+	};
 
 	return (
 		<section className="flex-shrink-0 rounded-lg border bg-card p-4">
 			<div className="mb-4 flex items-center justify-between gap-3">
 				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-					{summary.monthLabel} digest
+					{summary.periodLabel} digest
 				</p>
-				<p className="text-xs text-muted-foreground">
-					{summary.transactionCount} transactions
-				</p>
+				<div className="flex flex-wrap items-center justify-end gap-2">
+					<p className="text-xs text-muted-foreground">
+						{summary.transactionCount} transactions
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-8 px-2 text-xs"
+						onClick={() => setIsPeriodOpen((open) => !open)}
+						aria-expanded={isPeriodOpen}
+					>
+						<FiCalendar className="h-3.5 w-3.5" />
+						Period
+						<FiChevronDown
+							className={`h-3.5 w-3.5 transition-transform ${
+								isPeriodOpen ? 'rotate-180' : ''
+							}`}
+						/>
+					</Button>
+				</div>
 			</div>
+			{isPeriodOpen && (
+				<div className="mb-4 rounded-md border bg-muted/30 p-3">
+					<div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+						<div className="flex flex-wrap gap-2">
+							<Button
+								type="button"
+								variant={!isCustomPeriod ? 'secondary' : 'outline'}
+								size="sm"
+								onClick={() => onPeriodChange({ mode: 'monthToDate' })}
+							>
+								Month to date
+							</Button>
+							<Button
+								type="button"
+								variant={isCustomPeriod ? 'secondary' : 'outline'}
+								size="sm"
+								onClick={() => onPeriodChange(DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD)}
+							>
+								Custom cycle
+							</Button>
+						</div>
+						<div className="grid gap-3 sm:grid-cols-2">
+							<div>
+								<Label htmlFor="digest-start-day" className="mb-1 block text-xs">
+									Start day
+								</Label>
+								<Input
+									id="digest-start-day"
+									type="number"
+									min={1}
+									max={31}
+									value={customPeriod.startDay}
+									onFocus={() => {
+										if (!isCustomPeriod) {
+											onPeriodChange(DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD);
+										}
+									}}
+									onChange={(event) =>
+										handleCustomDayChange('startDay', event.target.value)
+									}
+									className="h-9 w-full sm:w-28"
+								/>
+							</div>
+							<div>
+								<Label htmlFor="digest-end-day" className="mb-1 block text-xs">
+									End day
+								</Label>
+								<Input
+									id="digest-end-day"
+									type="number"
+									min={1}
+									max={31}
+									value={customPeriod.endDay}
+									onFocus={() => {
+										if (!isCustomPeriod) {
+											onPeriodChange(DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD);
+										}
+									}}
+									onChange={(event) =>
+										handleCustomDayChange('endDay', event.target.value)
+									}
+									className="h-9 w-full sm:w-28"
+								/>
+							</div>
+						</div>
+					</div>
+				</div>
+			)}
 			<div className="grid gap-4 sm:grid-cols-3">
 				<div>
 					<p className="text-sm text-muted-foreground">Income</p>
@@ -29,7 +143,7 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({ summary }) => {
 						{formatCurrency(summary.income)}
 					</p>
 					<p className="mt-1 text-xs text-muted-foreground">
-						Current month inflow
+						Period inflow
 					</p>
 				</div>
 				<div>

--- a/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
+++ b/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
@@ -68,6 +68,26 @@ describe('AccountBalanceStrip', () => {
 		expect(onOpenAccounts).toHaveBeenCalledTimes(1);
 	});
 
+	it('does not mark a positive credit balance as owing', () => {
+		render(
+			<AccountBalanceStrip
+				accounts={[
+					{
+						id: 'credit-positive',
+						name: 'Credit Card',
+						type: 'credit',
+						balance: 3500,
+					},
+				]}
+				onOpenAccounts={jest.fn()}
+			/>
+		);
+
+		expect(screen.getByText('Available')).toBeInTheDocument();
+		expect(screen.queryByText('Owing')).not.toBeInTheDocument();
+		expect(screen.getByText(/1 linked - net/i)).toHaveTextContent(/net R/);
+	});
+
 	it('renders an empty state that opens account creation', async () => {
 		const user = userEvent.setup();
 		const onOpenAccounts = jest.fn();

--- a/src/features/dashboard/utils/__tests__/dashboardSummary.test.ts
+++ b/src/features/dashboard/utils/__tests__/dashboardSummary.test.ts
@@ -87,4 +87,61 @@ describe('calculateDashboardSummary', () => {
 		expect(summary.netWorth).toBe(0);
 		expect(summary.progressPercent).toBe(0);
 	});
+
+	it('calculates net worth from signed balances for credit accounts', () => {
+		const summary = calculateDashboardSummary(
+			[],
+			[
+				{ id: 'cheque', name: 'Cheque', type: 'debit', balance: 1000 },
+				{ id: 'credit-positive', name: 'Credit', type: 'credit', balance: 3500 },
+				{ id: 'credit-negative', name: 'Overdrawn', type: 'credit', balance: -100 },
+			],
+			new Date('2026-05-14T12:00:00')
+		);
+
+		expect(summary.netWorth).toBe(4400);
+	});
+
+	it('summarizes transactions inside a custom digest period', () => {
+		const summary = calculateDashboardSummary(
+			[
+				{
+					id: 'before-period',
+					accountId: 'cheque',
+					title: 'Before period',
+					amount: 100,
+					type: 'expense',
+					category: 'food',
+					date: new Date('2026-04-24T10:00:00'),
+				},
+				{
+					id: 'in-period',
+					accountId: 'cheque',
+					title: 'In period',
+					amount: 200,
+					type: 'expense',
+					category: 'food',
+					date: new Date('2026-04-25T10:00:00'),
+				},
+				{
+					id: 'income',
+					accountId: 'cheque',
+					title: 'Salary',
+					amount: 1000,
+					type: 'income',
+					category: 'personal',
+					date: new Date('2026-05-25T10:00:00'),
+				},
+			],
+			[],
+			new Date('2026-05-14T12:00:00'),
+			{ mode: 'customCycle', startDay: 25, endDay: 25 }
+		);
+
+		expect(summary.startDate).toBe('2026-04-25');
+		expect(summary.endDate).toBe('2026-05-25');
+		expect(summary.income).toBe(1000);
+		expect(summary.expense).toBe(200);
+		expect(summary.transactionCount).toBe(2);
+	});
 });

--- a/src/features/dashboard/utils/__tests__/digestPeriod.test.ts
+++ b/src/features/dashboard/utils/__tests__/digestPeriod.test.ts
@@ -1,0 +1,68 @@
+import {
+	DEFAULT_DASHBOARD_DIGEST_PERIOD,
+	DASHBOARD_DIGEST_PERIOD_STORAGE_KEY,
+	getDashboardDigestDateRange,
+	loadDashboardDigestPeriod,
+	saveDashboardDigestPeriod,
+} from '@/features/dashboard/utils/digestPeriod';
+
+describe('dashboard digest period', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('uses month-to-date by default', () => {
+		expect(
+			getDashboardDigestDateRange(
+				DEFAULT_DASHBOARD_DIGEST_PERIOD,
+				new Date('2026-05-14T12:00:00')
+			)
+		).toEqual({
+			startDate: '2026-05-01',
+			endDate: '2026-05-14',
+		});
+	});
+
+	it('builds a 25th-to-25th cycle around today', () => {
+		expect(
+			getDashboardDigestDateRange(
+				{ mode: 'customCycle', startDay: 25, endDay: 25 },
+				new Date('2026-05-14T12:00:00')
+			)
+		).toEqual({
+			startDate: '2026-04-25',
+			endDate: '2026-05-25',
+		});
+	});
+
+	it('moves the custom cycle forward after the end day', () => {
+		expect(
+			getDashboardDigestDateRange(
+				{ mode: 'customCycle', startDay: 25, endDay: 25 },
+				new Date('2026-05-26T12:00:00')
+			)
+		).toEqual({
+			startDate: '2026-05-25',
+			endDate: '2026-06-25',
+		});
+	});
+
+	it('saves and loads the digest period from localStorage', () => {
+		saveDashboardDigestPeriod({ mode: 'customCycle', startDay: 25, endDay: 25 });
+
+		expect(window.localStorage.setItem).toHaveBeenCalledWith(
+			DASHBOARD_DIGEST_PERIOD_STORAGE_KEY,
+			JSON.stringify({ mode: 'customCycle', startDay: 25, endDay: 25 })
+		);
+
+		(window.localStorage.getItem as jest.Mock).mockReturnValue(
+			JSON.stringify({ mode: 'customCycle', startDay: 25, endDay: 25 })
+		);
+
+		expect(loadDashboardDigestPeriod()).toEqual({
+			mode: 'customCycle',
+			startDay: 25,
+			endDay: 25,
+		});
+	});
+});

--- a/src/features/dashboard/utils/dashboardSummary.ts
+++ b/src/features/dashboard/utils/dashboardSummary.ts
@@ -1,3 +1,8 @@
+import { calculateNetWorth } from '@/features/accounts/models/AccountModel';
+import {
+	DashboardDigestPeriod,
+	getDashboardDigestDateRange,
+} from '@/features/dashboard/utils/digestPeriod';
 import { Account, Transaction } from '@/types';
 import { parseDbDateOrNull } from '@/utils/date';
 
@@ -8,20 +13,11 @@ export interface DashboardSummary {
 	transactionCount: number;
 	netWorth: number;
 	monthLabel: string;
+	periodLabel: string;
+	startDate: string;
+	endDate: string;
 	progressPercent: number;
 }
-
-const formatDateInput = (date: Date): string => {
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, '0');
-	const day = String(date.getDate()).padStart(2, '0');
-	return `${year}-${month}-${day}`;
-};
-
-const getCurrentMonthDateRange = (today = new Date()) => ({
-	startDate: formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1)),
-	endDate: formatDateInput(today),
-});
 
 const getTransactionDate = (transaction: Transaction): Date | null =>
 	parseDbDateOrNull(transaction.date) ?? parseDbDateOrNull(transaction.createdAt);
@@ -34,12 +30,31 @@ const isInDateRange = (date: Date, startDate: string, endDate: string): boolean 
 	return date >= start && date <= end;
 };
 
+const formatPeriodLabel = (startDate: string, endDate: string): string => {
+	const start = new Date(startDate);
+	const end = new Date(endDate);
+	const includeStartYear = start.getFullYear() !== end.getFullYear();
+	const startLabel = start.toLocaleDateString('en-ZA', {
+		day: 'numeric',
+		month: 'short',
+		...(includeStartYear ? { year: 'numeric' as const } : {}),
+	});
+	const endLabel = end.toLocaleDateString('en-ZA', {
+		day: 'numeric',
+		month: 'short',
+		year: 'numeric',
+	});
+
+	return `${startLabel} - ${endLabel}`;
+};
+
 export const calculateDashboardSummary = (
 	transactions: Transaction[],
 	accounts: Account[],
-	today = new Date()
+	today = new Date(),
+	digestPeriod?: DashboardDigestPeriod
 ): DashboardSummary => {
-	const { startDate, endDate } = getCurrentMonthDateRange(today);
+	const { startDate, endDate } = getDashboardDigestDateRange(digestPeriod, today);
 	const monthTransactions = transactions.filter((transaction) => {
 		const date = getTransactionDate(transaction);
 		return date ? isInDateRange(date, startDate, endDate) : false;
@@ -51,10 +66,7 @@ export const calculateDashboardSummary = (
 	const expense = monthTransactions
 		.filter((transaction) => transaction.type === 'expense')
 		.reduce((sum, transaction) => sum + transaction.amount, 0);
-	const netWorth = accounts.reduce((sum, account) => {
-		if (account.type === 'credit') return sum - Math.abs(account.balance);
-		return sum + account.balance;
-	}, 0);
+	const netWorth = calculateNetWorth(accounts).netWorth;
 	const progressPercent =
 		income > 0 ? Math.min(100, Math.max(0, ((income - expense) / income) * 100)) : 0;
 
@@ -68,6 +80,9 @@ export const calculateDashboardSummary = (
 			month: 'long',
 			year: 'numeric',
 		}),
+		periodLabel: formatPeriodLabel(startDate, endDate),
+		startDate,
+		endDate,
 		progressPercent,
 	};
 };

--- a/src/features/dashboard/utils/digestPeriod.ts
+++ b/src/features/dashboard/utils/digestPeriod.ts
@@ -1,0 +1,143 @@
+export type DashboardDigestPeriod =
+	| {
+			mode: 'monthToDate';
+	  }
+	| DashboardDigestCustomPeriod;
+
+export interface DashboardDigestCustomPeriod {
+	mode: 'customCycle';
+	startDay: number;
+	endDay: number;
+}
+
+export interface DashboardDigestDateRange {
+	startDate: string;
+	endDate: string;
+}
+
+export const DASHBOARD_DIGEST_PERIOD_STORAGE_KEY = 'cashflow.dashboardDigestPeriod';
+
+export const DEFAULT_DASHBOARD_DIGEST_PERIOD: DashboardDigestPeriod = {
+	mode: 'monthToDate',
+};
+
+export const DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD: DashboardDigestCustomPeriod = {
+	mode: 'customCycle',
+	startDay: 25,
+	endDay: 25,
+};
+
+export const clampDigestDay = (day: number): number => {
+	if (!Number.isFinite(day)) return 1;
+	return Math.min(31, Math.max(1, Math.round(day)));
+};
+
+const formatDateInput = (date: Date): string => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+};
+
+const getDaysInMonth = (year: number, month: number): number =>
+	new Date(year, month + 1, 0).getDate();
+
+const createClampedDate = (year: number, month: number, day: number): Date =>
+	new Date(year, month, Math.min(clampDigestDay(day), getDaysInMonth(year, month)));
+
+const shiftMonth = (date: Date, offset: number): Date =>
+	new Date(date.getFullYear(), date.getMonth() + offset, 1);
+
+export const getDashboardDigestDateRange = (
+	period: DashboardDigestPeriod = DEFAULT_DASHBOARD_DIGEST_PERIOD,
+	today = new Date()
+): DashboardDigestDateRange => {
+	if (period.mode === 'monthToDate') {
+		return {
+			startDate: formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1)),
+			endDate: formatDateInput(today),
+		};
+	}
+
+	const startDay = clampDigestDay(period.startDay);
+	const endDay = clampDigestDay(period.endDay);
+	const candidateEnd = createClampedDate(today.getFullYear(), today.getMonth(), endDay);
+	const startOffset = startDay < endDay ? 0 : -1;
+	const candidateStartMonth = shiftMonth(candidateEnd, startOffset);
+	const candidateStart = createClampedDate(
+		candidateStartMonth.getFullYear(),
+		candidateStartMonth.getMonth(),
+		startDay
+	);
+
+	let start = candidateStart;
+	let end = candidateEnd;
+
+	if (today < candidateStart) {
+		const previousEndMonth = shiftMonth(candidateEnd, -1);
+		end = createClampedDate(
+			previousEndMonth.getFullYear(),
+			previousEndMonth.getMonth(),
+			endDay
+		);
+		const previousStartMonth = shiftMonth(end, startOffset);
+		start = createClampedDate(
+			previousStartMonth.getFullYear(),
+			previousStartMonth.getMonth(),
+			startDay
+		);
+	} else if (today > candidateEnd) {
+		const nextEndMonth = shiftMonth(candidateEnd, 1);
+		end = createClampedDate(nextEndMonth.getFullYear(), nextEndMonth.getMonth(), endDay);
+		const nextStartMonth = shiftMonth(end, startOffset);
+		start = createClampedDate(
+			nextStartMonth.getFullYear(),
+			nextStartMonth.getMonth(),
+			startDay
+		);
+	}
+
+	return {
+		startDate: formatDateInput(start),
+		endDate: formatDateInput(end),
+	};
+};
+
+export const normalizeDashboardDigestPeriod = (
+	period: unknown
+): DashboardDigestPeriod => {
+	if (!period || typeof period !== 'object') return DEFAULT_DASHBOARD_DIGEST_PERIOD;
+
+	const candidate = period as Partial<DashboardDigestPeriod>;
+	if (candidate.mode === 'customCycle') {
+		return {
+			mode: 'customCycle',
+			startDay: clampDigestDay(Number(candidate.startDay)),
+			endDay: clampDigestDay(Number(candidate.endDay)),
+		};
+	}
+
+	return DEFAULT_DASHBOARD_DIGEST_PERIOD;
+};
+
+export const loadDashboardDigestPeriod = (): DashboardDigestPeriod => {
+	if (typeof window === 'undefined') return DEFAULT_DASHBOARD_DIGEST_PERIOD;
+
+	try {
+		const raw = window.localStorage.getItem(DASHBOARD_DIGEST_PERIOD_STORAGE_KEY);
+		return raw
+			? normalizeDashboardDigestPeriod(JSON.parse(raw))
+			: DEFAULT_DASHBOARD_DIGEST_PERIOD;
+	} catch {
+		return DEFAULT_DASHBOARD_DIGEST_PERIOD;
+	}
+};
+
+export const saveDashboardDigestPeriod = (period: DashboardDigestPeriod): void => {
+	if (typeof window === 'undefined') return;
+
+	window.localStorage.setItem(
+		DASHBOARD_DIGEST_PERIOD_STORAGE_KEY,
+		JSON.stringify(normalizeDashboardDigestPeriod(period))
+	);
+};


### PR DESCRIPTION
## Summary

Adds a configurable dashboard digest period so the dashboard can summarize transactions using either the existing month-to-date range or a saved custom monthly cycle such as the 25th of the previous month through the 25th of the current month.

Also fixes account balance display behavior in the dashboard strip: positive credit balances are no longer shown as owing, net worth uses the shared signed-balance account model calculation, and the strip cards stretch to fill the available width instead of leaving an empty grid column.

## Impact

- Dashboard digest users can switch between month-to-date and a custom day-to-day cycle.
- The chosen digest period is saved in localStorage and persists after refresh.
- Digest totals, transaction count, and period labels follow the selected range.
- Account balance cards render more accurately and fill the strip width.

## Root Cause

The digest summary was hard-coded to month-to-date, while the account strip treated all credit accounts as negative and reserved four grid columns on wide screens even when fewer cards were rendered.

## Validation

- `npm test -- --runInBand`
- `npm run lint` (passes with existing fast-refresh warnings)
- `npm run build`