### PR TITLE
[codex] Fix duplicate transaction submits

### DIFF
--- a/apps/desktop/src/features/transactions/hooks/useTransactions.ts
+++ b/apps/desktop/src/features/transactions/hooks/useTransactions.ts
@@ -88,13 +88,8 @@ export const useTransactions = () => {
 		if (!user) throw new Error('User not authenticated');
 		if (!data.category.trim()) throw new Error('Category is required.');
 
-		const accountRef = doc(db, 'users', user.uid, 'accounts', data.accountId);
-		const accountSnap = await getDoc(accountRef);
-		if (!accountSnap.exists()) {
-			throw new Error('Account not found.');
-		}
-
 		const batch = writeBatch(db);
+		const accountRef = doc(db, 'users', user.uid, 'accounts', data.accountId);
 
 		const txCol = collection(db, 'users', user.uid, 'transactions');
 		const txRef = doc(txCol);
@@ -126,14 +121,6 @@ export const useTransactions = () => {
 
 		const fromRef = doc(db, 'users', user.uid, 'accounts', data.fromAccountId);
 		const toRef = doc(db, 'users', user.uid, 'accounts', data.toAccountId);
-		const [fromSnap, toSnap] = await Promise.all([
-			getDoc(fromRef),
-			getDoc(toRef),
-		]);
-		if (!fromSnap.exists() || !toSnap.exists()) {
-			throw new Error('Account not found.');
-		}
-
 		const batch = writeBatch(db);
 		const txCol = collection(db, 'users', user.uid, 'transactions');
 		const now = Timestamp.now();

--- a/apps/desktop/src/features/transactions/views/TransactionForm.tsx
+++ b/apps/desktop/src/features/transactions/views/TransactionForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { FiRefreshCw } from 'react-icons/fi';
 import { useMainAccountPreference } from '@cash-flow/shared/accounts/mainAccountPreference';
 import { useTransactionsContext } from '@/features/transactions/context/TransactionsContext';
@@ -47,9 +47,11 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 	const [description, setDescription] = useState('');
 	const [date, setDate] = useState<string>('');
 	const [error, setError] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [selectedRecurringId, setSelectedRecurringId] = useState<string | null>(
 		initialRecurringTransaction?.id || null
 	);
+	const submitInFlightRef = useRef(false);
 
 	const availableCategories = React.useMemo(
 		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
@@ -183,6 +185,8 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
+		if (submitInFlightRef.current) return;
+
 		setError('');
 		if (type === 'transfer' && !transferAccountId) return;
 		const categoryForSubmit =
@@ -198,6 +202,10 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 			setError('Please select a category.');
 			return;
 		}
+
+		submitInFlightRef.current = true;
+		setIsSubmitting(true);
+
 		try {
 			if (transaction && transaction.id) {
 				const data: Partial<Transaction> = {
@@ -239,6 +247,9 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 		} catch (error) {
 			console.error('Failed to submit transaction:', error);
 			setError(error instanceof Error ? error.message : 'Failed to submit transaction.');
+		} finally {
+			submitInFlightRef.current = false;
+			setIsSubmitting(false);
 		}
 	};
 
@@ -288,7 +299,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 					</div>
 				)}
 
-				<form onSubmit={handleSubmit} className="space-y-6">
+				<form onSubmit={handleSubmit} className="space-y-6" aria-busy={isSubmitting}>
 					{error && (
 						<div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
 							{error}
@@ -305,6 +316,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 									type="button"
 									variant={type === t ? 'default' : 'outline'}
 									onClick={() => handleTypeChange(t)}
+									disabled={isSubmitting}
 									className="h-14 rounded-xl capitalize"
 								>
 									{t}
@@ -319,7 +331,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 							<Label htmlFor="transaction-account" className="text-sm font-medium">
 								{type === 'transfer' ? 'From Account' : 'Account'} *
 							</Label>
-							<Select value={accountId} onValueChange={setAccountId}>
+							<Select value={accountId} onValueChange={setAccountId} disabled={isSubmitting}>
 								<SelectTrigger id="transaction-account">
 									<SelectValue placeholder="Select account" />
 								</SelectTrigger>
@@ -346,7 +358,11 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 							<Label htmlFor="transaction-transfer-account" className="text-sm font-medium">
 								To Account *
 							</Label>
-							<Select value={transferAccountId} onValueChange={setTransferAccountId}>
+							<Select
+								value={transferAccountId}
+								onValueChange={setTransferAccountId}
+								disabled={isSubmitting}
+							>
 								<SelectTrigger id="transaction-transfer-account">
 									<SelectValue placeholder="Select destination account" />
 								</SelectTrigger>
@@ -378,6 +394,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								value={title}
 								onChange={(e) => setTitle(e.target.value)}
 								placeholder="Title"
+								disabled={isSubmitting}
 								required
 							/>
 						</div>
@@ -393,6 +410,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								placeholder="Amount"
 								min="0.01"
 								step="0.01"
+								disabled={isSubmitting}
 								required
 							/>
 						</div>
@@ -405,7 +423,11 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								<Label htmlFor="transaction-category" className="text-sm font-medium">
 									Category *
 								</Label>
-								<Select value={category} onValueChange={handleCategoryChange}>
+								<Select
+									value={category}
+									onValueChange={handleCategoryChange}
+									disabled={isSubmitting}
+								>
 									<SelectTrigger id="transaction-category">
 										<SelectValue placeholder="Select category" />
 									</SelectTrigger>
@@ -432,6 +454,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								type="date"
 								value={date}
 								onChange={(e) => setDate(e.target.value)}
+								disabled={isSubmitting}
 							/>
 						</div>
 					</div>
@@ -446,6 +469,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								onValueChange={(value) =>
 									setSubcategory(value === '__none__' ? '' : value)
 								}
+								disabled={isSubmitting}
 							>
 								<SelectTrigger id="transaction-subcategory">
 									<SelectValue placeholder="Select subcategory" />
@@ -475,15 +499,26 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 							onChange={(e) => setDescription(e.target.value)}
 							placeholder="Optional notes"
 							rows={3}
+							disabled={isSubmitting}
 						/>
 					</div>
 
 					{/* Actions */}
 					<div className="flex gap-3 pt-4">
-						<Button type="submit" className="flex-1 h-12" disabled={type === 'transfer' && !transferAccountId}>
-							{transaction ? 'Update Transaction' : 'Add Transaction'}
+						<Button
+							type="submit"
+							className="flex-1 h-12"
+							disabled={isSubmitting || (type === 'transfer' && !transferAccountId)}
+						>
+							{isSubmitting
+								? transaction
+									? 'Updating...'
+									: 'Adding...'
+								: transaction
+									? 'Update Transaction'
+									: 'Add Transaction'}
 						</Button>
-						<Button type="button" variant="outline" onClick={onClose}>
+						<Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
 							Cancel
 						</Button>
 					</div>

--- a/packages/shared/src/hooks/useTransactions.ts
+++ b/packages/shared/src/hooks/useTransactions.ts
@@ -90,13 +90,8 @@ export const useTransactions = () => {
 		if (!user) throw new Error('User not authenticated');
 		if (!data.category.trim()) throw new Error('Category is required.');
 
-		const accountRef = doc(db, 'users', user.uid, 'accounts', data.accountId);
-		const accountSnap = await getDoc(accountRef);
-		if (!accountSnap.exists()) {
-			throw new Error('Account not found.');
-		}
-
 		const batch = writeBatch(db);
+		const accountRef = doc(db, 'users', user.uid, 'accounts', data.accountId);
 
 		const txCol = collection(db, 'users', user.uid, 'transactions');
 		const txRef = doc(txCol);
@@ -128,14 +123,6 @@ export const useTransactions = () => {
 
 		const fromRef = doc(db, 'users', user.uid, 'accounts', data.fromAccountId);
 		const toRef = doc(db, 'users', user.uid, 'accounts', data.toAccountId);
-		const [fromSnap, toSnap] = await Promise.all([
-			getDoc(fromRef),
-			getDoc(toRef),
-		]);
-		if (!fromSnap.exists() || !toSnap.exists()) {
-			throw new Error('Account not found.');
-		}
-
 		const batch = writeBatch(db);
 		const txCol = collection(db, 'users', user.uid, 'transactions');
 		const now = Timestamp.now();


### PR DESCRIPTION
## Summary

Fixes the transaction form behavior where slow saves kept the form open with the submit button still active, allowing duplicate transaction creation.

## What changed

- Added an in-flight submit guard to the transaction form so repeated submits are ignored while a save is pending.
- Disabled form controls during the pending save and changed the primary action text to `Adding...` or `Updating...`.
- Removed extra account pre-read round trips before transaction and transfer writes so Firestore batch commits start sooner while preserving atomic account balance updates.

## Root cause

The form awaited the Firestore write before closing but did not lock the submit path during that await, so users could click submit again before the first save completed.

## Validation

- `npm run build:desktop`
- `npm test -- apps/desktop/src/features/transactions/hooks/__tests__/useTransactions.test.ts --runInBand`