### PR TITLE
[codex] Redesign dashboard cockpit layout

### DIFF
--- a/src/features/ai/components/AIChatbot.tsx
+++ b/src/features/ai/components/AIChatbot.tsx
@@ -26,9 +26,13 @@ const createMessage = (
 
 interface AIChatbotProps {
 	variant?: 'floating' | 'docked';
+	forceDocked?: boolean;
 }
 
-const AIChatbot: React.FC<AIChatbotProps> = ({ variant = 'floating' }) => {
+const AIChatbot: React.FC<AIChatbotProps> = ({
+	variant = 'floating',
+	forceDocked = false,
+}) => {
 	const { currentUser } = useAuth();
 	const { askQuestion } = useAIChatController();
 
@@ -280,7 +284,7 @@ const AIChatbot: React.FC<AIChatbotProps> = ({ variant = 'floating' }) => {
 	);
 
 	if (variant === 'docked') {
-		if (!isDockedMobile) {
+		if (forceDocked || !isDockedMobile) {
 			return renderPanel({ docked: true });
 		}
 

--- a/src/features/dashboard/components/AccountBalanceStrip.tsx
+++ b/src/features/dashboard/components/AccountBalanceStrip.tsx
@@ -11,30 +11,36 @@ import { formatCurrency } from '@/utils/formatCurrency';
 interface AccountBalanceStripProps {
 	accounts: Account[];
 	onOpenAccounts: () => void;
+	compact?: boolean;
 }
 
 const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 	accounts,
 	onOpenAccounts,
+	compact = false,
 }) => {
-	const hasOverflow = accounts.length > 4;
-	const displayAccounts = accounts.slice(0, hasOverflow ? 3 : 4);
+	const displayLimit = compact ? 3 : accounts.length > 4 ? 3 : 4;
+	const hasOverflow = accounts.length > displayLimit;
+	const displayAccounts = accounts.slice(0, displayLimit);
 	const remainingCount = Math.max(0, accounts.length - displayAccounts.length);
 	const totalBalance = calculateNetWorth(accounts).netWorth;
 
 	return (
 		<section
 			aria-label="Account balances"
-			className="overflow-hidden rounded-lg border bg-card"
+			className="overflow-hidden rounded-lg border bg-card shadow-sm"
 		>
-			<div className="flex items-center justify-between gap-3 border-b px-3 py-2">
+			<div className={`flex items-start justify-between gap-3 border-b bg-muted/20 ${compact ? 'p-3' : 'p-4'}`}>
 				<div className="min-w-0">
 					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 						Accounts
 					</p>
-					<p className="truncate text-xs text-muted-foreground">
+					<p className={`mt-1 font-semibold tracking-tight ${compact ? 'text-xl' : 'text-2xl'}`}>
+						{formatCurrency(totalBalance)}
+					</p>
+					<p className="mt-1 truncate text-xs text-muted-foreground">
 						{accounts.length > 0
-							? `${accounts.length} linked - net ${formatCurrency(totalBalance)}`
+							? `${accounts.length} linked account${accounts.length === 1 ? '' : 's'}`
 							: 'No accounts linked yet'}
 					</p>
 				</div>
@@ -48,7 +54,7 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 			</div>
 
 			<div
-				className="grid gap-px bg-border"
+				className={`grid ${compact ? 'gap-2 p-2' : 'gap-3 p-3'}`}
 				style={{
 					gridTemplateColumns:
 						'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
@@ -58,7 +64,7 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 					<button
 						type="button"
 						onClick={onOpenAccounts}
-						className="flex min-h-16 items-center gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60"
+						className={`flex items-center gap-3 rounded-md border bg-background text-left transition-colors hover:bg-muted/60 ${compact ? 'min-h-16 p-2.5' : 'min-h-24 p-3'}`}
 					>
 						<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
 							<FiPlus className="h-4 w-4" />
@@ -84,10 +90,10 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 									key={account.id ?? account.name}
 									type="button"
 									onClick={onOpenAccounts}
-									className="group relative flex min-h-16 min-w-0 items-center justify-between gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+									className={`group relative flex min-w-0 items-center justify-between gap-3 overflow-hidden rounded-md border bg-background text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${compact ? 'min-h-16 p-2.5' : 'min-h-24 p-3'}`}
 								>
 									<span
-										className="absolute inset-y-2 left-0 w-1 rounded-r-full"
+										className="absolute inset-y-3 left-0 w-1 rounded-r-full"
 										style={{ backgroundColor: account.color ?? '#6366f1' }}
 									/>
 									<span className="ml-2 flex min-w-0 flex-1 items-center gap-2">
@@ -124,7 +130,7 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 							<button
 								type="button"
 								onClick={onOpenAccounts}
-								className="flex min-h-16 min-w-0 items-center justify-between gap-3 bg-card p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+								className={`flex min-w-0 items-center justify-between gap-3 rounded-md border bg-background text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${compact ? 'min-h-16 p-2.5' : 'min-h-24 p-3'}`}
 							>
 								<span className="min-w-0">
 									<span className="block text-sm font-medium">

--- a/src/features/dashboard/components/DashboardOverview.tsx
+++ b/src/features/dashboard/components/DashboardOverview.tsx
@@ -9,7 +9,6 @@ import { Transaction } from '@/types';
 import { formatCurrency } from '@/utils/formatCurrency';
 import AccountBalanceStrip from '@/features/dashboard/components/AccountBalanceStrip';
 import MonthlyDigest from '@/features/dashboard/components/MonthlyDigest';
-import QuickTransactionPanel from '@/features/dashboard/components/QuickTransactionPanel';
 import RecentTransactionsPanel from '@/features/dashboard/components/RecentTransactionsPanel';
 import { calculateDashboardSummary } from '@/features/dashboard/utils/dashboardSummary';
 import {
@@ -19,7 +18,6 @@ import {
 } from '@/features/dashboard/utils/digestPeriod';
 
 interface DashboardOverviewProps {
-	onCreateAccount: () => void;
 	onOpenAccounts: () => void;
 	onOpenHistory: () => void;
 	onOpenSettings: () => void;
@@ -27,7 +25,6 @@ interface DashboardOverviewProps {
 }
 
 const DashboardOverview: React.FC<DashboardOverviewProps> = ({
-	onCreateAccount,
 	onOpenAccounts,
 	onOpenHistory,
 	onOpenSettings,
@@ -54,11 +51,16 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background">
-			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-5 md:px-6 lg:px-8 xl:overflow-hidden">
-				<header className="mb-4 flex flex-shrink-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 md:px-5 lg:px-6 xl:overflow-hidden xl:px-6">
+				<header className="mb-3 flex flex-shrink-0 flex-col gap-3 border-b pb-3 sm:flex-row sm:items-start sm:justify-between">
 					<div>
-						<h1 className="text-3xl font-semibold tracking-tight">Dashboard</h1>
-						<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+						<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+							CashFlow overview
+						</p>
+						<h1 className="mt-1 text-2xl font-semibold tracking-tight">
+							Dashboard
+						</h1>
+						<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
 							<span>Net worth {formatCurrency(summary.netWorth)}</span>
 							<span className={netWorthTone}>
 								{summary.saved >= 0 ? '+' : ''}
@@ -97,30 +99,31 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 					</div>
 				</header>
 
-				<div className="flex min-h-0 flex-1 flex-col gap-4">
+				<div className="grid flex-1 gap-3 xl:min-h-0 xl:grid-rows-[auto_minmax(0,1fr)]">
 					<MonthlyDigest
 						summary={summary}
 						period={digestPeriod}
 						onPeriodChange={handleDigestPeriodChange}
+						compact
 					/>
 
-					<div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.95fr)_minmax(320px,0.9fr)]">
+					<div className="grid gap-3 xl:min-h-0 xl:grid-cols-[minmax(280px,0.78fr)_minmax(360px,1fr)_minmax(320px,0.85fr)]">
+						<AccountBalanceStrip
+							accounts={accounts}
+							onOpenAccounts={onOpenAccounts}
+							compact
+						/>
 						<RecentTransactionsPanel
 							transactions={transactions}
 							accounts={accounts}
 							getCategoryPathLabel={getCategoryPathLabel}
 							onSelect={onSelectTransaction}
 							onOpenHistory={onOpenHistory}
+							compact
 						/>
-						<QuickTransactionPanel onCreateAccount={onCreateAccount} />
-						<AIChatbot variant="docked" />
-					</div>
-
-					<div className="flex-shrink-0">
-						<AccountBalanceStrip
-							accounts={accounts}
-							onOpenAccounts={onOpenAccounts}
-						/>
+						<div className="min-h-[28rem] xl:min-h-0">
+							<AIChatbot variant="docked" forceDocked />
+						</div>
 					</div>
 				</div>
 			</div>

--- a/src/features/dashboard/components/MonthlyDigest.tsx
+++ b/src/features/dashboard/components/MonthlyDigest.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { FiCalendar, FiChevronDown } from 'react-icons/fi';
+import {
+	FiArrowDownCircle,
+	FiArrowUpCircle,
+	FiCalendar,
+	FiChevronDown,
+	FiTarget,
+} from 'react-icons/fi';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
 import { Label } from '@/components/app/ui/label';
@@ -16,12 +22,14 @@ interface MonthlyDigestProps {
 	summary: DashboardSummary;
 	period: DashboardDigestPeriod;
 	onPeriodChange: (period: DashboardDigestPeriod) => void;
+	compact?: boolean;
 }
 
 const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 	summary,
 	period,
 	onPeriodChange,
+	compact = false,
 }) => {
 	const [isPeriodOpen, setIsPeriodOpen] = useState(false);
 	const savedTone =
@@ -41,20 +49,34 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 	};
 
 	return (
-		<section className="flex-shrink-0 rounded-lg border bg-card p-4">
-			<div className="mb-4 flex items-center justify-between gap-3">
-				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-					{summary.periodLabel} digest
-				</p>
-				<div className="flex flex-wrap items-center justify-end gap-2">
-					<p className="text-xs text-muted-foreground">
-						{summary.transactionCount} transactions
-					</p>
+		<section className="flex-shrink-0 overflow-hidden rounded-lg border bg-card shadow-sm">
+			<div className={`border-b bg-muted/20 ${compact ? 'p-3' : 'p-5'}`}>
+				<div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+					<div>
+						<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+							{summary.periodLabel} digest
+						</p>
+						<div className="mt-2 flex flex-wrap items-end gap-x-4 gap-y-2">
+							<div>
+								<p className="text-sm text-muted-foreground">
+									Retained this period
+								</p>
+								<p
+									className={`${compact ? 'text-3xl' : 'text-4xl'} mt-1 font-semibold tracking-tight ${savedTone}`}
+								>
+									{formatCurrency(summary.saved)}
+								</p>
+							</div>
+							<div className="pb-1 text-sm text-muted-foreground">
+								{summary.transactionCount} transactions tracked
+							</div>
+						</div>
+					</div>
 					<Button
 						type="button"
 						variant="outline"
 						size="sm"
-						className="h-8 px-2 text-xs"
+						className="h-9 self-start px-3 text-xs"
 						onClick={() => setIsPeriodOpen((open) => !open)}
 						aria-expanded={isPeriodOpen}
 					>
@@ -69,7 +91,7 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 				</div>
 			</div>
 			{isPeriodOpen && (
-				<div className="mb-4 rounded-md border bg-muted/30 p-3">
+				<div className="border-b bg-background p-4">
 					<div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
 						<div className="flex flex-wrap gap-2">
 							<Button
@@ -136,38 +158,45 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 					</div>
 				</div>
 			)}
-			<div className="grid gap-4 sm:grid-cols-3">
-				<div>
-					<p className="text-sm text-muted-foreground">Income</p>
-					<p className="mt-1 text-2xl font-semibold text-primary">
+			<div className="grid gap-px bg-border sm:grid-cols-3">
+				<div className={`bg-card ${compact ? 'p-3' : 'p-4'}`}>
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<p className="text-sm text-muted-foreground">Income</p>
+						<FiArrowUpCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+					</div>
+					<p className={`${compact ? 'text-xl' : 'text-2xl'} font-semibold text-primary`}>
 						{formatCurrency(summary.income)}
 					</p>
-					<p className="mt-1 text-xs text-muted-foreground">
-						Period inflow
-					</p>
+					<p className="mt-1 text-xs text-muted-foreground">Period inflow</p>
 				</div>
-				<div>
-					<p className="text-sm text-muted-foreground">Spent</p>
-					<p className="mt-1 text-2xl font-semibold text-red-600 dark:text-red-400">
+				<div className={`bg-card ${compact ? 'p-3' : 'p-4'}`}>
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<p className="text-sm text-muted-foreground">Spent</p>
+						<FiArrowDownCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+					</div>
+					<p className={`${compact ? 'text-xl' : 'text-2xl'} font-semibold text-red-600 dark:text-red-400`}>
 						{formatCurrency(summary.expense)}
 					</p>
 					<p className="mt-1 text-xs text-muted-foreground">
 						Tracked expenses
 					</p>
 				</div>
-				<div>
-					<p className="text-sm text-muted-foreground">Saved</p>
-					<p className={`mt-1 text-2xl font-semibold ${savedTone}`}>
-						{formatCurrency(summary.saved)}
+				<div className={`bg-card ${compact ? 'p-3' : 'p-4'}`}>
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<p className="text-sm text-muted-foreground">Retention</p>
+						<FiTarget className="h-4 w-4 text-primary" />
+					</div>
+					<p className={`${compact ? 'text-xl' : 'text-2xl'} font-semibold ${savedTone}`}>
+						{Math.round(summary.progressPercent)}%
 					</p>
 					<p className="mt-1 text-xs text-muted-foreground">
 						{summary.income > 0
-							? `${Math.round(summary.progressPercent)}% of income retained`
+							? `${formatCurrency(summary.saved)} kept`
 							: 'Add income to track retention'}
 					</p>
 				</div>
 			</div>
-			<div className="mt-4 h-1.5 overflow-hidden rounded-full bg-muted">
+			<div className="h-1.5 overflow-hidden bg-muted">
 				<div
 					className="h-full rounded-full bg-primary transition-all"
 					style={{ width: `${summary.progressPercent}%` }}

--- a/src/features/dashboard/components/RecentTransactionsPanel.tsx
+++ b/src/features/dashboard/components/RecentTransactionsPanel.tsx
@@ -17,6 +17,7 @@ interface RecentTransactionsPanelProps {
 	getCategoryPathLabel: (category: string, subcategory?: string) => string;
 	onSelect: (transaction: Transaction) => void;
 	onOpenHistory: () => void;
+	compact?: boolean;
 }
 
 const getTransactionIcon = (transaction: Transaction) => {
@@ -33,6 +34,7 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 	getCategoryPathLabel,
 	onSelect,
 	onOpenHistory,
+	compact = false,
 }) => {
 	const accountColorMap = useMemo(() => {
 		const map = new Map<string, string>();
@@ -50,20 +52,25 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 					const rightDate = parseDbDate(right.date ?? right.createdAt);
 					return rightDate.getTime() - leftDate.getTime();
 				})
-				.slice(0, 6),
-		[transactions]
+				.slice(0, compact ? 5 : 6),
+		[compact, transactions]
 	);
 
 	return (
-		<section className="flex h-full min-h-[22rem] flex-col rounded-lg border bg-card p-4 xl:min-h-0">
-			<div className="mb-4 flex flex-shrink-0 items-center justify-between gap-3">
-				<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-					Recent
-				</p>
+		<section className="flex h-full min-h-0 flex-col rounded-lg border bg-card p-3 shadow-sm">
+			<div className="mb-2 flex flex-shrink-0 items-start justify-between gap-3">
+				<div>
+					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+						Recent
+					</p>
+					<h2 className="mt-1 text-lg font-semibold tracking-tight">
+						Latest transactions
+					</h2>
+				</div>
 				<button
 					type="button"
 					onClick={onOpenHistory}
-					className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+					className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 				>
 					View all
 				</button>
@@ -80,7 +87,7 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 					</p>
 				</div>
 			) : (
-				<div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1">
+				<div className="min-h-0 flex-1 divide-y overflow-y-auto">
 					{recentTransactions.map((transaction) => {
 						const Icon = getTransactionIcon(transaction);
 						const isPositive = transaction.type === 'income';
@@ -99,11 +106,11 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 								key={transaction.id ?? `${transaction.title}-${date.toISOString()}`}
 								type="button"
 								onClick={() => onSelect(transaction)}
-								className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-3 text-left transition-colors hover:border-border hover:bg-muted/60"
+								className={`group flex w-full items-center gap-3 px-1 text-left transition-colors hover:bg-muted/50 sm:px-2 ${compact ? 'py-2' : 'py-3'}`}
 							>
 								<span
-									className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-									style={{ boxShadow: `inset 3px 0 0 ${color}` }}
+									className={`${compact ? 'h-9 w-9' : 'h-10 w-10'} flex flex-shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground`}
+									style={{ borderLeftColor: color, borderLeftWidth: 4 }}
 								>
 									<Icon className="h-4 w-4" />
 								</span>
@@ -125,9 +132,14 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 										})}
 									</span>
 								</span>
-								<span className={`text-sm font-semibold ${amountTone}`}>
-									{amountPrefix}
-									{formatCurrency(transaction.amount)}
+								<span className="min-w-[6rem] text-right">
+									<span className={`block text-sm font-semibold tabular-nums ${amountTone}`}>
+										{amountPrefix}
+										{formatCurrency(transaction.amount)}
+									</span>
+									<span className="text-xs text-muted-foreground">
+										{transaction.type}
+									</span>
 								</span>
 							</button>
 						);

--- a/src/features/dashboard/components/Sidebar.tsx
+++ b/src/features/dashboard/components/Sidebar.tsx
@@ -182,10 +182,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 			<aside
 				aria-hidden={collapsed}
-				className={`fixed left-0 top-0 z-40 h-screen-safe w-64 border-r bg-card transition-transform duration-300 ease-in-out md:relative md:z-auto md:transition-all ${
+				className={`fixed left-0 top-0 z-40 h-screen-safe w-72 border-r bg-card transition-transform duration-300 ease-in-out md:relative md:z-auto md:transition-all ${
 					collapsed
 						? '-translate-x-full md:translate-x-0 md:w-0'
-						: 'translate-x-0 md:w-64'
+						: 'translate-x-0 md:w-72'
 				}`}
 			>
 				<div
@@ -194,7 +194,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 					}`}
 				>
 					{/* Header */}
-					<div className="flex items-center justify-between border-b p-3 md:p-4">
+					<div className="flex items-center justify-between border-b bg-muted/20 p-4">
 						<div className="flex items-center gap-2 flex-1">
 							<img
 								src={logo}
@@ -206,7 +206,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 									CashFlow
 								</h3>
 								{accounts.length > 0 && (
-									<p className="text-xs text-muted-foreground truncate">
+									<p className="mt-0.5 text-xs text-muted-foreground truncate">
 										{formatCurrency(availableBalance)}
 									</p>
 								)}
@@ -239,7 +239,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 					{/* Navigation */}
 					{!collapsed && (
 						<>
-							<div className="border-b p-2">
+							<div className="border-b p-3">
 								<p className="px-3 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
 									App map
 								</p>
@@ -255,7 +255,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 												onClick={() => handleViewClick(id)}
 												className={`w-full flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
 													isActive
-														? 'bg-accent text-accent-foreground'
+														? 'bg-primary text-primary-foreground shadow-sm'
 														: 'text-muted-foreground hover:bg-muted hover:text-foreground'
 												}`}
 											>
@@ -267,7 +267,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 								</div>
 							</div>
 
-							<div className="border-b p-2">
+							<div className="border-b p-3">
 								<button
 									type="button"
 									onClick={() => setTransactionsExpanded((current) => !current)}
@@ -292,27 +292,27 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 							{/* Search */}
 							{transactionsExpanded && (
-								<div className="border-b p-2">
-								<div className="relative">
-									<FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-									<Input
-										type="text"
-										placeholder="Search transactions..."
-										value={searchTerm}
-										onChange={(e) => setSearchTerm(e.target.value)}
-										className="pl-9 pr-9 text-sm"
-									/>
-									{searchTerm && (
-										<button
-											onClick={() => setSearchTerm('')}
-											className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-											aria-label="Clear search"
-										>
-											<FiX className="h-4 w-4" />
-										</button>
-									)}
+								<div className="border-b p-3">
+									<div className="relative">
+										<FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+										<Input
+											type="text"
+											placeholder="Search transactions..."
+											value={searchTerm}
+											onChange={(e) => setSearchTerm(e.target.value)}
+											className="pl-9 pr-9 text-sm"
+										/>
+										{searchTerm && (
+											<button
+												onClick={() => setSearchTerm('')}
+												className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+												aria-label="Clear search"
+											>
+												<FiX className="h-4 w-4" />
+											</button>
+										)}
+									</div>
 								</div>
-							</div>
 							)}
 						</>
 					)}
@@ -328,10 +328,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 								<div className="space-y-4">
 									{Object.entries(groupedTransactions).map(([date, txs]) => (
 										<div key={date} className="space-y-1">
-											<div className="sticky top-0 z-10 bg-card px-2 py-1 text-xs font-semibold text-muted-foreground bg-opacity-95 backdrop-blur-sm border-b">
+											<div className="sticky top-0 z-10 bg-card/95 px-2 py-1 text-xs font-semibold text-muted-foreground backdrop-blur-sm">
 												{date}
 											</div>
-											<div className="space-y-2 pt-1">
+											<div className="space-y-1 pt-1">
 												{txs.map((tx) => {
 													const acctColor =
 														accountColorMap[tx.accountId] ?? '#6366f1';
@@ -352,8 +352,8 @@ const Sidebar: React.FC<SidebarProps> = ({
 															tabIndex={0}
 															className={`group flex cursor-pointer items-center justify-between rounded-lg border p-2 md:p-3 transition-colors ${
 																selectedId === tx.id
-																	? 'border-primary bg-accent'
-																	: 'border-border bg-background hover:bg-muted'
+																	? 'border-primary bg-primary/10'
+																	: 'border-transparent bg-background hover:border-border hover:bg-muted'
 															}`}
 														>
 															<div className="flex items-center gap-2 flex-1 min-w-0">
@@ -426,10 +426,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 					{/* New Transaction Button */}
 					{!collapsed && (
-						<div className="border-t p-2">
+						<div className="border-t p-3">
 							<Button
 								onClick={handleCreateTransaction}
-								className="w-full text-sm md:text-base h-9 md:h-10"
+								className="h-10 w-full text-sm md:text-base"
 							>
 								<FiPlus className="mr-2 h-4 w-4" />
 								{hasNoAccounts ? 'Add First Account' : 'New Transaction'}
@@ -438,7 +438,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 					)}
 
 					{/* User Section */}
-					<div className="border-t p-2">
+					<div className="border-t bg-muted/20 p-3">
 						{currentUser ? (
 							<button
 								onClick={() => {

--- a/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
+++ b/src/features/dashboard/components/__tests__/AccountBalanceStrip.test.tsx
@@ -50,7 +50,8 @@ describe('AccountBalanceStrip', () => {
 			screen.getByRole('region', { name: /account balances/i })
 		).toBeInTheDocument();
 		expect(screen.getByText('Accounts')).toBeInTheDocument();
-		expect(screen.getByText(/5 linked - net/i)).toBeInTheDocument();
+		expect(screen.getByText('5 linked accounts')).toBeInTheDocument();
+		expect(screen.getByText(/R.*4.*752/)).toBeInTheDocument();
 		expect(screen.getByText('FNB Cheque')).toBeInTheDocument();
 		expect(screen.getByText('FNB - Debit')).toBeInTheDocument();
 		expect(screen.getByText('2 more accounts')).toBeInTheDocument();
@@ -85,7 +86,8 @@ describe('AccountBalanceStrip', () => {
 
 		expect(screen.getByText('Available')).toBeInTheDocument();
 		expect(screen.queryByText('Owing')).not.toBeInTheDocument();
-		expect(screen.getByText(/1 linked - net/i)).toHaveTextContent(/net R/);
+		expect(screen.getByText('1 linked account')).toBeInTheDocument();
+		expect(screen.getAllByText(/R.*3.*500/).length).toBeGreaterThan(0);
 	});
 
 	it('renders an empty state that opens account creation', async () => {

--- a/src/features/dashboard/components/__tests__/DashboardOverview.test.tsx
+++ b/src/features/dashboard/components/__tests__/DashboardOverview.test.tsx
@@ -1,10 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import DashboardOverview from '@/features/dashboard/components/DashboardOverview';
 
 const mockAddTransaction = jest.fn();
 const mockAddTransfer = jest.fn();
-const mockOnCreateAccount = jest.fn();
 const mockOnOpenAccounts = jest.fn();
 const mockOnOpenHistory = jest.fn();
 const mockOnOpenSettings = jest.fn();
@@ -99,10 +97,9 @@ describe('DashboardOverview', () => {
 		mockAddTransfer.mockResolvedValue(undefined);
 	});
 
-	it('renders the reference-style dashboard panels with a docked assistant', () => {
+	it('renders the redesigned executive dashboard panels with a docked assistant', () => {
 		render(
 			<DashboardOverview
-				onCreateAccount={mockOnCreateAccount}
 				onOpenAccounts={mockOnOpenAccounts}
 				onOpenHistory={mockOnOpenHistory}
 				onOpenSettings={mockOnOpenSettings}
@@ -111,38 +108,12 @@ describe('DashboardOverview', () => {
 		);
 
 		expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+		expect(screen.getByText(/Net worth/i)).toBeInTheDocument();
 		expect(screen.getByText(/digest/i)).toBeInTheDocument();
+		expect(screen.queryByText('Money movement')).not.toBeInTheDocument();
+		expect(screen.getByText('Accounts')).toBeInTheDocument();
 		expect(screen.getByText('Recent')).toBeInTheDocument();
-		expect(screen.getByText('New transaction')).toBeInTheDocument();
+		expect(screen.queryByText('New transaction')).not.toBeInTheDocument();
 		expect(screen.getByTestId('assistant-variant')).toHaveTextContent('docked');
-	});
-
-	it('submits a quick expense through the transaction context', async () => {
-		const user = userEvent.setup();
-		render(
-			<DashboardOverview
-				onCreateAccount={mockOnCreateAccount}
-				onOpenAccounts={mockOnOpenAccounts}
-				onOpenHistory={mockOnOpenHistory}
-				onOpenSettings={mockOnOpenSettings}
-				onSelectTransaction={mockOnSelectTransaction}
-			/>
-		);
-
-		await user.type(screen.getByLabelText('Amount'), '123.45');
-		await user.type(screen.getByLabelText('Description'), 'Lunch');
-		await user.click(screen.getByRole('button', { name: 'Add transaction' }));
-
-		await waitFor(() => {
-			expect(mockAddTransaction).toHaveBeenCalledWith(
-				expect.objectContaining({
-					accountId: 'acc-1',
-					amount: 123.45,
-					title: 'Lunch',
-					type: 'expense',
-					category: 'food',
-				})
-			);
-		});
 	});
 });

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -222,7 +222,6 @@ const Dashboard: React.FC = () => {
 			default:
 				return (
 					<DashboardOverview
-						onCreateAccount={handleCreateAccount}
 						onOpenAccounts={() => setActiveView('accounts')}
 						onOpenHistory={handleOpenHistory}
 						onOpenSettings={() => handleOpenSettings('general')}


### PR DESCRIPTION
## Summary
- Redesign the dashboard overview into a compact cockpit layout with digest, accounts, recent transactions, and AI assistant visible together on desktop.
- Keep the AI assistant docked and visible on the dashboard while preserving mobile/tablet scrolling.
- Refresh dashboard/sidebar panel density and update tests for the new account summary presentation.

## User impact
- Users can see the key dashboard information without scrolling on desktop.
- Mobile users can still scroll naturally through the stacked dashboard sections.
- Transaction creation remains driven by the existing New Transaction button instead of an inline quick-add panel.

## Validation
- `npm test -- DashboardOverview AccountBalanceStrip --runInBand`
- `npm run build`
- `git diff --check`

Note: the production build still reports the existing large chunk warning.