### PR TITLE
Redesign desktop app with premium marketing UI

### DIFF
--- a/.cursor/skills/git-workflow/SKILL.md
+++ b/.cursor/skills/git-workflow/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: git-workflow
+description: >-
+  Branch naming, commit messages, and pull request creation for the cash-flow
+  repo. Use when creating branches, commits, or PRs; when the user asks to
+  open a pull request; or when an agent needs git conventions for this project.
+---
+
+# Git Workflow (cash-flow)
+
+## Base branch
+
+- **Default PR target:** `master`
+- Never force-push to `master`
+- Only create commits when the user explicitly asks
+
+## Branch naming
+
+Format:
+
+```text
+<type>/<short-kebab-description>
+```
+
+### Allowed types
+
+| Type | Use when |
+|------|----------|
+| `feat` | New user-facing capability or meaningful UI/behavior addition |
+| `fix` | Bug fix or regression repair |
+| `chore` | Tooling, deps, CI, config, housekeeping (no user-facing behavior change) |
+| `docs` | Documentation-only changes |
+| `refactor` | Internal restructure with no intended behavior change |
+
+### Rules
+
+- Lowercase, kebab-case after the slash
+- Short but specific (2–5 words)
+- No ticket IDs unless the team already uses them consistently
+- One logical change per branch
+
+### Examples
+
+```text
+feat/premium-dashboard-ui
+feat/mobisite-home-picker
+fix/due-today-layout-overlap
+fix/transaction-form-close
+chore/upgrade-vite
+docs/routes-and-agents
+refactor/extract-marketing-primitives
+```
+
+### Choosing a type
+
+- User-visible new behavior → `feat`
+- Something broken → `fix`
+- README, docs/, skill files, comments only → `docs`
+- Move/rename/simplify code, same behavior → `refactor`
+- package.json scripts, lint config, `.github/` → `chore`
+
+## Commit messages
+
+Prefer imperative, concise subject lines. Optional scope in parentheses.
+
+```text
+<type>(<scope>): <subject>
+
+<optional body — why, not a file list>
+```
+
+Examples:
+
+```text
+feat(dashboard): redesign overview with marketing-style cards
+
+fix(mobisite): show due-today section above widget grid
+
+docs(agents): add git-workflow skill for branch and PR standards
+
+refactor(accounts): extract Currency into marketing components
+
+chore: align jest config with workspace packages
+```
+
+Pass the message via HEREDOC when committing:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(dashboard): add marketing card primitives
+
+Introduce shared Currency and SectionHeader for consistent styling.
+EOF
+)"
+```
+
+## Pull request workflow
+
+Use `gh` for all GitHub tasks. Before opening a PR:
+
+1. `git status` — see untracked/modified files
+2. `git diff` — review staged and unstaged changes
+3. Confirm branch tracks remote and is up to date with `master`
+4. `git log master...HEAD` and `git diff master...HEAD` — full PR scope
+5. Run relevant tests (`npm test`; `tsc` for desktop if TS changed)
+
+### Create branch and push
+
+```bash
+git checkout -b feat/short-description
+# ... work, commit when user asks ...
+git push -u origin HEAD
+```
+
+### PR title
+
+Match the primary change type and scope:
+
+```text
+feat: premium dashboard marketing UI
+fix: recurring due-today layout overlap
+docs: agent git workflow standards
+```
+
+Title case or sentence case is fine; stay consistent within the PR.
+
+### PR body template
+
+```markdown
+## Summary
+- Bullet 1: what changed and why
+- Bullet 2: another logical group of changes
+
+## Test plan
+- [ ] `npm test`
+- [ ] Manual check: <specific route or flow>
+- [ ] Light/dark mode (if UI)
+```
+
+Create with HEREDOC:
+
+```bash
+gh pr create --title "feat: short title" --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+
+EOF
+)"
+```
+
+Return the PR URL when done.
+
+## Pre-PR checklist
+
+- [ ] Branch name uses an allowed `type/` prefix
+- [ ] Commits match the change (don't mix unrelated feat + fix)
+- [ ] No secrets (`.env`, credentials) staged
+- [ ] Tests pass for touched areas
+- [ ] PR summary covers **all** commits on the branch, not only the latest
+- [ ] PR targets `master` unless user specifies otherwise
+
+## Repo context for agents
+
+- **Monorepo:** `apps/desktop`, `apps/mobisite`, `packages/shared`, `packages/ui`
+- **Desktop shell:** `apps/desktop/src/pages/dashboard/`, domain views under `apps/desktop/src/domains/`
+- **Mobile:** `apps/mobisite/src/App.tsx` at `/mobisite`; mobile viewports redirect from dashboard routes
+- **Shared logic:** `packages/shared/src/`
+- **Docs:** start at `docs/PROJECT_CONTEXT.md`, routes in `docs/ROUTES.md`
+- **UI standards:** marketing landing uses raw Tailwind `blue-600` / `gray-*`; app dashboard uses `apps/desktop/src/styles/marketingStyles.ts` and `apps/desktop/src/components/marketing/`
+
+## Additional resources
+
+- Extended examples: [reference.md](reference.md)
+- App architecture: [docs/PROJECT_CONTEXT.md](../../../docs/PROJECT_CONTEXT.md)
+- Routes: [docs/ROUTES.md](../../../docs/ROUTES.md)

--- a/.cursor/skills/git-workflow/reference.md
+++ b/.cursor/skills/git-workflow/reference.md
@@ -1,0 +1,71 @@
+# Git workflow reference
+
+## Branch name → PR title mapping
+
+| Branch | PR title |
+|--------|----------|
+| `feat/premium-dashboard-ui` | `feat: premium dashboard marketing UI` |
+| `fix/mobisite-nav-overlap` | `fix: mobisite nav overlapping content` |
+| `docs/agent-git-standards` | `docs: add agent git workflow skills` |
+| `refactor/shared-date-helpers` | `refactor: consolidate transaction date parsing` |
+| `chore/jest-workspace-config` | `chore: align jest with npm workspaces` |
+
+## Multi-commit PR example
+
+Branch `feat/dashboard-redesign` with commits:
+
+1. `feat(dashboard): add marketing primitives`
+2. `feat(dashboard): restyle shell and overview`
+3. `fix(dashboard): due-today section layout`
+
+PR summary should mention **all three**, not only the latest commit.
+
+## When to split branches
+
+Split into separate PRs when:
+
+- Changes are independently reviewable (e.g. `docs/` vs large `feat/`)
+- One part is blocked or risky
+- User explicitly asks to split
+
+Keep together when:
+
+- Changes are one feature/fix end-to-end
+- Shared types/components are required by the feature in the same PR
+
+## Common mistakes
+
+| Mistake | Correct approach |
+|---------|------------------|
+| `feature/new-ui` | Use `feat/new-ui` |
+| `bugfix-login` | Use `fix/login-redirect` |
+| `updates` | Use specific type + description |
+| PR body lists only latest commit | Summarize full `git diff master...HEAD` |
+| Targeting `develop` | Target `master` for this repo |
+| Commit without user request | Ask or wait for explicit commit instruction |
+
+## Test commands
+
+```bash
+# Full suite
+npm test
+
+# Desktop TypeScript
+cd apps/desktop && npx tsc -p tsconfig.app.json
+
+# Focused tests
+npm test -- --testPathPattern="DashboardOverview|mobisite"
+```
+
+## File locations agents often touch
+
+| Area | Path |
+|------|------|
+| Dashboard shell | `apps/desktop/src/pages/dashboard/` |
+| Marketing primitives | `apps/desktop/src/components/marketing/` |
+| Marketing styles | `apps/desktop/src/styles/marketingStyles.ts` |
+| Domain views | `apps/desktop/src/domains/*/views/` |
+| Mobisite app | `apps/mobisite/src/App.tsx` |
+| Mobisite frame | `apps/desktop/src/pages/mobisite/MobisiteFrame.tsx` |
+| Shared hooks/types | `packages/shared/src/` |
+| Agent skills | `.cursor/skills/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent guide (cash-flow)
+
+Quick context for AI agents working in this repository.
+
+## Start here
+
+1. [docs/PROJECT_CONTEXT.md](docs/PROJECT_CONTEXT.md) — purpose, architecture, data model
+2. [docs/ROUTES.md](docs/ROUTES.md) — `/dashboard`, `/mobisite`, mobile redirects
+3. [.cursor/skills/git-workflow/SKILL.md](.cursor/skills/git-workflow/SKILL.md) — **branch names, commits, PRs**
+
+## Git conventions (summary)
+
+**Branch format:** `<type>/<short-kebab-description>`
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature or user-facing behavior |
+| `fix` | Bug fix |
+| `chore` | Tooling, deps, CI, maintenance |
+| `docs` | Documentation only |
+| `refactor` | Code restructure, same behavior |
+
+**Base branch for PRs:** `master`
+
+**Examples:** `feat/premium-dashboard-ui`, `fix/due-today-layout`, `docs/agent-standards`
+
+Read the full workflow (commit format, PR template, checklist) in [.cursor/skills/git-workflow/SKILL.md](.cursor/skills/git-workflow/SKILL.md).
+
+## Repo layout
+
+```
+apps/desktop/     # Main SPA (dashboard, marketing, mobisite frame)
+apps/mobisite/    # Mobile capture app (mounted at /mobisite)
+packages/shared/  # Firebase, types, hooks, utilities
+packages/ui/      # Shared UI placeholder
+docs/             # Project documentation
+.cursor/skills/   # Agent skills (project-specific)
+```
+
+## Key rules
+
+- Only commit when the user explicitly asks
+- Do not force-push `master`
+- Use `gh` for GitHub (PRs, issues, checks)
+- Run `npm test` before opening PRs when code changed
+- Desktop UI: marketing-style tokens in `apps/desktop/src/styles/marketingStyles.ts`
+- Mobile: authenticated users on viewports `<768px` redirect to `/mobisite`
+
+## Testing
+
+```bash
+npm test
+cd apps/desktop && npx tsc -p tsconfig.app.json
+```
+
+See [docs/TESTING.md](docs/TESTING.md) for manual regression checklist.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Unauthenticated users see the landing page. Authenticated users on mobile-sized 
 
 If you are returning to the project after time away, start with [docs/PROJECT_CONTEXT.md](docs/PROJECT_CONTEXT.md). It is the quick re-entry guide for purpose, architecture boundaries, and important rules.
 
+AI agents should read [AGENTS.md](AGENTS.md) for git branch/PR conventions and [.cursor/skills/git-workflow/SKILL.md](.cursor/skills/git-workflow/SKILL.md) before creating branches or pull requests.
+
 Useful docs:
 
 - [docs/PROJECT_CONTEXT.md](docs/PROJECT_CONTEXT.md) - app purpose, MVP boundaries, architecture map, and product shape.

--- a/apps/desktop/src/components/app/ui/button.tsx
+++ b/apps/desktop/src/components/app/ui/button.tsx
@@ -9,6 +9,8 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+				marketing:
+					'rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-500',
 				destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
 				outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
 				secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/apps/desktop/src/components/marketing/Currency.tsx
+++ b/apps/desktop/src/components/marketing/Currency.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { formatCurrency } from '@/utils/formatCurrency';
+import {
+	balanceNegative,
+	balancePositive,
+	currencyBase,
+	currencyExpense,
+	currencyIncome,
+	currencyNegative,
+	currencyPositive,
+} from '@/styles/marketingStyles';
+
+export type CurrencyTone =
+	| 'default'
+	| 'positive'
+	| 'negative'
+	| 'income'
+	| 'expense'
+	| 'balance-positive'
+	| 'balance-negative';
+
+const toneClasses: Record<CurrencyTone, string> = {
+	default: '',
+	positive: currencyPositive,
+	negative: currencyNegative,
+	income: currencyIncome,
+	expense: currencyExpense,
+	'balance-positive': balancePositive,
+	'balance-negative': balanceNegative,
+};
+
+interface CurrencyProps {
+	amount: number | string;
+	tone?: CurrencyTone;
+	className?: string;
+	showSign?: boolean;
+}
+
+const Currency: React.FC<CurrencyProps> = ({
+	amount,
+	tone = 'default',
+	className,
+	showSign = false,
+}) => {
+	const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+	let display = formatCurrency(amount);
+	if (showSign && numAmount > 0) {
+		display = `+${display}`;
+	}
+
+	return (
+		<span className={cn(currencyBase, toneClasses[tone], className)}>{display}</span>
+	);
+};
+
+export default Currency;

--- a/apps/desktop/src/components/marketing/MarketingCard.tsx
+++ b/apps/desktop/src/components/marketing/MarketingCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { cardSurface } from '@/styles/marketingStyles';
+
+interface MarketingCardProps {
+	children: React.ReactNode;
+	className?: string;
+	header?: React.ReactNode;
+	footer?: React.ReactNode;
+	hover?: boolean;
+}
+
+const MarketingCard: React.FC<MarketingCardProps> = ({
+	children,
+	className,
+	header,
+	footer,
+	hover = true,
+}) => {
+	return (
+		<section
+			className={cn(
+				cardSurface,
+				!hover && 'hover:shadow-sm',
+				'overflow-hidden',
+				className
+			)}
+		>
+			{header && <div className="border-b border-gray-100 bg-gray-50/40 px-5 py-4 dark:border-gray-800 dark:bg-gray-800/20">{header}</div>}
+			<div className={cn(header || footer ? 'p-5' : 'p-5')}>{children}</div>
+			{footer && <div className="border-t border-gray-100 px-5 py-4 dark:border-gray-800">{footer}</div>}
+		</section>
+	);
+};
+
+export default MarketingCard;

--- a/apps/desktop/src/components/marketing/MotionReveal.tsx
+++ b/apps/desktop/src/components/marketing/MotionReveal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+interface MotionRevealProps {
+	children: React.ReactNode;
+	className?: string;
+	delay?: number;
+	duration?: number;
+	y?: number;
+}
+
+const MotionReveal: React.FC<MotionRevealProps> = ({
+	children,
+	className,
+	delay = 0,
+	duration = 0.55,
+	y = 24,
+}) => {
+	return (
+		<motion.div
+			className={cn(className)}
+			initial={{ opacity: 0, y }}
+			whileInView={{ opacity: 1, y: 0 }}
+			viewport={{ once: true, margin: '-40px' }}
+			transition={{ duration, delay, ease: 'easeOut' }}
+		>
+			{children}
+		</motion.div>
+	);
+};
+
+export default MotionReveal;

--- a/apps/desktop/src/components/marketing/SectionHeader.tsx
+++ b/apps/desktop/src/components/marketing/SectionHeader.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { pageSubtitle, pageTitle, pillBadge } from '@/styles/marketingStyles';
+
+interface SectionHeaderProps {
+	badge?: string;
+	title: string;
+	subtitle?: React.ReactNode;
+	actions?: React.ReactNode;
+	className?: string;
+	compact?: boolean;
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({
+	badge,
+	title,
+	subtitle,
+	actions,
+	className,
+	compact = false,
+}) => {
+	return (
+		<header
+			className={cn(
+				'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between',
+				className
+			)}
+		>
+			<div>
+				{badge && <div className={cn(pillBadge, 'mb-4')}>{badge}</div>}
+				<h1
+					className={cn(
+						compact ? 'text-2xl' : pageTitle,
+						badge ? '' : 'mt-0'
+					)}
+				>
+					{title}
+				</h1>
+				{subtitle && (
+					<div className={cn(pageSubtitle, 'mt-1 text-sm')}>{subtitle}</div>
+				)}
+			</div>
+			{actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+		</header>
+	);
+};
+
+export default SectionHeader;

--- a/apps/desktop/src/components/marketing/index.ts
+++ b/apps/desktop/src/components/marketing/index.ts
@@ -1,0 +1,5 @@
+export { default as Currency } from './Currency';
+export type { CurrencyTone } from './Currency';
+export { default as MarketingCard } from './MarketingCard';
+export { default as SectionHeader } from './SectionHeader';
+export { default as MotionReveal } from './MotionReveal';

--- a/apps/desktop/src/domains/accounts/views/AccountsList.tsx
+++ b/apps/desktop/src/domains/accounts/views/AccountsList.tsx
@@ -8,7 +8,9 @@ import {
 	getAccountAvailableBalance,
 	getAccountLiability,
 } from '@/domains/accounts/models/AccountModel';
-import { formatCurrency } from '@/utils/formatCurrency';
+import Currency from '@/components/marketing/Currency';
+import MotionReveal from '@/components/marketing/MotionReveal';
+import SectionHeader from '@/components/marketing/SectionHeader';
 import { Button } from '@/components/app/ui/button';
 import {
 	Dialog,
@@ -18,6 +20,15 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/app/ui/dialog';
+import {
+	cardSurface,
+	cardSurfaceMuted,
+	modalShell,
+	pageBg,
+	sectionLabel,
+} from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
+import { formatCurrency } from '@/utils/formatCurrency';
 import AccountForm from './AccountForm';
 
 const AccountsList: React.FC = () => {
@@ -60,10 +71,33 @@ const AccountsList: React.FC = () => {
 		return <AccountForm onClose={handleCloseForm} account={editingAccount} />;
 	}
 
+	const statCards = [
+		{
+			label: 'Available to Spend',
+			amount: availableBalance,
+			tone: availableBalance >= 0 ? 'balance-positive' : 'balance-negative',
+		},
+		{
+			label: 'Total Assets',
+			amount: netWorth.assets,
+			tone: 'balance-positive' as const,
+		},
+		{
+			label: 'Total Liabilities',
+			amount: netWorth.liabilities,
+			tone: 'balance-negative' as const,
+		},
+		{
+			label: 'Net Worth',
+			amount: netWorth.netWorth,
+			tone: netWorth.netWorth >= 0 ? 'balance-positive' : 'balance-negative',
+		},
+	];
+
 	return (
-		<div className="flex flex-col min-h-screen bg-background">
+		<div className={cn('flex min-h-screen flex-col', pageBg)}>
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-				<DialogContent className="w-[90vw] md:w-full rounded-lg">
+				<DialogContent className={cn('w-[90vw] md:w-full', modalShell)}>
 					<DialogHeader>
 						<DialogTitle>Delete Account</DialogTitle>
 						<DialogDescription>
@@ -72,10 +106,7 @@ const AccountsList: React.FC = () => {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setDeleteDialogOpen(false)}
-						>
+						<Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
 							Cancel
 						</Button>
 						<Button variant="destructive" onClick={handleConfirmDelete}>
@@ -86,79 +117,51 @@ const AccountsList: React.FC = () => {
 			</Dialog>
 
 			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				{/* Page header */}
-				<div className="mb-6 flex items-center justify-between">
-					<div>
-						<h1 className="text-2xl md:text-3xl font-bold tracking-tight">
-							Accounts
-						</h1>
-						<p className="mt-1 text-sm text-muted-foreground">
-							Manage your bank and cash accounts
-						</p>
-					</div>
-					<Button onClick={() => setShowForm(true)}>
-						<FiPlus className="mr-2 h-4 w-4" />
-						Add Account
-					</Button>
-				</div>
+				<SectionHeader
+					title="Accounts"
+					subtitle="Manage your bank and cash accounts"
+					actions={
+						<Button variant="marketing" onClick={() => setShowForm(true)}>
+							<FiPlus className="mr-2 h-4 w-4" />
+							Add Account
+						</Button>
+					}
+					className="mb-6"
+				/>
 
-				{/* Net Worth summary */}
 				<div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-					<div className="rounded-xl border bg-card p-5">
-						<p className="text-sm text-muted-foreground">Available to Spend</p>
-						<p
-							className={`mt-1 text-xl font-bold ${
-								availableBalance >= 0
-									? 'text-green-600 dark:text-green-400'
-									: 'text-red-600 dark:text-red-400'
-							}`}
-						>
-							{formatCurrency(availableBalance)}
-						</p>
-					</div>
-					<div className="rounded-xl border bg-card p-5">
-						<p className="text-sm text-muted-foreground">Total Assets</p>
-						<p className="mt-1 text-xl font-bold text-green-600 dark:text-green-400">
-							{formatCurrency(netWorth.assets)}
-						</p>
-					</div>
-					<div className="rounded-xl border bg-card p-5">
-						<p className="text-sm text-muted-foreground">Total Liabilities</p>
-						<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
-							{formatCurrency(netWorth.liabilities)}
-						</p>
-					</div>
-					<div className="rounded-xl border bg-card p-5">
-						<p className="text-sm text-muted-foreground">Net Worth</p>
-						<p
-							className={`mt-1 text-xl font-bold ${
-								netWorth.netWorth >= 0
-									? 'text-green-600 dark:text-green-400'
-									: 'text-red-600 dark:text-red-400'
-							}`}
-						>
-							{formatCurrency(netWorth.netWorth)}
-						</p>
-					</div>
+					{statCards.map((stat, index) => (
+						<MotionReveal key={stat.label} delay={index * 0.06}>
+							<div className={cn('p-5', cardSurfaceMuted)}>
+								<p className={sectionLabel}>{stat.label}</p>
+								<Currency
+									amount={stat.amount}
+									tone={stat.tone as 'balance-positive' | 'balance-negative'}
+									className="mt-1 text-xl"
+								/>
+							</div>
+						</MotionReveal>
+					))}
 				</div>
 
-				{/* Account grid */}
 				{accounts.length === 0 ? (
-					<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed py-16 text-center">
-						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-							<FiPlus className="h-6 w-6 text-primary" />
+					<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 py-16 text-center dark:border-gray-700">
+						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-950">
+							<FiPlus className="h-6 w-6 text-blue-600 dark:text-blue-400" />
 						</div>
-						<h3 className="text-lg font-semibold">No accounts yet</h3>
-						<p className="mt-1 text-sm text-muted-foreground">
+						<h3 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+							No accounts yet
+						</h3>
+						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 							Add your first account to start tracking balances
 						</p>
-						<Button className="mt-4" onClick={() => setShowForm(true)}>
+						<Button variant="marketing" className="mt-4" onClick={() => setShowForm(true)}>
 							Add Account
 						</Button>
 					</div>
 				) : (
 					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-						{accounts.map((account) => {
+						{accounts.map((account, index) => {
 							const availableAmount = getAccountAvailableBalance(account);
 							const liability = getAccountLiability(account);
 							const displayAmount =
@@ -169,97 +172,93 @@ const AccountsList: React.FC = () => {
 									: account.balance < 0;
 
 							return (
-								<div
-									key={account.id}
-									role="button"
-									tabIndex={0}
-									onClick={() =>
-										account.id && navigate(`/dashboard/accounts/${account.id}`)
-									}
-									onKeyDown={(e) => {
-										if (e.key === 'Enter' || e.key === ' ') {
-											if (account.id) navigate(`/dashboard/accounts/${account.id}`);
-										}
-									}}
-									className="group relative cursor-pointer rounded-2xl border bg-card overflow-hidden transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								>
-									{/* Colour strip */}
+								<MotionReveal key={account.id} delay={index * 0.06}>
 									<div
-										className="h-2 w-full"
-										style={{
-											backgroundColor: account.color ?? '#6366f1',
-										}}
-									/>
-
-									<div className="p-5">
-										<div className="mb-3 flex items-start justify-between">
-											<div className="flex-1 min-w-0">
-												<h3 className="truncate text-base font-semibold">
-													{account.name}
-												</h3>
-												{account.bank && (
-													<p className="text-xs text-muted-foreground truncate">
-														{account.bank}
-													</p>
-												)}
-											</div>
-											<span className="ml-2 flex-shrink-0 rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
-												{ACCOUNT_TYPE_LABELS[account.type]}
-											</span>
-										</div>
-
-										<p
-											className={`text-2xl font-bold ${
-												isNegative
-													? 'text-red-600 dark:text-red-400'
-													: 'text-foreground'
-											}`}
-										>
-											{formatCurrency(displayAmount)}
-										</p>
-
-										<div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-											{isNegative || liability > 0 ? (
-												<FiArrowDownRight className="h-3 w-3 text-red-500" />
-											) : (
-												<FiArrowUpRight className="h-3 w-3 text-green-500" />
-											)}
-											<span>
-												{account.type === 'credit'
-													? liability > 0
-														? `Debt ${formatCurrency(liability)}`
-														: 'Available credit'
-													: 'Available balance'}
-											</span>
-										</div>
-										{account.type === 'credit' && (
-											<p className="mt-1 text-xs text-muted-foreground">
-												Balance {formatCurrency(account.balance)} &#183; Limit{' '}
-												{formatCurrency(account.creditLimit ?? 0)}
-											</p>
-										)}
-									</div>
-
-									{/* Action buttons - visible on hover */}
-									<div className="absolute right-3 top-3 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-										<button
-											onClick={(e) => handleEdit(e, account)}
-											className="rounded-md border bg-background p-1.5 text-muted-foreground shadow-sm transition-colors hover:text-foreground"
-											aria-label="Edit account"
-										>
-											<FiEdit2 className="h-3.5 w-3.5" />
-										</button>
-										<button
-											onClick={(e) =>
-												account.id && handleDeleteClick(e, account.id)
+										role="button"
+										tabIndex={0}
+										onClick={() =>
+											account.id && navigate(`/dashboard/accounts/${account.id}`)
+										}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												if (account.id) navigate(`/dashboard/accounts/${account.id}`);
 											}
-											className="rounded-md border bg-background p-1.5 text-muted-foreground shadow-sm transition-colors hover:text-destructive"
-											aria-label="Delete account"
-										>
-											<FiTrash2 className="h-3.5 w-3.5" />
-										</button>
+										}}
+										className={cn(
+											'group relative cursor-pointer overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600',
+											cardSurface
+										)}
+									>
+										<div
+											className="h-2 w-full"
+											style={{ backgroundColor: account.color ?? '#6366f1' }}
+										/>
+
+										<div className="p-5">
+											<div className="mb-3 flex items-start justify-between">
+												<div className="min-w-0 flex-1">
+													<h3 className="truncate text-base font-semibold text-gray-900 dark:text-gray-50">
+														{account.name}
+													</h3>
+													{account.bank && (
+														<p className="truncate text-xs text-gray-500 dark:text-gray-400">
+															{account.bank}
+														</p>
+													)}
+												</div>
+												<span className="ml-2 flex-shrink-0 rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+													{ACCOUNT_TYPE_LABELS[account.type]}
+												</span>
+											</div>
+
+											<Currency
+												amount={displayAmount}
+												tone={isNegative ? 'balance-negative' : 'default'}
+												className="text-2xl"
+											/>
+
+											<div className="mt-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+												{isNegative || liability > 0 ? (
+													<FiArrowDownRight className="h-3 w-3 text-red-500" />
+												) : (
+													<FiArrowUpRight className="h-3 w-3 text-emerald-500" />
+												)}
+												<span>
+													{account.type === 'credit'
+														? liability > 0
+															? `Debt ${formatCurrency(liability)}`
+															: 'Available credit'
+														: 'Available balance'}
+												</span>
+											</div>
+											{account.type === 'credit' && (
+												<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+													Balance {formatCurrency(account.balance)} · Limit{' '}
+													{formatCurrency(account.creditLimit ?? 0)}
+												</p>
+											)}
+										</div>
+
+										<div className="absolute right-3 top-3 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+											<button
+												onClick={(e) => handleEdit(e, account)}
+												className="rounded-md border border-gray-200 bg-white p-1.5 text-gray-500 shadow-sm transition-colors hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:hover:text-gray-50"
+												aria-label="Edit account"
+											>
+												<FiEdit2 className="h-3.5 w-3.5" />
+											</button>
+											<button
+												onClick={(e) =>
+													account.id && handleDeleteClick(e, account.id)
+												}
+												className="rounded-md border border-gray-200 bg-white p-1.5 text-gray-500 shadow-sm transition-colors hover:text-red-600 dark:border-gray-700 dark:bg-gray-900"
+												aria-label="Delete account"
+											>
+												<FiTrash2 className="h-3.5 w-3.5" />
+											</button>
+										</div>
 									</div>
-								</div>
+								</MotionReveal>
 							);
 						})}
 					</div>

--- a/apps/desktop/src/domains/accounts/views/ReconcileForm.tsx
+++ b/apps/desktop/src/domains/accounts/views/ReconcileForm.tsx
@@ -4,6 +4,8 @@ import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { ACCOUNT_TYPE_LABELS } from '@/domains/accounts/models/AccountModel';
+import { modalShell, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
@@ -83,8 +85,8 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 
 	if (step === 'done') {
 		return (
-			<div className="flex min-h-screen items-center justify-center bg-background p-4">
-				<div className="w-full max-w-md rounded-2xl border bg-card p-8 shadow-xl text-center">
+			<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
+				<div className={cn('w-full max-w-md p-8 text-center', modalShell)}>
 					<div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
 						<FiCheckCircle className="h-7 w-7 text-green-600 dark:text-green-400" />
 					</div>
@@ -116,8 +118,8 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 	}
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4">
-			<div className="w-full max-w-lg rounded-2xl border bg-card p-8 shadow-xl">
+		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
+			<div className={cn('w-full max-w-lg p-8', modalShell)}>
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">Reconcile Account</h2>
 					<p className="mt-1.5 text-sm text-muted-foreground">

--- a/apps/desktop/src/domains/accounts/views/TransferForm.tsx
+++ b/apps/desktop/src/domains/accounts/views/TransferForm.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import { FiArrowRight } from 'react-icons/fi';
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
-import { formatCurrency } from '@/utils/formatCurrency';
+import Currency from '@/components/marketing/Currency';
+import { cardSurfaceInner, modalShell, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
 import { Textarea } from '@/components/app/ui/textarea';
@@ -72,11 +74,11 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 	};
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4">
-			<div className="w-full max-w-lg rounded-2xl border bg-card p-8 shadow-xl">
+		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
+			<div className={cn('w-full max-w-lg p-8', modalShell)}>
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">Transfer Money</h2>
-					<p className="mt-1.5 text-sm text-muted-foreground">
+					<p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
 						Move funds between your accounts
 					</p>
 				</div>
@@ -89,26 +91,28 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 
 				{/* Live transfer summary */}
 				{fromAccount && toAccount && Number(amount) > 0 && (
-					<div className="mb-6 rounded-xl border bg-muted/40 p-4">
+					<div className="mb-6 rounded-xl border border-gray-100 bg-gray-50/60 p-4 dark:border-gray-800 dark:bg-gray-800/40">
 						<div className="flex items-center justify-between gap-3 text-sm">
-							<div className="flex-1 rounded-lg border bg-background p-3 text-center">
-								<p className="text-xs text-muted-foreground mb-1">From</p>
-								<p className="font-semibold truncate">{fromAccount.name}</p>
-								<p className="text-xs text-muted-foreground mt-1">
-									{formatCurrency(fromAccount.balance - Number(amount))}
-								</p>
+							<div className={cn('flex-1 p-3 text-center', cardSurfaceInner)}>
+								<p className="mb-1 text-xs text-gray-500 dark:text-gray-400">From</p>
+								<p className="truncate font-semibold">{fromAccount.name}</p>
+								<Currency
+									amount={fromAccount.balance - Number(amount)}
+									className="mt-1 text-xs"
+								/>
 							</div>
-							<FiArrowRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-							<div className="flex-1 rounded-lg border bg-background p-3 text-center">
-								<p className="text-xs text-muted-foreground mb-1">To</p>
-								<p className="font-semibold truncate">{toAccount.name}</p>
-								<p className="text-xs text-muted-foreground mt-1">
-									{formatCurrency(toAccount.balance + Number(amount))}
-								</p>
+							<FiArrowRight className="h-5 w-5 flex-shrink-0 text-gray-400" />
+							<div className={cn('flex-1 p-3 text-center', cardSurfaceInner)}>
+								<p className="mb-1 text-xs text-gray-500 dark:text-gray-400">To</p>
+								<p className="truncate font-semibold">{toAccount.name}</p>
+								<Currency
+									amount={toAccount.balance + Number(amount)}
+									className="mt-1 text-xs"
+								/>
 							</div>
 						</div>
-						<p className="mt-3 text-center text-sm font-medium text-primary">
-							Transferring {formatCurrency(Number(amount))}
+						<p className="mt-3 text-center text-sm font-medium text-blue-600 dark:text-blue-400">
+							Transferring <Currency amount={Number(amount)} className="text-sm" />
 						</p>
 					</div>
 				)}
@@ -222,7 +226,7 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 
 					{/* Actions */}
 					<div className="flex gap-3 pt-2">
-						<Button type="submit" className="flex-1 h-12" disabled={loading}>
+						<Button type="submit" variant="marketing" className="h-12 flex-1" disabled={loading}>
 							{loading ? 'Transferring...' : 'Complete Transfer'}
 						</Button>
 						<Button type="button" variant="outline" onClick={onClose}>

--- a/apps/desktop/src/domains/ai/components/AIChatbot.tsx
+++ b/apps/desktop/src/domains/ai/components/AIChatbot.tsx
@@ -5,6 +5,8 @@ import { useAIChatController } from '@/domains/ai/controllers/AIChatController';
 import { AIChatMessage } from '@/types';
 import { Button } from '@/components/app/ui/button';
 import { Textarea } from '@/components/app/ui/textarea';
+import { cardSurface, sectionLabel } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 
 const SUGGESTED_PROMPTS = [
 	'How much did I spend on food this month?',
@@ -151,7 +153,7 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 		<div ref={messagesRef} className="flex-1 space-y-3 overflow-y-auto p-4">
 			{messages.length === 0 ? (
 				<div className="space-y-2">
-					<p className="text-xs font-medium text-muted-foreground">Try asking:</p>
+					<p className={sectionLabel}>Try asking</p>
 					<div className="flex flex-wrap gap-2">
 						{SUGGESTED_PROMPTS.map((prompt) => (
 							<Button
@@ -183,13 +185,14 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 						}`}
 					>
 						<div
-							className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+							className={cn(
+								'max-w-[85%] rounded-2xl px-3 py-2 text-sm',
 								message.role === 'user'
-									? 'bg-primary text-primary-foreground'
+									? 'bg-blue-600 text-white'
 									: message.isError
-										? 'border border-destructive/30 bg-destructive/10 text-destructive'
-										: 'bg-muted text-foreground'
-							}`}
+										? 'border border-red-300 bg-red-50 text-red-600 dark:border-red-800 dark:bg-red-950/50 dark:text-red-400'
+										: 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-50'
+							)}
 						>
 							{message.content}
 						</div>
@@ -199,7 +202,7 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 
 			{isLoading && (
 				<div className="flex justify-start">
-					<div className="rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground">
+					<div className="rounded-2xl bg-gray-100 px-3 py-2 text-sm text-gray-500 dark:bg-gray-800 dark:text-gray-400">
 						AI is thinking...
 					</div>
 				</div>
@@ -208,7 +211,7 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 	);
 
 	const renderComposer = () => (
-		<div className="border-t p-3">
+		<div className="border-t border-gray-100 p-3 dark:border-gray-800">
 			<div className="flex items-end gap-2">
 				<Textarea
 					ref={inputRef}
@@ -241,16 +244,18 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 	const renderPanel = (options?: { onClose?: () => void; docked?: boolean }) => (
 		<section
 			aria-label="AI assistant"
-			className={`flex flex-col overflow-hidden border bg-card ${
+			className={cn(
+				'flex flex-col overflow-hidden shadow-2xl',
+				cardSurface,
 				options?.docked
-					? 'h-full min-h-0 rounded-lg'
-					: 'h-[min(32rem,calc(var(--vh-screen)-6rem))] w-[calc(100vw-2rem)] max-w-md rounded-2xl shadow-2xl'
-			}`}
+					? 'h-full min-h-0'
+					: 'h-[min(32rem,calc(var(--vh-screen)-6rem))] w-[calc(100vw-2rem)] max-w-md'
+			)}
 		>
-			<div className="flex items-center justify-between border-b px-4 py-3">
+			<div className="flex items-center justify-between border-b border-gray-100 px-4 py-3 dark:border-gray-800">
 				<div>
-					<h2 className="text-sm font-semibold">AI Assistant</h2>
-					<p className="text-xs text-muted-foreground">
+					<h2 className="text-sm font-semibold text-gray-900 dark:text-gray-50">AI Assistant</h2>
+					<p className="text-xs text-gray-500 dark:text-gray-400">
 						Ask about your spending, accounts, and budgets
 					</p>
 				</div>
@@ -297,8 +302,9 @@ const AIChatbot: React.FC<AIChatbotProps> = ({
 				)}
 				<Button
 					type="button"
+					variant="marketing"
 					size="icon"
-					className="h-12 w-12 rounded-full shadow-xl"
+					className="h-12 w-12 shadow-xl"
 					onClick={() => setIsOpen((prev) => !prev)}
 					aria-label={isOpen ? 'Close AI assistant' : 'Open AI assistant'}
 				>

--- a/apps/desktop/src/domains/ai/components/__tests__/AIChatbot.test.tsx
+++ b/apps/desktop/src/domains/ai/components/__tests__/AIChatbot.test.tsx
@@ -124,7 +124,7 @@ describe('AIChatbot', () => {
 
 		await user.click(screen.getByRole('button', { name: /clear chat/i }));
 		expect(screen.queryByText('You visited KFC 3 times.')).not.toBeInTheDocument();
-		expect(screen.getByText('Try asking:')).toBeInTheDocument();
+		expect(screen.getByText('Try asking')).toBeInTheDocument();
 	});
 
 	it('disables sending and shows auth-required hint when user is missing', async () => {

--- a/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
+++ b/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
@@ -12,6 +12,8 @@ import {
 import { useBudgetsContext } from '@/domains/budgets/context/BudgetsContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { Budget, BudgetProgress, DateRange } from '@/types';
+import { modalShell, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import {
 	filterTransactionsByDateRangeObject,
@@ -32,9 +34,9 @@ import {
 import BudgetForm from './BudgetForm';
 
 const getBarColour = (percent: number): string => {
-	if (percent >= 90) return 'bg-red-500';
-	if (percent >= 70) return 'bg-amber-500';
-	return 'bg-green-500';
+	if (percent >= 90) return 'bg-red-500 dark:bg-red-400';
+	if (percent >= 70) return 'bg-amber-500 dark:bg-amber-400';
+	return 'bg-blue-500 dark:bg-blue-400';
 };
 
 const BudgetsList: React.FC = () => {
@@ -152,9 +154,9 @@ const BudgetsList: React.FC = () => {
 	);
 
 	return (
-		<div className="flex min-h-screen flex-col bg-background">
+		<div className={cn('flex min-h-screen flex-col', pageBg)}>
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-				<DialogContent className="w-[90vw] rounded-lg md:w-full">
+				<DialogContent className={cn('w-[90vw] md:w-full', modalShell)}>
 					<DialogHeader>
 						<DialogTitle>Delete Budget</DialogTitle>
 						<DialogDescription>
@@ -177,7 +179,7 @@ const BudgetsList: React.FC = () => {
 				<div className="mb-6 flex items-center justify-between gap-4">
 					<div>
 						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">Budgets</h1>
-						<p className="mt-1 text-sm text-muted-foreground">
+						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 							Plan draft budgets with live spend, then publish them when the period
 							is ready.
 						</p>
@@ -188,9 +190,9 @@ const BudgetsList: React.FC = () => {
 					</Button>
 				</div>
 
-				<div className="mb-6 rounded-xl border bg-card p-4">
+				<div className="mb-6 rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-4">
 					<div className="mb-3 flex items-center gap-2">
-						<FiCalendar className="h-4 w-4 text-muted-foreground" />
+						<FiCalendar className="h-4 w-4 text-gray-500 dark:text-gray-400" />
 						<p className="text-sm font-medium">Published Budget Period Override</p>
 					</div>
 					<DateRangeFilter
@@ -201,7 +203,7 @@ const BudgetsList: React.FC = () => {
 							setActionError('');
 						}}
 					/>
-					<p className="mt-3 text-xs text-muted-foreground">
+					<p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
 						Published budgets use their published period by default. Choose a range
 						here only when you need to update a published budget comparison period.
 					</p>
@@ -219,29 +221,29 @@ const BudgetsList: React.FC = () => {
 
 				{startedBudgets.length > 0 ? (
 					<div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Planned Total</p>
+						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
+							<p className="text-sm text-gray-500 dark:text-gray-400">Planned Total</p>
 							<p className="mt-1 text-xl font-bold">{formatCurrency(totalPlanned)}</p>
 						</div>
-						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Actual Total</p>
+						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
+							<p className="text-sm text-gray-500 dark:text-gray-400">Actual Total</p>
 							<p className="mt-1 text-xl font-bold">{formatCurrency(totalActual)}</p>
 						</div>
-						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Remaining</p>
+						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
+							<p className="text-sm text-gray-500 dark:text-gray-400">Remaining</p>
 							<p className="mt-1 text-xl font-bold text-green-600 dark:text-green-400">
 								{formatCurrency(totalRemaining)}
 							</p>
 						</div>
-						<div className="rounded-xl border bg-card p-5">
-							<p className="text-sm text-muted-foreground">Over Budget</p>
+						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
+							<p className="text-sm text-gray-500 dark:text-gray-400">Over Budget</p>
 							<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
 								{formatCurrency(totalOverBudget)}
 							</p>
 						</div>
 					</div>
 				) : budgets.length > 0 ? (
-					<div className="mb-8 rounded-xl border border-dashed bg-card px-4 py-5 text-sm text-muted-foreground">
+					<div className="mb-8 rounded-xl border border-dashed bg-card px-4 py-5 text-sm text-gray-500 dark:text-gray-400">
 						No published budgets have an active comparison period yet. Drafts will
 						become active automatically when published.
 					</div>
@@ -249,11 +251,11 @@ const BudgetsList: React.FC = () => {
 
 				{budgets.length === 0 ? (
 					<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed py-16 text-center">
-						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-950">
 							<FiPlus className="h-6 w-6 text-primary" />
 						</div>
 						<h3 className="text-lg font-semibold">No budgets yet</h3>
-						<p className="mt-1 text-sm text-muted-foreground">
+						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 							Create a draft budget to plan a custom period by category
 						</p>
 						<Button className="mt-4" onClick={() => setShowForm(true)}>
@@ -306,11 +308,11 @@ const BudgetsList: React.FC = () => {
 										<div className="flex items-center justify-between border-b pb-2">
 											<div>
 												<h2 className="text-lg font-semibold">Draft Budgets</h2>
-												<p className="text-sm text-muted-foreground">
+												<p className="text-sm text-gray-500 dark:text-gray-400">
 													Plan with live calculations before publishing.
 												</p>
 											</div>
-											<span className="text-sm text-muted-foreground">
+											<span className="text-sm text-gray-500 dark:text-gray-400">
 												{draftCount}
 											</span>
 										</div>
@@ -319,28 +321,28 @@ const BudgetsList: React.FC = () => {
 										<div className="flex items-center justify-between border-b pb-2 pt-4">
 											<div>
 												<h2 className="text-lg font-semibold">Published Budgets</h2>
-												<p className="text-sm text-muted-foreground">
+												<p className="text-sm text-gray-500 dark:text-gray-400">
 													Active budget periods and historical comparisons.
 												</p>
 											</div>
-											<span className="text-sm text-muted-foreground">
+											<span className="text-sm text-gray-500 dark:text-gray-400">
 												{publishedCount}
 											</span>
 										</div>
 									)}
-									<div className="group rounded-2xl border bg-card p-5">
+									<div className="group rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-800 dark:bg-gray-900 p-5">
 										<div className="mb-4 flex items-start justify-between gap-3">
 											<div className="min-w-0 flex-1">
 												<div className="flex items-center gap-2">
 													<h3 className="truncate font-semibold">{label}</h3>
-													<span className="rounded-full border px-2 py-0.5 text-xs capitalize text-muted-foreground">
+													<span className="rounded-full border px-2 py-0.5 text-xs capitalize text-gray-500 dark:text-gray-400">
 														{isDraft ? 'Draft' : 'Published'}
 													</span>
 													{isOverBudget && (
 														<FiAlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
 													)}
 												</div>
-												<p className="mt-0.5 text-xs text-muted-foreground">
+												<p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
 													{isDraft
 														? 'Live draft calculations for the planned period'
 														: 'Published budget tracking'}
@@ -389,7 +391,7 @@ const BudgetsList: React.FC = () => {
 											<Button
 												variant="ghost"
 												size="icon"
-												className="h-8 w-8 opacity-0 transition-opacity text-muted-foreground group-hover:opacity-100 hover:text-destructive"
+												className="h-8 w-8 opacity-0 transition-opacity text-gray-500 dark:text-gray-400 group-hover:opacity-100 hover:text-destructive"
 												onClick={() => budget.id && handleDeleteClick(budget.id)}
 												aria-label="Delete budget"
 											>
@@ -399,27 +401,27 @@ const BudgetsList: React.FC = () => {
 									</div>
 
 									<div className="mb-4 grid gap-3 md:grid-cols-2">
-										<div className="rounded-xl border bg-muted/20 p-3">
+										<div className="rounded-xl border border-gray-100 bg-gray-50/60 dark:border-gray-800 dark:bg-gray-800/40 p-3">
 											<div className="mb-1 flex items-center gap-2">
 												<FiTarget className="h-4 w-4 text-primary" />
-												<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+												<p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
 													Planned
 												</p>
 											</div>
 											<p className="text-lg font-semibold">
 												{formatCurrency(plannedAmount)}
 											</p>
-											<p className="mt-1 text-sm text-muted-foreground">
+											<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 												{formatDateRange({
 													startDate: plannedStartDate,
 													endDate: plannedEndDate,
 												})}
 											</p>
 										</div>
-										<div className="rounded-xl border bg-muted/20 p-3">
+										<div className="rounded-xl border border-gray-100 bg-gray-50/60 dark:border-gray-800 dark:bg-gray-800/40 p-3">
 											<div className="mb-1 flex items-center gap-2">
 												<FiCalendar className="h-4 w-4 text-primary" />
-												<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+												<p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
 													{isDraft ? 'Live Spend' : 'Actual'}
 												</p>
 											</div>
@@ -428,7 +430,7 @@ const BudgetsList: React.FC = () => {
 													<p className="text-lg font-semibold">
 														{formatCurrency(actualSpent)}
 													</p>
-													<p className="mt-1 text-sm text-muted-foreground">
+													<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 														{formatDateRange({
 															startDate: comparisonStartDate,
 															endDate: comparisonEndDate,
@@ -438,7 +440,7 @@ const BudgetsList: React.FC = () => {
 											) : (
 												<>
 													<p className="text-lg font-semibold">Not started</p>
-													<p className="mt-1 text-sm text-muted-foreground">
+													<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 														Use the date filter to set a comparison period.
 													</p>
 												</>
@@ -446,7 +448,7 @@ const BudgetsList: React.FC = () => {
 										</div>
 									</div>
 
-									<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+									<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
 										<div
 											className={`h-full rounded-full transition-all ${barColour}`}
 											style={{ width: `${Math.min(100, percent)}%` }}
@@ -456,14 +458,14 @@ const BudgetsList: React.FC = () => {
 									{calculating ? (
 										<>
 											<div className="flex items-center justify-between text-sm">
-												<span className="text-muted-foreground">
+												<span className="text-gray-500 dark:text-gray-400">
 													{formatCurrency(actualSpent)} actual spend
 												</span>
 												<span
 													className={`font-medium ${
 														isOverBudget
 															? 'text-red-600 dark:text-red-400'
-															: 'text-muted-foreground'
+															: 'text-gray-500 dark:text-gray-400'
 													}`}
 												>
 													{isOverBudget
@@ -472,7 +474,7 @@ const BudgetsList: React.FC = () => {
 													of {formatCurrency(plannedAmount)}
 												</span>
 											</div>
-											<div className="mt-1 text-right text-xs text-muted-foreground">
+											<div className="mt-1 text-right text-xs text-gray-500 dark:text-gray-400">
 												{percent.toFixed(0)}% used
 											</div>
 											<div className="mt-4 border-t pt-4">
@@ -480,7 +482,7 @@ const BudgetsList: React.FC = () => {
 													<h4 className="text-sm font-semibold">
 														Matching Transactions
 													</h4>
-													<span className="text-xs text-muted-foreground">
+													<span className="text-xs text-gray-500 dark:text-gray-400">
 														{matchingTransactions.length}{' '}
 														{matchingTransactions.length === 1
 															? 'transaction'
@@ -488,7 +490,7 @@ const BudgetsList: React.FC = () => {
 													</span>
 												</div>
 												{matchingTransactions.length === 0 ? (
-													<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
+													<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
 														No transactions matched this budget category in the
 														selected period.
 													</div>
@@ -512,7 +514,7 @@ const BudgetsList: React.FC = () => {
 																		<p className="truncate text-sm font-medium">
 																			{transaction.title}
 																		</p>
-																		<p className="text-xs text-muted-foreground">
+																		<p className="text-xs text-gray-500 dark:text-gray-400">
 																			{transactionDate}
 																			{transaction.description
 																				? ` • ${transaction.description}`
@@ -530,7 +532,7 @@ const BudgetsList: React.FC = () => {
 											</div>
 										</>
 									) : (
-										<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
+										<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
 											This budget has a planned amount and period, but no active
 											comparison period yet.
 										</div>

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { FiEdit, FiTrash2, FiPlus, FiDollarSign, FiRefreshCw, FiX, FiSettings } from 'react-icons/fi';
+import { FiEdit, FiTrash2, FiPlus, FiDollarSign, FiX, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { RecurringTransaction } from '@/domains/recurring/models/RecurringTransactionModel';
@@ -21,6 +21,9 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/app/ui/select';
+import SectionHeader from '@/components/marketing/SectionHeader';
+import { cardSurface, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { useFilterPreferences } from '@/shared/filters/context/FilterPreferencesContext';
 import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
@@ -285,69 +288,68 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	if (recurringTransactionsLoading) {
 		return (
 			<div className="flex flex-1 items-center justify-center" aria-live="polite">
-				<div className="text-sm text-muted-foreground">Loading recurring transactions...</div>
+				<div className="text-sm text-gray-500 dark:text-gray-400">Loading recurring transactions...</div>
 			</div>
 		);
 	}
 
 	return (
-		<div className="flex flex-1 flex-col overflow-y-auto p-4 md:p-6 lg:p-8">
-			{/* Header */}
-			<div className="mb-6 flex items-start justify-between gap-4">
-				<div>
-					<div className="flex items-center gap-2">
-						<FiRefreshCw className="h-6 w-6 text-primary" />
-						<h1 className="text-2xl font-bold tracking-tight">Recurring Transactions</h1>
-					</div>
-					<p className="mt-1 text-sm text-muted-foreground">
-						Manage your subscriptions, debit orders, salary, and other recurring transactions.
-					</p>
-				</div>
-				<div className="flex flex-col items-end gap-2">
-					<div
-						className="inline-flex items-center rounded-lg border bg-muted/20 p-1"
-						role="tablist"
-						aria-label="Recurring transactions view mode"
-					>
-						<button
-							type="button"
-							role="tab"
-							aria-selected={viewMode === 'list'}
-							className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-								viewMode === 'list'
-									? 'bg-background text-foreground shadow-sm'
-									: 'text-muted-foreground hover:text-foreground'
-							}`}
-							onClick={() => setViewMode('list')}
+		<div className={cn('flex flex-1 flex-col overflow-y-auto p-4 md:p-6 lg:p-8', pageBg, 'min-h-screen')}>
+			<SectionHeader
+				badge="Recurring"
+				title="Recurring Transactions"
+				subtitle="Manage your subscriptions, debit orders, salary, and other recurring transactions."
+				compact
+				actions={
+					<div className="flex flex-col items-end gap-2">
+						<div
+							className="inline-flex items-center rounded-full border border-gray-200 bg-white p-1 dark:border-gray-800 dark:bg-gray-900"
+							role="tablist"
+							aria-label="Recurring transactions view mode"
 						>
-							List
-						</button>
-						{isDesktopCalendarAllowed && (
 							<button
 								type="button"
 								role="tab"
-								aria-selected={viewMode === 'calendar'}
-								className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-									viewMode === 'calendar'
-										? 'bg-background text-foreground shadow-sm'
-										: 'text-muted-foreground hover:text-foreground'
-								}`}
-								onClick={() => setViewMode('calendar')}
+								aria-selected={viewMode === 'list'}
+								className={cn(
+									'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+									viewMode === 'list'
+										? 'bg-blue-600 text-white shadow-sm'
+										: 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50'
+								)}
+								onClick={() => setViewMode('list')}
 							>
-								Calendar
+								List
 							</button>
-						)}
+							{isDesktopCalendarAllowed && (
+								<button
+									type="button"
+									role="tab"
+									aria-selected={viewMode === 'calendar'}
+									className={cn(
+										'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+										viewMode === 'calendar'
+											? 'bg-blue-600 text-white shadow-sm'
+											: 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50'
+									)}
+									onClick={() => setViewMode('calendar')}
+								>
+									Calendar
+								</button>
+							)}
+						</div>
+						<Button variant="marketing" onClick={handleAddNew} className="flex-shrink-0">
+							<FiPlus className="mr-2 h-4 w-4" />
+							Add New
+						</Button>
 					</div>
-					<Button onClick={handleAddNew} className="flex-shrink-0">
-						<FiPlus className="mr-2 h-4 w-4" />
-						Add New
-					</Button>
-				</div>
-			</div>
+				}
+				className="mb-6"
+			/>
 
 			{/* Filter Bar */}
 			{allFiltersHidden ? (
-				<div className="mb-4 flex items-center gap-2 rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
+				<div className="mb-4 flex items-center gap-2 rounded-lg border border-dashed p-3 text-sm text-gray-500 dark:text-gray-400">
 					<FiSettings className="h-4 w-4 shrink-0" />
 					<span>All filters are hidden.</span>
 					<button
@@ -439,7 +441,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 							variant="ghost"
 							size="sm"
 							onClick={handleResetFilters}
-							className="h-9 gap-1 text-muted-foreground hover:text-foreground"
+							className="h-9 gap-1 text-gray-500 dark:text-gray-400 hover:text-foreground"
 						>
 							<FiX className="h-4 w-4" />
 							Reset
@@ -449,14 +451,14 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 			)}
 
 			{/* Total Summary Card */}
-			<div className="mb-6 rounded-xl border bg-card p-4 shadow-sm">
+			<div className={cn('mb-6 p-4', cardSurface)}>
 				<div className="flex items-center justify-between gap-4">
 					<div className="flex items-center gap-3">
 						<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
 							<FiDollarSign className="h-5 w-5 text-primary" />
 						</div>
 						<div>
-							<p className="text-xs text-muted-foreground">{filterLabel}</p>
+							<p className="text-xs text-gray-500 dark:text-gray-400">{filterLabel}</p>
 							<p className="text-2xl font-bold tracking-tight">
 								{formatCurrency(filteredTotal)}
 							</p>
@@ -472,14 +474,14 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 			{/* Transaction Content */}
 			{filteredTransactions.length === 0 ? (
 				<div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed p-12 text-center">
-					<FiDollarSign className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
-					<p className="font-medium text-muted-foreground">
+					<FiDollarSign className="mx-auto mb-3 h-10 w-10 text-gray-500 dark:text-gray-400/50" />
+					<p className="font-medium text-gray-500 dark:text-gray-400">
 						{hasActiveFilters
 							? 'No transactions match the current filters'
 							: 'No recurring transactions yet'}
 					</p>
 					{!hasActiveFilters && (
-						<p className="mt-1 text-sm text-muted-foreground">
+						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 							Add one to track your subscriptions, debit orders, and income.
 						</p>
 					)}
@@ -500,7 +502,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 						<div
 							key={expense.id}
 							role="listitem"
-							className="flex flex-col gap-3 rounded-xl border bg-card p-4 transition-colors hover:bg-muted/50 sm:flex-row sm:items-center sm:justify-between"
+							className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-900 dark:hover:bg-gray-800/50 sm:flex-row sm:items-center sm:justify-between"
 						>
 							<div className="min-w-0 flex-1">
 								<div className="flex flex-wrap items-center gap-2">
@@ -523,7 +525,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 										</Badge>
 									)}
 								</div>
-								<div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+								<div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
 									<span className="font-medium text-foreground">
 										{formatCurrency(expense.amount)}
 									</span>

--- a/apps/desktop/src/domains/reports/views/ReportsView.tsx
+++ b/apps/desktop/src/domains/reports/views/ReportsView.tsx
@@ -32,6 +32,17 @@ import {
 } from '@/pages/dashboard/utils/digestPeriod';
 import { filterTransactionsByDateRangeObject } from '@/shared/filters/utils/dateRangeFilter';
 import { compareTransactionsByDateDesc } from '@/utils/date';
+import Currency from '@/components/marketing/Currency';
+import SectionHeader from '@/components/marketing/SectionHeader';
+import {
+	cardSurface,
+	cardSurfaceInner,
+	cardSurfaceMuted,
+	pageBg,
+	progressTrack,
+	sectionLabel,
+} from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { useFilterPreferences } from '@/shared/filters/context/FilterPreferencesContext';
 import { Button } from '@/components/app/ui/button';
@@ -255,43 +266,40 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 			: null;
 
 	return (
-		<div className="flex min-h-screen flex-col bg-background">
+		<div className={cn('flex min-h-screen flex-col', pageBg)}>
 			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				<div className="mb-6 flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-					<div>
-						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">
-							Monthly Reports
-						</h1>
-						<p className="mt-1 text-sm text-muted-foreground">
-							A month-first view with visible amounts, category decisions, and account review.
-						</p>
-					</div>
-					<div className="flex flex-wrap items-center gap-2">
-						<div className="inline-flex rounded-lg border bg-card p-1">
+				<SectionHeader
+					title="Monthly Reports"
+					subtitle="A month-first view with visible amounts, category decisions, and account review."
+					actions={
+						<div className="inline-flex rounded-full border border-gray-200 bg-white p-1 dark:border-gray-800 dark:bg-gray-900">
 							{(['expense', 'income', 'net'] as ReportMode[]).map((mode) => (
 								<button
 									key={mode}
 									type="button"
 									onClick={() => setReportMode(mode)}
-									className={`rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors ${reportMode === mode
-										? 'bg-primary text-primary-foreground'
-										: 'text-muted-foreground hover:text-foreground'
-										}`}
+									className={cn(
+										'rounded-full px-3 py-1.5 text-sm font-medium capitalize transition-colors',
+										reportMode === mode
+											? 'bg-blue-600 text-white shadow-sm'
+											: 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50'
+									)}
 								>
 									{mode}
 								</button>
 							))}
 						</div>
-					</div>
-				</div>
+					}
+					className="mb-6"
+				/>
 
 				{reportPrefs.dateRange && (
-					<div className="mb-6 space-y-3 rounded-xl border bg-card p-4">
+					<div className={cn('mb-6 space-y-3 p-4', cardSurface)}>
 						<div className="flex flex-wrap items-center gap-2">
 							<Button type="button" variant="outline" size="icon" onClick={() => moveMonth(-1)}>
 								<FiChevronLeft className="h-4 w-4" />
 							</Button>
-							<div className="min-w-[210px] rounded-lg border bg-background px-4 py-2 text-sm font-semibold">
+							<div className="min-w-[210px] rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-semibold dark:border-gray-800 dark:bg-gray-900">
 								{periodMode === 'month' ? getMonthLabel(selectedMonth) : 'Custom cycle'}
 							</div>
 							<Button type="button" variant="outline" size="icon" onClick={() => moveMonth(1)}>
@@ -302,7 +310,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 							</Button>
 							<Button
 								type="button"
-								variant={periodMode === 'customCycle' ? 'default' : 'outline'}
+								variant={periodMode === 'customCycle' ? 'marketing' : 'outline'}
 								onClick={openCustomCycle}
 							>
 								Custom cycle
@@ -371,11 +379,11 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 				)}
 
 				{!hasVisibleReportSections && (
-					<div className="flex items-center gap-2 rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+					<div className="flex items-center gap-2 rounded-2xl border border-dashed border-gray-200 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
 						<FiSettings className="h-4 w-4 shrink-0" />
 						<span>Reports are hidden.</span>
 						<button
-							className="ml-1 underline underline-offset-2 hover:text-foreground"
+							className="ml-1 underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-50"
 							onClick={() => onOpenSettings?.()}
 						>
 							Manage in Settings
@@ -385,12 +393,10 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 
 				{reportPrefs.summaryCards && (
 					<div className="mb-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-						<div className="rounded-xl border bg-card p-4">
-							<p className="text-xs text-muted-foreground">Monthly expenses</p>
-							<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
-								{formatCurrency(totalExpense)}
-							</p>
-							<p className="text-sm text-muted-foreground">
+						<div className={cn('p-4', cardSurfaceMuted)}>
+							<p className={sectionLabel}>Monthly expenses</p>
+							<Currency amount={totalExpense} tone="expense" className="mt-1 text-xl" />
+							<p className="text-sm text-gray-500 dark:text-gray-400">
 								{
 									filteredTransactions.filter(
 										(transaction) => transaction.type === 'expense'
@@ -399,18 +405,22 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 								transactions
 							</p>
 						</div>
-						<div className="rounded-xl border bg-card p-4">
-							<p className="text-xs text-muted-foreground">Biggest category</p>
-							<p className="mt-1 truncate text-xl font-bold">
+						<div className={cn('p-4', cardSurfaceMuted)}>
+							<p className={sectionLabel}>Biggest category</p>
+							<p className="mt-1 truncate text-xl font-semibold text-gray-900 dark:text-gray-50">
 								{biggestCategory ? getCategoryLabel(biggestCategory.category) : 'None yet'}
 							</p>
-							<p className="text-sm text-muted-foreground">
-								{biggestCategory ? formatCurrency(biggestCategory.amount) : 'No expenses'}
+							<p className="text-sm text-gray-500 dark:text-gray-400">
+								{biggestCategory ? (
+									<Currency amount={biggestCategory.amount} className="text-sm" />
+								) : (
+									'No expenses'
+								)}
 							</p>
 						</div>
-						<div className="rounded-xl border bg-card p-4">
-							<p className="text-xs text-muted-foreground">Biggest subcategory</p>
-							<p className="mt-1 truncate text-xl font-bold">
+						<div className={cn('p-4', cardSurfaceMuted)}>
+							<p className={sectionLabel}>Biggest subcategory</p>
+							<p className="mt-1 truncate text-xl font-semibold text-gray-900 dark:text-gray-50">
 								{biggestSubcategory
 									? getSubcategoryDisplayLabel(
 										biggestSubcategory.category,
@@ -418,22 +428,23 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 									)
 									: 'None yet'}
 							</p>
-							<p className="text-sm text-muted-foreground">
-								{biggestSubcategory ? formatCurrency(biggestSubcategory.amount) : 'No subcategories'}
+							<p className="text-sm text-gray-500 dark:text-gray-400">
+								{biggestSubcategory ? (
+									<Currency amount={biggestSubcategory.amount} className="text-sm" />
+								) : (
+									'No subcategories'
+								)}
 							</p>
 						</div>
-						<div className="rounded-xl border bg-card p-4">
-							<p className="text-xs text-muted-foreground">Net position</p>
-							<p
-								className={`mt-1 text-xl font-bold ${netPosition >= 0
-									? 'text-green-600 dark:text-green-400'
-									: 'text-red-600 dark:text-red-400'
-									}`}
-							>
-								{formatCurrency(netPosition)}
-							</p>
-							<p className="text-sm text-muted-foreground">
-								Income {formatCurrency(totalIncome)}
+						<div className={cn('p-4', cardSurfaceMuted)}>
+							<p className={sectionLabel}>Net position</p>
+							<Currency
+								amount={netPosition}
+								tone={netPosition >= 0 ? 'balance-positive' : 'balance-negative'}
+								className="mt-1 text-xl"
+							/>
+							<p className="text-sm text-gray-500 dark:text-gray-400">
+								Income <Currency amount={totalIncome} tone="income" className="text-sm" />
 							</p>
 						</div>
 					</div>
@@ -441,11 +452,11 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 
 				<div className="mb-6 grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.65fr)]">
 					{reportPrefs.categoryBreakdown && (
-						<div className="rounded-2xl border bg-card p-5">
+						<div className={cn('p-5', cardSurface)}>
 							<div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
 								<div>
 									<h2 className="text-base font-semibold">Monthly category breakdown</h2>
-									<p className="text-sm text-muted-foreground">
+									<p className="text-sm text-gray-500 dark:text-gray-400">
 										Amounts are visible first. Select a category to inspect the month.
 									</p>
 								</div>
@@ -473,8 +484,12 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 										return (
 											<div
 												key={category.category}
-												className={`rounded-xl border p-3 transition-colors ${isSelected ? 'border-primary bg-muted/50' : 'bg-background'
-													}`}
+												className={cn(
+													'rounded-xl border p-3 transition-colors',
+													isSelected
+														? 'border-blue-600 bg-blue-50 dark:border-blue-500 dark:bg-blue-950/50'
+														: cardSurfaceInner
+												)}
 											>
 												<button
 													type="button"
@@ -492,7 +507,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 																	{getCategoryLabel(category.category)}
 																</span>
 															</div>
-															<div className="mt-2 h-2 rounded-full bg-muted">
+															<div className={cn('mt-2 h-2 rounded-full', progressTrack)}>
 																<div
 																	className="h-2 rounded-full"
 																	style={{
@@ -502,14 +517,14 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 																/>
 															</div>
 														</div>
-														<div className="text-sm text-muted-foreground">
+														<div className="text-sm text-gray-500 dark:text-gray-400">
 															{category.percentage.toFixed(0)}%
 														</div>
-														<div className="text-sm text-muted-foreground">
+														<div className="text-sm text-gray-500 dark:text-gray-400">
 															{category.transactionCount} tx
 														</div>
 														<div className="text-right">
-															<div className="font-bold">{formatCurrency(category.amount)}</div>
+															<Currency amount={category.amount} className="text-base" />
 															<div className={`text-xs ${deltaTone}`}>
 																{category.deltaAmount === 0
 																	? 'No change'
@@ -533,8 +548,12 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 																			current === subcategoryKey ? null : subcategoryKey
 																		)
 																	}
-																	className={`grid w-full gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center ${isSubSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'
-																		}`}
+																	className={cn(
+																		'grid w-full gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center',
+																		isSubSelected
+																			? 'bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400'
+																			: 'hover:bg-gray-50 dark:hover:bg-gray-800/50'
+																	)}
 																>
 																	<span className="truncate">
 																		{getSubcategoryDisplayLabel(
@@ -542,15 +561,13 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 																			subcategory.subcategory
 																		)}
 																	</span>
-																	<span className="text-muted-foreground">
+																	<span className="text-gray-500 dark:text-gray-400">
 																		{subcategory.percentage.toFixed(0)}%
 																	</span>
-																	<span className="text-muted-foreground">
+																	<span className="text-gray-500 dark:text-gray-400">
 																		{subcategory.transactionCount} tx
 																	</span>
-																	<span className="font-semibold">
-																		{formatCurrency(subcategory.amount)}
-																	</span>
+																	<Currency amount={subcategory.amount} className="text-sm" />
 																</button>
 															);
 														})}
@@ -561,7 +578,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 									})}
 								</div>
 							) : (
-								<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+								<div className="flex h-40 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
 									No expense data for this period
 								</div>
 							)}
@@ -570,7 +587,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 
 					<div className="space-y-6">
 						{reportPrefs.subcategoryBreakdown && (
-							<div className="rounded-2xl border bg-card p-5">
+							<div className={cn('p-5', cardSurface)}>
 								<h2 className="text-base font-semibold">
 									{selectedSubcategoryLabel ??
 										(selectedCategory
@@ -588,24 +605,26 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 											{focusedTransactions.map((transaction) => (
 												<div
 													key={transaction.id}
-													className="rounded-lg border bg-background px-3 py-2 text-sm"
+													className={cn('rounded-xl px-3 py-2 text-sm', cardSurfaceInner)}
 												>
 													<div className="flex items-center justify-between gap-3">
 														<div className="min-w-0">
 															<div className="truncate font-medium">{transaction.title}</div>
-															<div className="text-xs text-muted-foreground">
+															<div className="text-xs text-gray-500 dark:text-gray-400">
 																{formatDate(transaction)} · {accountNameMap[transaction.accountId] ?? 'Unknown account'}
 															</div>
 														</div>
-														<div className="shrink-0 font-semibold text-red-600 dark:text-red-400">
-															{formatCurrency(transaction.amount)}
-														</div>
+														<Currency
+															amount={transaction.amount}
+															tone="expense"
+															className="shrink-0 text-sm"
+														/>
 													</div>
 												</div>
 											))}
 										</div>
 									) : (
-										<div className="flex h-28 items-center justify-center text-center text-sm text-muted-foreground">
+										<div className="flex h-28 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-400">
 											No focused transactions yet.
 										</div>
 									)}
@@ -614,52 +633,45 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 						)}
 
 						{reportPrefs.accountActivity && (
-							<div className="rounded-2xl border bg-card p-5">
+							<div className={cn('p-5', cardSurface)}>
 								<h2 className="mb-4 text-base font-semibold">Monthly account review</h2>
 								{accountSummaries.length > 0 ? (
 									<div className="space-y-3">
 										{accountSummaries.map((account) => (
-											<div key={account.accountId} className="rounded-xl border bg-background p-3">
+											<div key={account.accountId} className={cn('rounded-xl p-3', cardSurfaceInner)}>
 												<div className="mb-3 flex items-center gap-2">
 													<span
 														className="h-2.5 w-2.5 rounded-full"
 														style={{ backgroundColor: account.color }}
 													/>
 													<span className="font-semibold">{account.accountName}</span>
-													<span className="ml-auto text-xs text-muted-foreground">
+													<span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
 														{account.transactionCount} tx
 													</span>
 												</div>
 												<div className="grid grid-cols-3 gap-2 text-sm">
 													<div>
-														<p className="text-xs text-muted-foreground">Income</p>
-														<p className="font-semibold text-green-600 dark:text-green-400">
-															{formatCurrency(account.income)}
-														</p>
+														<p className={sectionLabel}>Income</p>
+														<Currency amount={account.income} tone="income" className="text-sm" />
 													</div>
 													<div>
-														<p className="text-xs text-muted-foreground">Expense</p>
-														<p className="font-semibold text-red-600 dark:text-red-400">
-															{formatCurrency(account.expense)}
-														</p>
+														<p className={sectionLabel}>Expense</p>
+														<Currency amount={account.expense} tone="expense" className="text-sm" />
 													</div>
 													<div>
-														<p className="text-xs text-muted-foreground">Net</p>
-														<p
-															className={`font-semibold ${account.net >= 0
-																? 'text-green-600 dark:text-green-400'
-																: 'text-red-600 dark:text-red-400'
-																}`}
-														>
-															{formatCurrency(account.net)}
-														</p>
+														<p className={sectionLabel}>Net</p>
+														<Currency
+															amount={account.net}
+															tone={account.net >= 0 ? 'balance-positive' : 'balance-negative'}
+															className="text-sm"
+														/>
 													</div>
 												</div>
 											</div>
 										))}
 									</div>
 								) : (
-									<div className="flex h-28 items-center justify-center text-sm text-muted-foreground">
+									<div className="flex h-28 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
 										No account activity for this period
 									</div>
 								)}
@@ -670,7 +682,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 
 				<div className="grid gap-6 xl:grid-cols-2">
 					{reportPrefs.incomeExpenseTrend && (
-						<div className="rounded-2xl border bg-card p-5">
+						<div className={cn('p-5', cardSurface)}>
 							<div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 								<h2 className="text-base font-semibold">6-Month Money Movement</h2>
 								<p className="text-sm text-muted-foreground">
@@ -686,12 +698,12 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 									<AreaChart data={monthlyTrend} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
 										<defs>
 											<linearGradient id="incomeGrad" x1="0" y1="0" x2="0" y2="1">
-												<stop offset="5%" stopColor="#22c55e" stopOpacity={0.25} />
-												<stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+												<stop offset="5%" stopColor="#3b82f6" stopOpacity={0.25} />
+												<stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
 											</linearGradient>
 											<linearGradient id="expenseGrad" x1="0" y1="0" x2="0" y2="1">
-												<stop offset="5%" stopColor="#ef4444" stopOpacity={0.25} />
-												<stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+												<stop offset="5%" stopColor="#6366f1" stopOpacity={0.2} />
+												<stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
 											</linearGradient>
 										</defs>
 										<CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -700,18 +712,18 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 										<Tooltip formatter={(value: number) => formatCurrency(value)} contentStyle={{ borderRadius: '8px', fontSize: '12px' }} />
 										<Legend />
 										{reportMode !== 'expense' && (
-											<Area type="monotone" dataKey="income" name="Income" stroke="#22c55e" fill="url(#incomeGrad)" strokeWidth={2} />
+											<Area type="monotone" dataKey="income" name="Income" stroke="#3b82f6" fill="url(#incomeGrad)" strokeWidth={2} />
 										)}
 										{reportMode !== 'income' && (
-											<Area type="monotone" dataKey="expense" name="Expenses" stroke="#ef4444" fill="url(#expenseGrad)" strokeWidth={2} />
+											<Area type="monotone" dataKey="expense" name="Expenses" stroke="#6366f1" fill="url(#expenseGrad)" strokeWidth={2} />
 										)}
 										{reportMode === 'net' && (
-											<Line type="monotone" dataKey="net" name="Net" stroke="#0ea5e9" strokeWidth={2} dot={false} />
+											<Line type="monotone" dataKey="net" name="Net" stroke="#2563eb" strokeWidth={2} dot={false} />
 										)}
 									</AreaChart>
 								</ResponsiveContainer>
 							) : (
-								<div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+								<div className="flex h-40 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
 									No transaction data available
 								</div>
 							)}
@@ -719,31 +731,24 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onOpenSettings }) => {
 					)}
 
 					{reportPrefs.netWorth && accounts.length > 0 && (
-						<div className="rounded-2xl border bg-card p-5">
+						<div className={cn('p-5', cardSurface)}>
 							<h2 className="mb-4 text-base font-semibold">Net Worth Breakdown</h2>
 							<div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
 								<div>
-									<p className="mb-1 text-xs text-muted-foreground">Assets</p>
-									<p className="text-xl font-bold text-green-600 dark:text-green-400">
-										{formatCurrency(netWorth.assets)}
-									</p>
+									<p className={cn(sectionLabel, 'mb-1')}>Assets</p>
+									<Currency amount={netWorth.assets} tone="balance-positive" className="text-xl" />
 								</div>
 								<div>
-									<p className="mb-1 text-xs text-muted-foreground">Liabilities</p>
-									<p className="text-xl font-bold text-red-600 dark:text-red-400">
-										{formatCurrency(netWorth.liabilities)}
-									</p>
+									<p className={cn(sectionLabel, 'mb-1')}>Liabilities</p>
+									<Currency amount={netWorth.liabilities} tone="balance-negative" className="text-xl" />
 								</div>
 								<div>
-									<p className="mb-1 text-xs text-muted-foreground">Net Worth</p>
-									<p
-										className={`text-xl font-bold ${netWorth.netWorth >= 0
-											? 'text-green-600 dark:text-green-400'
-											: 'text-red-600 dark:text-red-400'
-											}`}
-									>
-										{formatCurrency(netWorth.netWorth)}
-									</p>
+									<p className={cn(sectionLabel, 'mb-1')}>Net Worth</p>
+									<Currency
+										amount={netWorth.netWorth}
+										tone={netWorth.netWorth >= 0 ? 'balance-positive' : 'balance-negative'}
+										className="text-xl"
+									/>
 								</div>
 							</div>
 						</div>

--- a/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
+++ b/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
@@ -18,6 +18,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/app/ui/select';
+import { modalShell, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
 
@@ -256,14 +258,14 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 	const availableTransferAccounts = accounts.filter((a) => a.id !== accountId);
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4">
-			<div className="w-full max-w-2xl rounded-2xl border bg-card p-8 shadow-xl backdrop-blur-sm">
+		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
+			<div className={cn('w-full max-w-2xl p-8 backdrop-blur-sm', modalShell)}>
 				{/* Header */}
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">
 						{transaction ? 'Edit Transaction' : 'New Transaction'}
 					</h2>
-					<p className="mt-1.5 text-sm text-muted-foreground">
+					<p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
 						{transaction
 							? 'Update your transaction details'
 							: 'Add a new income, expense, or transfer'}
@@ -272,9 +274,9 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 
 				{/* Recurring – Smart Autofill */}
 				{!transaction && recurringTransactions.length > 0 && (
-					<div className="mb-8 rounded-xl border border-dashed bg-muted/40 p-4">
+					<div className="mb-8 rounded-xl border border-dashed border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700 dark:bg-gray-800/40">
 						<div className="mb-3 flex items-center gap-2 text-sm font-medium">
-							<FiRefreshCw className="h-4 w-4 text-primary" />
+							<FiRefreshCw className="h-4 w-4 text-blue-600 dark:text-blue-400" />
 							<Label htmlFor="quick-fill">Quick fill from a recurring expense</Label>
 						</div>
 						<Select
@@ -314,10 +316,10 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 								<Button
 									key={t}
 									type="button"
-									variant={type === t ? 'default' : 'outline'}
+									variant={type === t ? 'marketing' : 'outline'}
 									onClick={() => handleTypeChange(t)}
 									disabled={isSubmitting}
-									className="h-14 rounded-xl capitalize"
+									className="h-14 rounded-2xl capitalize"
 								>
 									{t}
 								</Button>
@@ -507,7 +509,8 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 					<div className="flex gap-3 pt-4">
 						<Button
 							type="submit"
-							className="flex-1 h-12"
+							variant="marketing"
+							className="h-12 flex-1"
 							disabled={isSubmitting || (type === 'transfer' && !transferAccountId)}
 						>
 							{isSubmitting

--- a/apps/desktop/src/domains/transactions/views/TransactionsTable.tsx
+++ b/apps/desktop/src/domains/transactions/views/TransactionsTable.tsx
@@ -5,6 +5,15 @@ import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import DateRangeFilter from '@/shared/filters/components/DateRangeFilter';
 import { filterTransactionsByDateRangeObject } from '@/shared/filters/utils/dateRangeFilter';
+import Currency from '@/components/marketing/Currency';
+import SectionHeader from '@/components/marketing/SectionHeader';
+import {
+	cardSurface,
+	frostedPanel,
+	pageBg,
+	selectedRow,
+} from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { DateRange, Transaction } from '@/types';
 import { compareTransactionsByDateDesc, getTransactionDateOrEpoch } from '@/utils/date';
@@ -259,29 +268,27 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 				: `Amount (Total Expense: ${formatCurrency(totals.totalExpense)})`;
 
 	return (
-		<div className="flex flex-col gap-6 p-4 md:p-6">
-			{/* Prompt-style Header */}
-			<div className="flex flex-col gap-1">
-				<h2 className="text-xl font-semibold tracking-tight">Transaction history</h2>
-				<p className="text-sm text-muted-foreground">
-					Search, filter, and review your activity.
-				</p>
-			</div>
+		<div className={cn('flex flex-col gap-6 p-4 md:p-6', pageBg, 'min-h-screen')}>
+			<SectionHeader
+				title="Transaction history"
+				subtitle="Search, filter, and review your activity."
+				compact
+			/>
 
 			{/* Control Bar */}
 			{allFiltersHidden ? (
-				<div className="flex items-center gap-2 rounded-2xl border border-dashed p-3 text-sm text-muted-foreground">
+				<div className="flex items-center gap-2 rounded-2xl border border-dashed border-gray-200 p-3 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
 					<FiSettings className="h-4 w-4 shrink-0" />
 					<span>All filters are hidden.</span>
 					<button
-						className="ml-1 underline underline-offset-2 hover:text-foreground"
+						className="ml-1 underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-50"
 						onClick={() => onOpenSettings?.()}
 					>
 						Manage in Settings
 					</button>
 				</div>
 			) : (
-				<div className="flex flex-wrap items-center gap-2 rounded-2xl border bg-card p-3">
+				<div className={cn('flex flex-wrap items-center gap-2 rounded-2xl p-3', frostedPanel)}>
 					{tablePrefs.search && (
 						<Input
 							placeholder="Search transactions…"
@@ -385,7 +392,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
 			{selectedCount > 0 && (
 				<div
-					className="flex flex-wrap items-center gap-3 rounded-2xl border bg-muted/40 p-3"
+					className="flex flex-wrap items-center gap-3 rounded-2xl border border-gray-200 bg-blue-50/50 p-3 dark:border-gray-800 dark:bg-blue-950/30"
 					onClick={(event) => event.stopPropagation()}
 				>
 					<div className="text-sm font-medium">
@@ -409,6 +416,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 					</Select>
 					<Button
 						type="button"
+						variant="marketing"
 						onClick={handleApplyBulkCategory}
 						disabled={!selectedBulkCategory || isBulkSaving}
 					>
@@ -426,13 +434,13 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 			)}
 
 			{/* Table Surface */}
-			<div className="rounded-2xl border bg-card">
+			<div className={cardSurface}>
 				<div
 					className="relative max-h-[calc(var(--vh-screen)-220px)] overflow-auto"
 					onScroll={handleScroll}
 				>
 					<Table>
-						<TableHeader className="sticky top-0 z-10 bg-card/80 backdrop-blur">
+						<TableHeader className="sticky top-0 z-10 bg-white/80 backdrop-blur dark:bg-gray-900/80">
 							<TableRow className="hover:bg-transparent">
 								<TableHead className="w-12">
 									<input
@@ -463,8 +471,12 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 								<TableRow
 									key={tx.id}
 									onClick={() => onSelect(tx)}
-									className={`cursor-pointer transition-colors ${tx.id === selectedId ? 'bg-muted' : 'hover:bg-muted/40'
-										}`}
+									className={cn(
+										'cursor-pointer transition-colors',
+										tx.id === selectedId
+											? selectedRow
+											: 'hover:bg-gray-50/80 dark:hover:bg-gray-800/30'
+									)}
 								>
 									<TableCell>
 										<input
@@ -481,21 +493,20 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 									</TableCell>
 									<TableCell>
 										<div className="font-medium">{tx.title}</div>
-										<div className="text-xs text-muted-foreground">
+										<div className="text-xs text-gray-500 dark:text-gray-400">
 											{tx.type}
 										</div>
 									</TableCell>
 
-									<TableCell
-										className={`text-right font-medium ${tx.type === 'income'
-											? 'text-green-600 dark:text-green-400'
-											: 'text-red-600 dark:text-red-400'
-											}`}
-									>
-										{formatCurrency(tx.amount)}
+									<TableCell className="text-right">
+										<Currency
+											amount={tx.amount}
+											tone={tx.type === 'income' ? 'income' : 'expense'}
+											className="text-sm"
+										/>
 									</TableCell>
 
-									<TableCell className="text-right text-sm text-muted-foreground">
+									<TableCell className="text-right text-sm text-gray-500 dark:text-gray-400">
 										{(() => {
 											return getTransactionDateOrEpoch(
 												tx.date,
@@ -544,7 +555,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 													? 'No transactions yet'
 													: 'Nothing to show'}
 											</div>
-											<div className="text-sm text-muted-foreground">
+											<div className="text-sm text-gray-500 dark:text-gray-400">
 												{transactions.length === 0
 													? hasNoAccounts
 														? 'Create an account first, then transactions will appear here.'

--- a/apps/desktop/src/pages/accounts/AccountDetail.tsx
+++ b/apps/desktop/src/pages/accounts/AccountDetail.tsx
@@ -16,12 +16,22 @@ import {
 	getAccountAvailableBalance,
 	getAccountLiability,
 } from '@/domains/accounts/models/AccountModel';
-import { formatCurrency } from '@/utils/formatCurrency';
-import { parseDbDate } from '@/utils/date';
+import Currency from '@/components/marketing/Currency';
 import { Button } from '@/components/app/ui/button';
 import AccountForm from '@/domains/accounts/views/AccountForm';
 import TransferForm from '@/domains/accounts/views/TransferForm';
 import ReconcileForm from '@/domains/accounts/views/ReconcileForm';
+import {
+	cardSurface,
+	currencyBase,
+	currencyExpense,
+	pageBg,
+	rowDivider,
+	sectionLabel,
+} from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
+import { formatCurrency } from '@/utils/formatCurrency';
+import { parseDbDate } from '@/utils/date';
 
 type SubView = 'detail' | 'edit' | 'transfer' | 'reconcile';
 
@@ -62,9 +72,7 @@ const AccountDetailPage: React.FC = () => {
 	}, [accountTransactions]);
 
 	if (subView === 'edit' && account) {
-		return (
-			<AccountForm account={account} onClose={() => setSubView('detail')} />
-		);
+		return <AccountForm account={account} onClose={() => setSubView('detail')} />;
 	}
 	if (subView === 'transfer') {
 		return <TransferForm onClose={() => setSubView('detail')} />;
@@ -75,13 +83,15 @@ const AccountDetailPage: React.FC = () => {
 
 	if (!account) {
 		return (
-			<div className="flex min-h-screen items-center justify-center bg-background p-4">
+			<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
 				<div className="text-center">
-					<h2 className="text-xl font-semibold mb-2">Account not found</h2>
-					<p className="text-muted-foreground mb-4">
+					<h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-gray-50">
+						Account not found
+					</h2>
+					<p className="mb-4 text-gray-500 dark:text-gray-400">
 						This account may have been deleted.
 					</p>
-					<Button onClick={() => navigate('/dashboard')}>
+					<Button variant="marketing" onClick={() => navigate('/dashboard')}>
 						Back to Dashboard
 					</Button>
 				</div>
@@ -93,19 +103,17 @@ const AccountDetailPage: React.FC = () => {
 	const liability = getAccountLiability(account);
 
 	return (
-		<div className="flex flex-col min-h-screen bg-background">
+		<div className={cn('flex min-h-screen flex-col', pageBg)}>
 			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				{/* Back button */}
 				<button
 					onClick={() => navigate('/dashboard')}
-					className="mb-6 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+					className="mb-6 flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50"
 				>
 					<FiArrowLeft className="h-4 w-4" />
 					Back to Dashboard
 				</button>
 
-				{/* Account header */}
-				<div className="mb-6 rounded-2xl border bg-card overflow-hidden">
+				<div className={cn('mb-6 overflow-hidden', cardSurface)}>
 					<div
 						className="h-3 w-full"
 						style={{ backgroundColor: account.color ?? '#6366f1' }}
@@ -113,37 +121,25 @@ const AccountDetailPage: React.FC = () => {
 					<div className="p-6">
 						<div className="flex items-start justify-between gap-4">
 							<div>
-								<h1 className="text-2xl font-bold tracking-tight">
+								<h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-50">
 									{account.name}
 								</h1>
-								<div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+								<div className="mt-1 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
 									{account.bank && <span>{account.bank}</span>}
-									{account.bank && <span>&#183;</span>}
+									{account.bank && <span>·</span>}
 									<span>{ACCOUNT_TYPE_LABELS[account.type]}</span>
 								</div>
 							</div>
 							<div className="flex gap-2">
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setSubView('reconcile')}
-								>
+								<Button variant="outline" size="sm" className="rounded-full" onClick={() => setSubView('reconcile')}>
 									<FiRefreshCw className="mr-1.5 h-3.5 w-3.5" />
 									Reconcile
 								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setSubView('transfer')}
-								>
+								<Button variant="outline" size="sm" className="rounded-full" onClick={() => setSubView('transfer')}>
 									<FiRepeat className="mr-1.5 h-3.5 w-3.5" />
 									Transfer
 								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setSubView('edit')}
-								>
+								<Button variant="outline" size="sm" className="rounded-full" onClick={() => setSubView('edit')}>
 									<FiEdit2 className="mr-1.5 h-3.5 w-3.5" />
 									Edit
 								</Button>
@@ -152,84 +148,61 @@ const AccountDetailPage: React.FC = () => {
 
 						<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
 							<div>
-								<p className="text-xs text-muted-foreground mb-1">
-									Current Balance
-								</p>
-								<p
-									className={`text-2xl font-bold ${
-										account.balance < 0
-											? 'text-red-600 dark:text-red-400'
-											: 'text-foreground'
-									}`}
-								>
-									{formatCurrency(account.balance)}
-								</p>
+								<p className={cn(sectionLabel, 'mb-1')}>Current Balance</p>
+								<Currency
+									amount={account.balance}
+									tone={account.balance < 0 ? 'balance-negative' : 'default'}
+									className="text-2xl"
+								/>
 							</div>
 							<div>
-								<p className="text-xs text-muted-foreground mb-1">
-									{account.type === 'credit'
-										? 'Available Credit'
-										: 'Available Balance'}
+								<p className={cn(sectionLabel, 'mb-1')}>
+									{account.type === 'credit' ? 'Available Credit' : 'Available Balance'}
 								</p>
-								<p
-									className={`text-xl font-semibold ${
-										availableBalance < 0
-											? 'text-red-600 dark:text-red-400'
-											: 'text-green-600 dark:text-green-400'
-									}`}
-								>
-									{formatCurrency(availableBalance)}
-								</p>
+								<Currency
+									amount={availableBalance}
+									tone={availableBalance < 0 ? 'balance-negative' : 'balance-positive'}
+									className="text-xl"
+								/>
 								{account.type === 'credit' && (
-									<p className="mt-1 text-xs text-muted-foreground">
+									<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
 										Limit {formatCurrency(account.creditLimit ?? 0)}
 									</p>
 								)}
 							</div>
 							{account.type === 'credit' && (
 								<div>
-									<p className="text-xs text-muted-foreground mb-1">Debt</p>
-									<p
-										className={`text-xl font-semibold ${
-											liability > 0
-												? 'text-red-600 dark:text-red-400'
-												: 'text-foreground'
-										}`}
-									>
-										{formatCurrency(liability)}
-									</p>
+									<p className={cn(sectionLabel, 'mb-1')}>Debt</p>
+									<Currency
+										amount={liability}
+										tone={liability > 0 ? 'balance-negative' : 'default'}
+										className="text-xl"
+									/>
 								</div>
 							)}
 							<div>
-								<p className="text-xs text-muted-foreground mb-1">
-									Total Income
-								</p>
-								<p className="text-xl font-semibold text-green-600 dark:text-green-400">
-									{formatCurrency(totals.income)}
-								</p>
+								<p className={cn(sectionLabel, 'mb-1')}>Total Income</p>
+								<Currency amount={totals.income} tone="income" className="text-xl" />
 							</div>
 							<div>
-								<p className="text-xs text-muted-foreground mb-1">
-									Total Expenses
-								</p>
-								<p className="text-xl font-semibold text-red-600 dark:text-red-400">
-									{formatCurrency(totals.expense)}
-								</p>
+								<p className={cn(sectionLabel, 'mb-1')}>Total Expenses</p>
+								<Currency amount={totals.expense} tone="expense" className="text-xl" />
 							</div>
 						</div>
 					</div>
 				</div>
 
-				{/* Transactions */}
 				<div>
-					<h2 className="mb-4 text-lg font-semibold">Transactions</h2>
+					<h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-50">
+						Transactions
+					</h2>
 					{accountTransactions.length === 0 ? (
-						<div className="rounded-2xl border border-dashed py-12 text-center text-sm text-muted-foreground">
+						<div className="rounded-2xl border border-dashed border-gray-200 py-12 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
 							No transactions for this account yet
 						</div>
 					) : (
-						<div className="space-y-2">
-							{accountTransactions.map((tx) => {
+						<div className={cn('overflow-hidden p-4', cardSurface)}>
+							{accountTransactions.map((tx, index) => {
 								const date = parseDbDate(tx.date ?? tx.createdAt);
 								const dateStr = date.toLocaleDateString('en-ZA', {
 									day: 'numeric',
@@ -239,48 +212,51 @@ const AccountDetailPage: React.FC = () => {
 								return (
 									<div
 										key={tx.id}
-										className="flex items-center justify-between rounded-xl border bg-card p-4"
+										className={cn(
+											'flex items-center justify-between py-2.5',
+											index < accountTransactions.length - 1 && rowDivider
+										)}
 									>
 										<div className="flex items-center gap-3">
 											<div
-												className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full ${
+												className={cn(
+													'flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full',
 													tx.type === 'income'
-														? 'bg-green-100 dark:bg-green-900/30'
+														? 'bg-blue-50 dark:bg-blue-950'
 														: tx.type === 'transfer'
-															? 'bg-blue-100 dark:bg-blue-900/30'
-															: 'bg-red-100 dark:bg-red-900/30'
-												}`}
+															? 'bg-gray-100 dark:bg-gray-800'
+															: 'bg-gray-100 dark:bg-gray-800'
+												)}
 											>
 												{tx.type === 'income' ? (
-													<FiArrowUp className="h-4 w-4 text-green-600 dark:text-green-400" />
+													<FiArrowUp className="h-4 w-4 text-blue-600 dark:text-blue-400" />
 												) : tx.type === 'transfer' ? (
-													<FiRepeat className="h-4 w-4 text-blue-500" />
+													<FiRepeat className="h-4 w-4 text-blue-600 dark:text-blue-400" />
 												) : (
-													<FiArrowDown className="h-4 w-4 text-red-600 dark:text-red-400" />
+													<FiArrowDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
 												)}
 											</div>
 											<div>
-												<p className="font-medium text-sm">{tx.title}</p>
-												<p className="text-xs text-muted-foreground">
+												<p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+													{tx.title}
+												</p>
+												<p className="text-xs text-gray-400 dark:text-gray-500">
 													{tx.category
-														? `${getCategoryPathLabel(tx.category, tx.subcategory)} &#183; `
+														? `${getCategoryPathLabel(tx.category, tx.subcategory)} · `
 														: ''}
 													{dateStr}
 												</p>
 											</div>
 										</div>
-										<p
-											className={`font-semibold ${
-												tx.type === 'income'
-													? 'text-green-600 dark:text-green-400'
-													: tx.type === 'transfer'
-														? 'text-blue-500'
-														: 'text-red-600 dark:text-red-400'
-											}`}
-										>
-											{tx.type === 'income' ? '+' : tx.type === 'transfer' ? '' : '-'}
-											{formatCurrency(tx.amount)}
-										</p>
+										{tx.type === 'income' ? (
+											<Currency amount={tx.amount} tone="income" showSign className="text-sm" />
+										) : tx.type === 'transfer' ? (
+											<Currency amount={tx.amount} className="text-sm" />
+										) : (
+											<span className={cn(currencyBase, currencyExpense, 'text-sm')}>
+												-{formatCurrency(tx.amount).replace(/^-/, '')}
+											</span>
+										)}
 									</div>
 								);
 							})}

--- a/apps/desktop/src/pages/dashboard/Dashboard.tsx
+++ b/apps/desktop/src/pages/dashboard/Dashboard.tsx
@@ -33,6 +33,8 @@ import {
 	exportTransactionsToJson,
 	importTransactionsFromFile,
 } from '@/domains/transactions/utils/transactionImportExport';
+import { frostedPanel, modalShell, pageBg } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 
 const routeToView = (pathname: string, isMobile: boolean): ViewType => {
 	if (pathname.startsWith('/dashboard/transactions')) return isMobile ? 'list' : 'table';
@@ -291,7 +293,7 @@ const Dashboard: React.FC = () => {
 	};
 
 	return (
-		<div className="flex h-screen-safe flex-col md:flex-row bg-background">
+		<div className={cn('flex h-screen-safe flex-col md:flex-row', pageBg)}>
 			<Toaster />
 			<Sidebar
 				collapsed={!sidebarVisible}
@@ -309,7 +311,7 @@ const Dashboard: React.FC = () => {
 			/>
 
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-				<DialogContent className="w-[90vw] md:w-full rounded-lg">
+				<DialogContent className={cn('w-[90vw] md:w-full', modalShell)}>
 					<DialogHeader>
 						<DialogTitle>Confirm Deletion</DialogTitle>
 						<DialogDescription>
@@ -425,7 +427,10 @@ const Dashboard: React.FC = () => {
 				{!sidebarVisible && (
 					<Button
 						variant="outline"
-						className="absolute left-4 top-4 z-50 shadow-sm"
+						className={cn(
+							'absolute left-4 top-4 z-50 rounded-full shadow-sm',
+							frostedPanel
+						)}
 						onClick={toggleSidebar}
 						aria-label="Open menu"
 					>

--- a/apps/desktop/src/pages/dashboard/components/AccountBalanceStrip.tsx
+++ b/apps/desktop/src/pages/dashboard/components/AccountBalanceStrip.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { FiArrowDownRight, FiArrowUpRight, FiCreditCard, FiPlus } from 'react-icons/fi';
+import { FiArrowDownRight, FiArrowUpRight, FiPlus } from 'react-icons/fi';
 import {
 	ACCOUNT_TYPE_LABELS,
 	calculateNetWorth,
 	getAccountLiability,
 } from '@/domains/accounts/models/AccountModel';
+import Currency from '@/components/marketing/Currency';
 import { Account } from '@/types';
+import { cardSurface, sectionLabel } from '@/styles/marketingStyles';
 import { cn } from '@/lib/utils';
-import { formatCurrency } from '@/utils/formatCurrency';
 
 interface AccountBalanceStripProps {
 	accounts: Account[];
@@ -27,28 +28,20 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 	const totalBalance = calculateNetWorth(accounts).netWorth;
 	const headerPadding = compact ? 'p-3' : 'p-4';
 	const contentSpacing = compact ? 'gap-2 p-2' : 'gap-3 p-3';
-	const rowDensity = compact ? 'min-h-16 p-2.5' : 'min-h-24 p-3';
 	const totalTextSize = compact ? 'text-xl' : 'text-2xl';
 
 	return (
-		<section
-			aria-label="Account balances"
-			className="overflow-hidden rounded-lg border bg-card shadow-sm"
-		>
+		<section aria-label="Account balances" className={cn('overflow-hidden', cardSurface)}>
 			<div
 				className={cn(
-					'flex items-start justify-between gap-3 border-b bg-muted/20',
+					'flex items-start justify-between gap-3 border-b border-gray-100 bg-gray-50/40 dark:border-gray-800 dark:bg-gray-800/20',
 					headerPadding
 				)}
 			>
 				<div className="min-w-0">
-					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-						Accounts
-					</p>
-					<p className={cn('mt-1 font-semibold tracking-tight', totalTextSize)}>
-						{formatCurrency(totalBalance)}
-					</p>
-					<p className="mt-1 truncate text-xs text-muted-foreground">
+					<p className={sectionLabel}>Accounts</p>
+					<Currency amount={totalBalance} className={cn('mt-1 tracking-tight', totalTextSize)} />
+					<p className="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">
 						{accounts.length > 0
 							? `${accounts.length} linked account${accounts.length === 1 ? '' : 's'}`
 							: 'No accounts linked yet'}
@@ -57,34 +50,29 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 				<button
 					type="button"
 					onClick={onOpenAccounts}
-					className="flex-shrink-0 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					className="flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-50"
 				>
 					View all
 				</button>
 			</div>
 
-			<div
-				className={cn('grid', contentSpacing)}
-				style={{
-					gridTemplateColumns:
-						'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
-				}}
-			>
+			<div className={cn('grid', contentSpacing)}>
 				{displayAccounts.length === 0 ? (
 					<button
 						type="button"
 						onClick={onOpenAccounts}
 						className={cn(
-							'flex items-center gap-3 rounded-md border bg-background text-left transition-colors hover:bg-muted/60',
-							rowDensity
+							'flex items-center gap-3 rounded-xl border border-dashed border-gray-200 bg-white p-4 text-left transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-800/50',
 						)}
 					>
-						<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+						<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400">
 							<FiPlus className="h-4 w-4" />
 						</span>
 						<span className="min-w-0 flex-1">
-							<span className="block font-medium">Create your first account</span>
-							<span className="block text-sm text-muted-foreground">
+							<span className="block font-medium text-gray-900 dark:text-gray-50">
+								Create your first account
+							</span>
+							<span className="block text-sm text-gray-500 dark:text-gray-400">
 								Accounts anchor balances for transactions and transfers.
 							</span>
 						</span>
@@ -94,9 +82,6 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 						{displayAccounts.map((account) => {
 							const isNegative = getAccountLiability(account) > 0;
 							const BalanceIcon = isNegative ? FiArrowDownRight : FiArrowUpRight;
-							const balanceTone = isNegative
-								? 'text-red-600 dark:text-red-400'
-								: 'text-foreground';
 
 							return (
 								<button
@@ -104,40 +89,30 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 									type="button"
 									onClick={onOpenAccounts}
 									className={cn(
-										'group relative flex min-w-0 items-center justify-between gap-3 overflow-hidden rounded-md border bg-background text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-										rowDensity
+										'group relative flex min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-gray-100 bg-gray-50/60 p-4 text-left transition-shadow hover:shadow-md dark:border-gray-800 dark:bg-gray-800/40',
 									)}
 								>
+									<p className={sectionLabel}>
+										{account.bank
+											? `${account.bank} - ${ACCOUNT_TYPE_LABELS[account.type]}`
+											: ACCOUNT_TYPE_LABELS[account.type]}
+									</p>
+									<p className="truncate text-sm font-medium text-gray-900 dark:text-gray-50">
+										{account.name}
+									</p>
+									<Currency
+										amount={account.balance}
+										tone={isNegative ? 'balance-negative' : 'default'}
+										className="text-2xl"
+									/>
+									<span className="flex items-center gap-1 text-xs text-gray-400">
+										<BalanceIcon className="h-3 w-3" />
+										{isNegative ? 'Owing' : 'Available'}
+									</span>
 									<span
-										className="absolute inset-y-3 left-0 w-1 rounded-r-full"
+										className="absolute inset-y-3 right-0 w-1 rounded-l-full"
 										style={{ backgroundColor: account.color ?? '#6366f1' }}
 									/>
-									<span className="ml-2 flex min-w-0 flex-1 items-center gap-2">
-										<span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-											<FiCreditCard className="h-4 w-4" />
-										</span>
-										<span className="min-w-0">
-											<span className="block truncate text-sm font-medium">
-												{account.name}
-											</span>
-											<span className="block truncate text-xs text-muted-foreground">
-												{account.bank
-													? `${account.bank} - ${ACCOUNT_TYPE_LABELS[account.type]}`
-													: ACCOUNT_TYPE_LABELS[account.type]}
-											</span>
-										</span>
-									</span>
-									<span className="flex min-w-0 flex-shrink-0 flex-col items-end">
-										<span
-											className={`max-w-[8rem] truncate text-right text-sm font-semibold tabular-nums sm:max-w-[9rem] ${balanceTone}`}
-										>
-											{formatCurrency(account.balance)}
-										</span>
-										<span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
-											<BalanceIcon className="h-3 w-3" />
-											{isNegative ? 'Owing' : 'Available'}
-										</span>
-									</span>
 								</button>
 							);
 						})}
@@ -147,19 +122,18 @@ const AccountBalanceStrip: React.FC<AccountBalanceStripProps> = ({
 								type="button"
 								onClick={onOpenAccounts}
 								className={cn(
-									'flex min-w-0 items-center justify-between gap-3 rounded-md border bg-background text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-									rowDensity
+									'flex min-w-0 items-center justify-between gap-3 rounded-xl border border-gray-100 bg-white p-4 text-left transition-colors hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-900 dark:hover:bg-gray-800/50',
 								)}
 							>
 								<span className="min-w-0">
-									<span className="block text-sm font-medium">
+									<span className="block text-sm font-medium text-gray-900 dark:text-gray-50">
 										{remainingCount} more account{remainingCount === 1 ? '' : 's'}
 									</span>
-									<span className="block truncate text-xs text-muted-foreground">
+									<span className="block truncate text-xs text-gray-500 dark:text-gray-400">
 										Open accounts to review every balance.
 									</span>
 								</span>
-								<span className="rounded-full border px-2 py-1 text-xs font-medium text-muted-foreground">
+								<span className="rounded-full border border-gray-200 px-2 py-1 text-xs font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
 									View
 								</span>
 							</button>

--- a/apps/desktop/src/pages/dashboard/components/DashboardOverview.tsx
+++ b/apps/desktop/src/pages/dashboard/components/DashboardOverview.tsx
@@ -6,10 +6,13 @@ import AIChatbot from '@/domains/ai/components/AIChatbot';
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
+import Currency from '@/components/marketing/Currency';
+import MotionReveal from '@/components/marketing/MotionReveal';
+import SectionHeader from '@/components/marketing/SectionHeader';
+import MarketingCard from '@/components/marketing/MarketingCard';
 import { Button } from '@/components/app/ui/button';
 import { useToast } from '@/components/app/ui/use-toast';
 import { Transaction } from '@/types';
-import { formatCurrency } from '@/utils/formatCurrency';
 import AccountBalanceStrip from '@/pages/dashboard/components/AccountBalanceStrip';
 import MonthlyDigest from '@/pages/dashboard/components/MonthlyDigest';
 import RecentTransactionsPanel from '@/pages/dashboard/components/RecentTransactionsPanel';
@@ -19,6 +22,8 @@ import {
 	loadDashboardDigestPeriod,
 	saveDashboardDigestPeriod,
 } from '@/pages/dashboard/utils/digestPeriod';
+import { outlinePill, pageBg, radialWash } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 
 interface DashboardOverviewProps {
 	onOpenAccounts: () => void;
@@ -58,10 +63,6 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 		const mainAccount = accounts.find((account) => account.id === mainAccountId);
 		return mainAccount?.id ?? accounts[0]?.id;
 	}, [accounts, mainAccountId]);
-	const netWorthTone =
-		summary.saved >= 0
-			? 'text-green-600 dark:text-green-400'
-			: 'text-red-600 dark:text-red-400';
 
 	const handleConfirmRecurringDraft = async (
 		draft: (typeof dueRecurringDrafts)[number]
@@ -108,136 +109,161 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 		}
 	};
 
-	return (
-		<div className="flex h-full min-h-0 flex-col bg-background">
-			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 md:px-5 lg:px-6 xl:overflow-hidden xl:px-6">
-				<header className="mb-3 flex flex-shrink-0 flex-col gap-3 border-b pb-3 sm:flex-row sm:items-start sm:justify-between">
-					<div>
-						<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							CashFlow overview
-						</p>
-						<h1 className="mt-1 text-2xl font-semibold tracking-tight">
-							Dashboard
-						</h1>
-						<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-							<span>Net worth {formatCurrency(summary.netWorth)}</span>
-							<span className={netWorthTone}>
-								{summary.saved >= 0 ? '+' : ''}
-								{formatCurrency(summary.saved)} this period
-							</span>
-						</div>
-					</div>
-					<div className="flex items-center gap-2">
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={onOpenHistory}
-							aria-label="Search transactions"
-						>
-							<FiSearch className="h-4 w-4" />
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={onOpenSettings}
-							aria-label="Open dashboard settings"
-						>
-							<FiSettings className="h-4 w-4" />
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={onOpenAccounts}
-							aria-label="View accounts"
-						>
-							<FiEye className="h-4 w-4" />
-						</Button>
-					</div>
-				</header>
+	const headerActions = (
+		<>
+			<Button
+				type="button"
+				variant="outline"
+				size="icon"
+				className={cn('h-9 w-9', outlinePill)}
+				onClick={onOpenHistory}
+				aria-label="Search transactions"
+			>
+				<FiSearch className="h-4 w-4" />
+			</Button>
+			<Button
+				type="button"
+				variant="outline"
+				size="icon"
+				className={cn('h-9 w-9', outlinePill)}
+				onClick={onOpenSettings}
+				aria-label="Open dashboard settings"
+			>
+				<FiSettings className="h-4 w-4" />
+			</Button>
+			<Button
+				type="button"
+				variant="outline"
+				size="icon"
+				className={cn('h-9 w-9', outlinePill)}
+				onClick={onOpenAccounts}
+				aria-label="View accounts"
+			>
+				<FiEye className="h-4 w-4" />
+			</Button>
+		</>
+	);
 
-				<div className="grid flex-1 gap-3 xl:min-h-0 xl:grid-rows-[auto_minmax(0,1fr)]">
-					<MonthlyDigest
-						summary={summary}
-						period={digestPeriod}
-						onPeriodChange={handleDigestPeriodChange}
+	return (
+		<div className={cn('relative flex h-full min-h-0 flex-col', pageBg)}>
+			<div className={radialWash} aria-hidden />
+			<div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 md:px-5 lg:px-6 xl:overflow-hidden xl:px-6">
+				<MotionReveal className="mb-4 flex-shrink-0 border-b border-gray-200 pb-4 dark:border-gray-800">
+					<SectionHeader
+						badge="CashFlow overview"
+						title="Dashboard"
 						compact
+						subtitle={
+							<span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+								<span>
+									Net worth{' '}
+									<Currency amount={summary.netWorth} className="text-sm" />
+								</span>
+								<Currency
+									amount={summary.saved}
+									tone={summary.saved >= 0 ? 'balance-positive' : 'balance-negative'}
+									className="text-sm"
+									showSign
+								/>
+								<span className="text-gray-500 dark:text-gray-400">this period</span>
+							</span>
+						}
+						actions={headerActions}
 					/>
+				</MotionReveal>
+
+				<div className="flex min-h-0 flex-1 flex-col gap-3">
+					<MotionReveal delay={0.06} className="shrink-0">
+						<MonthlyDigest
+							summary={summary}
+							period={digestPeriod}
+							onPeriodChange={handleDigestPeriodChange}
+							compact
+						/>
+					</MotionReveal>
 
 					{dueRecurringDrafts.length > 0 && (
-						<section className="rounded-lg border bg-card p-3">
-							<div className="mb-3 flex items-center justify-between gap-3">
-								<div>
-									<h2 className="flex items-center gap-2 text-sm font-semibold">
-										<FiRefreshCw className="h-4 w-4 text-primary" />
-										Due today
-									</h2>
-									<p className="text-xs text-muted-foreground">
-										Confirm recurring expenses that should become transactions.
-									</p>
-								</div>
-							</div>
-							<div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-								{dueRecurringDrafts.map((draft) => {
-									const recurringTransaction = draft.recurringTransaction;
-									const account = accounts.find(
-										(item) => item.id === recurringTransaction.accountId
-									);
-									return (
-										<div
-											key={recurringTransaction.id}
-											className="flex items-center justify-between gap-3 rounded-md border bg-background p-3"
-										>
-											<div className="min-w-0">
-												<p className="truncate text-sm font-semibold">
-													{recurringTransaction.title}
-												</p>
-												<p className="truncate text-xs text-muted-foreground">
-													{getCategoryPathLabel(
-														recurringTransaction.category,
-														recurringTransaction.subcategory
-													)}
-													{account ? ` • ${account.name}` : ''}
-												</p>
-												<p className="mt-1 text-sm font-semibold text-red-600 dark:text-red-400">
-													{formatCurrency(recurringTransaction.amount)}
-												</p>
-											</div>
-											<Button
-												type="button"
-												size="sm"
-												onClick={() => handleConfirmRecurringDraft(draft)}
-												disabled={confirmingDraftId === recurringTransaction.id}
+						<MotionReveal delay={0.12} className="relative z-10 shrink-0">
+							<MarketingCard
+								header={
+									<div>
+										<h2 className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-50">
+											<FiRefreshCw className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+											Due today
+										</h2>
+										<p className="text-xs text-gray-500 dark:text-gray-400">
+											Confirm recurring expenses that should become transactions.
+										</p>
+									</div>
+								}
+							>
+								<div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+									{dueRecurringDrafts.map((draft) => {
+										const recurringTransaction = draft.recurringTransaction;
+										const account = accounts.find(
+											(item) => item.id === recurringTransaction.accountId
+										);
+										return (
+											<div
+												key={recurringTransaction.id}
+												className="flex items-center justify-between gap-3 rounded-xl border border-gray-100 bg-gray-50/60 p-3 dark:border-gray-800 dark:bg-gray-800/40"
 											>
-												<FiCheck className="mr-2 h-4 w-4" />
-												Confirm
-											</Button>
-										</div>
-									);
-								})}
-							</div>
-						</section>
+												<div className="min-w-0">
+													<p className="truncate text-sm font-semibold text-gray-900 dark:text-gray-50">
+														{recurringTransaction.title}
+													</p>
+													<p className="truncate text-xs text-gray-500 dark:text-gray-400">
+														{getCategoryPathLabel(
+															recurringTransaction.category,
+															recurringTransaction.subcategory
+														)}
+														{account ? ` • ${account.name}` : ''}
+													</p>
+													<Currency
+														amount={recurringTransaction.amount}
+														tone="balance-negative"
+														className="mt-1 text-sm"
+													/>
+												</div>
+												<Button
+													type="button"
+													variant="marketing"
+													size="sm"
+													onClick={() => handleConfirmRecurringDraft(draft)}
+													disabled={confirmingDraftId === recurringTransaction.id}
+												>
+													<FiCheck className="mr-2 h-4 w-4" />
+													Confirm
+												</Button>
+											</div>
+										);
+									})}
+								</div>
+							</MarketingCard>
+						</MotionReveal>
 					)}
 
-					<div className="grid gap-3 xl:min-h-0 xl:grid-cols-[minmax(280px,0.78fr)_minmax(360px,1fr)_minmax(320px,0.85fr)]">
-						<AccountBalanceStrip
-							accounts={accounts}
-							onOpenAccounts={onOpenAccounts}
-							compact
-						/>
-						<RecentTransactionsPanel
-							transactions={transactions}
-							accounts={accounts}
-							getCategoryPathLabel={getCategoryPathLabel}
-							onSelect={onSelectTransaction}
-							onOpenHistory={onOpenHistory}
-							compact
-						/>
-						<div className="min-h-[28rem] xl:min-h-0">
+					<div className="grid min-h-0 flex-1 gap-3 xl:grid-cols-[minmax(280px,0.78fr)_minmax(360px,1fr)_minmax(320px,0.85fr)]">
+						<MotionReveal delay={0.18}>
+							<AccountBalanceStrip
+								accounts={accounts}
+								onOpenAccounts={onOpenAccounts}
+								compact
+							/>
+						</MotionReveal>
+						<MotionReveal delay={0.24}>
+							<RecentTransactionsPanel
+								transactions={transactions}
+								accounts={accounts}
+								getCategoryPathLabel={getCategoryPathLabel}
+								onSelect={onSelectTransaction}
+								onOpenHistory={onOpenHistory}
+								compact
+							/>
+						</MotionReveal>
+						<MotionReveal delay={0.3} className="min-h-[28rem] xl:min-h-0">
 							<AIChatbot variant="docked" alwaysDocked />
-						</div>
+						</MotionReveal>
 					</div>
 				</div>
 			</div>

--- a/apps/desktop/src/pages/dashboard/components/MonthlyDigest.tsx
+++ b/apps/desktop/src/pages/dashboard/components/MonthlyDigest.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
 import { Label } from '@/components/app/ui/label';
+import Currency from '@/components/marketing/Currency';
 import { DashboardSummary } from '@/pages/dashboard/utils/dashboardSummary';
 import {
 	DashboardDigestCustomPeriod,
@@ -16,6 +17,13 @@ import {
 	DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD,
 	clampDigestDay,
 } from '@/pages/dashboard/utils/digestPeriod';
+import {
+	cardSurface,
+	cardSurfaceMuted,
+	progressFill,
+	progressTrack,
+	sectionLabel,
+} from '@/styles/marketingStyles';
 import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 
@@ -34,17 +42,13 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 }) => {
 	const [isPeriodOpen, setIsPeriodOpen] = useState(false);
 	const savedTone =
-		summary.saved >= 0
-			? 'text-green-600 dark:text-green-400'
-			: 'text-red-600 dark:text-red-400';
+		summary.saved >= 0 ? 'balance-positive' : 'balance-negative';
 	const isCustomPeriod = period.mode === 'customCycle';
 	const customPeriod: DashboardDigestCustomPeriod = isCustomPeriod
 		? period
 		: DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD;
 	const headerPadding = compact ? 'p-3' : 'p-5';
-	const metricPadding = compact ? 'p-3' : 'p-4';
 	const heroAmountSize = compact ? 'text-3xl' : 'text-4xl';
-	const metricAmountSize = compact ? 'text-xl' : 'text-2xl';
 
 	const handleCustomDayChange = (field: 'startDay' | 'endDay', value: string) => {
 		onPeriodChange({
@@ -54,29 +58,23 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 	};
 
 	return (
-		<section className="flex-shrink-0 overflow-hidden rounded-lg border bg-card shadow-sm">
-			<div className={cn('border-b bg-muted/20', headerPadding)}>
+		<section className={cn('flex-shrink-0 overflow-hidden', cardSurface)}>
+			<div className={cn('border-b border-gray-100 bg-gray-50/40 dark:border-gray-800 dark:bg-gray-800/20', headerPadding)}>
 				<div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
 					<div>
-						<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							{summary.periodLabel} digest
-						</p>
+						<p className={sectionLabel}>{summary.periodLabel} digest</p>
 						<div className="mt-2 flex flex-wrap items-end gap-x-4 gap-y-2">
 							<div>
-								<p className="text-sm text-muted-foreground">
+								<p className="text-sm text-gray-500 dark:text-gray-400">
 									Retained this period
 								</p>
-								<p
-									className={cn(
-										'mt-1 font-semibold tracking-tight',
-										heroAmountSize,
-										savedTone
-									)}
-								>
-									{formatCurrency(summary.saved)}
-								</p>
+								<Currency
+									amount={summary.saved}
+									tone={savedTone}
+									className={cn('mt-1 tracking-tight', heroAmountSize)}
+								/>
 							</div>
-							<div className="pb-1 text-sm text-muted-foreground">
+							<div className="pb-1 text-sm text-gray-500 dark:text-gray-400">
 								{summary.transactionCount} transactions tracked
 							</div>
 						</div>
@@ -85,7 +83,7 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 						type="button"
 						variant="outline"
 						size="sm"
-						className="h-9 self-start px-3 text-xs"
+						className="h-9 self-start rounded-full border-gray-200 px-3 text-xs dark:border-gray-700"
 						onClick={() => setIsPeriodOpen((open) => !open)}
 						aria-expanded={isPeriodOpen}
 					>
@@ -100,21 +98,23 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 				</div>
 			</div>
 			{isPeriodOpen && (
-				<div className="border-b bg-background p-4">
+				<div className="border-b border-gray-100 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
 					<div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
 						<div className="flex flex-wrap gap-2">
 							<Button
 								type="button"
-								variant={!isCustomPeriod ? 'secondary' : 'outline'}
+								variant={!isCustomPeriod ? 'marketing' : 'outline'}
 								size="sm"
+								className={isCustomPeriod ? 'rounded-full' : ''}
 								onClick={() => onPeriodChange({ mode: 'monthToDate' })}
 							>
 								Month to date
 							</Button>
 							<Button
 								type="button"
-								variant={isCustomPeriod ? 'secondary' : 'outline'}
+								variant={isCustomPeriod ? 'marketing' : 'outline'}
 								size="sm"
+								className={!isCustomPeriod ? 'rounded-full' : ''}
 								onClick={() => onPeriodChange(DEFAULT_CUSTOM_DASHBOARD_DIGEST_PERIOD)}
 							>
 								Custom cycle
@@ -139,7 +139,7 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 									onChange={(event) =>
 										handleCustomDayChange('startDay', event.target.value)
 									}
-									className="h-9 w-full sm:w-28"
+									className="h-9 w-full rounded-xl sm:w-28"
 								/>
 							</div>
 							<div>
@@ -160,59 +160,55 @@ const MonthlyDigest: React.FC<MonthlyDigestProps> = ({
 									onChange={(event) =>
 										handleCustomDayChange('endDay', event.target.value)
 									}
-									className="h-9 w-full sm:w-28"
+									className="h-9 w-full rounded-xl sm:w-28"
 								/>
 							</div>
 						</div>
 					</div>
 				</div>
 			)}
-			<div className="grid gap-px bg-border sm:grid-cols-3">
-				<div className={cn('bg-card', metricPadding)}>
+			<div className="grid gap-3 p-3 sm:grid-cols-3 sm:p-4">
+				<div className={cn('p-4', cardSurfaceMuted)}>
 					<div className="mb-2 flex items-center justify-between gap-3">
-						<p className="text-sm text-muted-foreground">Income</p>
-						<FiArrowUpCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+						<p className={sectionLabel}>Income</p>
+						<FiArrowUpCircle className="h-4 w-4 text-blue-600 dark:text-blue-400" />
 					</div>
-					<p className={cn('font-semibold text-primary', metricAmountSize)}>
-						{formatCurrency(summary.income)}
-					</p>
-					<p className="mt-1 text-xs text-muted-foreground">Period inflow</p>
+					<Currency amount={summary.income} tone="income" className="text-2xl" />
+					<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Period inflow</p>
 				</div>
-				<div className={cn('bg-card', metricPadding)}>
+				<div className={cn('p-4', cardSurfaceMuted)}>
 					<div className="mb-2 flex items-center justify-between gap-3">
-						<p className="text-sm text-muted-foreground">Spent</p>
-						<FiArrowDownCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+						<p className={sectionLabel}>Spent</p>
+						<FiArrowDownCircle className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+					</div>
+					<Currency amount={summary.expense} tone="expense" className="text-2xl" />
+					<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Tracked expenses</p>
+				</div>
+				<div className={cn('p-4', cardSurfaceMuted)}>
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<p className={sectionLabel}>Retention</p>
+						<FiTarget className="h-4 w-4 text-blue-600 dark:text-blue-400" />
 					</div>
 					<p
 						className={cn(
-							'font-semibold text-red-600 dark:text-red-400',
-							metricAmountSize
+							'font-mono text-2xl font-semibold',
+							summary.saved >= 0
+								? 'text-emerald-600 dark:text-emerald-400'
+								: 'text-red-500 dark:text-red-400'
 						)}
 					>
-						{formatCurrency(summary.expense)}
-					</p>
-					<p className="mt-1 text-xs text-muted-foreground">
-						Tracked expenses
-					</p>
-				</div>
-				<div className={cn('bg-card', metricPadding)}>
-					<div className="mb-2 flex items-center justify-between gap-3">
-						<p className="text-sm text-muted-foreground">Retention</p>
-						<FiTarget className="h-4 w-4 text-primary" />
-					</div>
-					<p className={cn('font-semibold', metricAmountSize, savedTone)}>
 						{Math.round(summary.progressPercent)}%
 					</p>
-					<p className="mt-1 text-xs text-muted-foreground">
+					<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
 						{summary.income > 0
 							? `${formatCurrency(summary.saved)} kept`
 							: 'Add income to track retention'}
 					</p>
 				</div>
 			</div>
-			<div className="h-1.5 overflow-hidden bg-muted">
+			<div className={cn('h-1.5 overflow-hidden', progressTrack)}>
 				<div
-					className="h-full rounded-full bg-primary transition-all"
+					className={cn('h-full rounded-full transition-all', progressFill)}
 					style={{ width: `${summary.progressPercent}%` }}
 				/>
 			</div>

--- a/apps/desktop/src/pages/dashboard/components/RecentTransactionsPanel.tsx
+++ b/apps/desktop/src/pages/dashboard/components/RecentTransactionsPanel.tsx
@@ -1,16 +1,17 @@
 import React, { useMemo } from 'react';
-import {
-	FiArrowDown,
-	FiArrowUp,
-	FiCreditCard,
-	FiDollarSign,
-	FiHome,
-	FiShoppingCart,
-} from 'react-icons/fi';
+import { FiDollarSign } from 'react-icons/fi';
+import Currency from '@/components/marketing/Currency';
 import { Account, Transaction } from '@/types';
+import {
+	cardSurface,
+	currencyBase,
+	currencyExpense,
+	rowDivider,
+	sectionLabel,
+} from '@/styles/marketingStyles';
+import { formatCurrency } from '@/utils/formatCurrency';
 import { cn } from '@/lib/utils';
 import { parseDbDate } from '@/utils/date';
-import { formatCurrency } from '@/utils/formatCurrency';
 
 interface RecentTransactionsPanelProps {
 	transactions: Transaction[];
@@ -21,30 +22,13 @@ interface RecentTransactionsPanelProps {
 	compact?: boolean;
 }
 
-const getTransactionIcon = (transaction: Transaction) => {
-	if (transaction.type === 'income') return FiArrowUp;
-	if (transaction.type === 'transfer') return FiCreditCard;
-	if (transaction.category === 'food') return FiShoppingCart;
-	if (transaction.category === 'personal') return FiHome;
-	return FiArrowDown;
-};
-
 const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 	transactions,
-	accounts,
 	getCategoryPathLabel,
 	onSelect,
 	onOpenHistory,
 	compact = false,
 }) => {
-	const accountColorMap = useMemo(() => {
-		const map = new Map<string, string>();
-		accounts.forEach((account) => {
-			if (account.id) map.set(account.id, account.color ?? '#6366f1');
-		});
-		return map;
-	}, [accounts]);
-
 	const recentTransactions = useMemo(
 		() =>
 			[...transactions]
@@ -56,24 +40,20 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 				.slice(0, compact ? 5 : 6),
 		[compact, transactions]
 	);
-	const rowPadding = compact ? 'py-2' : 'py-3';
-	const iconSize = compact ? 'h-9 w-9' : 'h-10 w-10';
 
 	return (
-		<section className="flex h-full min-h-0 flex-col rounded-lg border bg-card p-3 shadow-sm">
-			<div className="mb-2 flex flex-shrink-0 items-start justify-between gap-3">
+		<section className={cn('flex h-full min-h-0 flex-col p-5', cardSurface)}>
+			<div className="mb-4 flex flex-shrink-0 items-start justify-between gap-3">
 				<div>
-					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-						Recent
-					</p>
-					<h2 className="mt-1 text-lg font-semibold tracking-tight">
+					<p className={sectionLabel}>Recent</p>
+					<h2 className="mt-1 text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-50">
 						Latest transactions
 					</h2>
 				</div>
 				<button
 					type="button"
 					onClick={onOpenHistory}
-					className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					className="rounded-full px-3 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-50"
 				>
 					View all
 				</button>
@@ -81,28 +61,20 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 
 			{recentTransactions.length === 0 ? (
 				<div className="flex flex-1 flex-col items-center justify-center text-center">
-					<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-						<FiDollarSign className="h-5 w-5 text-primary" />
+					<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-950">
+						<FiDollarSign className="h-5 w-5 text-blue-600 dark:text-blue-400" />
 					</div>
-					<p className="font-medium">No transactions yet</p>
-					<p className="mt-1 max-w-xs text-sm text-muted-foreground">
+					<p className="font-medium text-gray-900 dark:text-gray-50">No transactions yet</p>
+					<p className="mt-1 max-w-xs text-sm text-gray-500 dark:text-gray-400">
 						Add your first transaction and this feed will start filling in.
 					</p>
 				</div>
 			) : (
-				<div className="min-h-0 flex-1 divide-y overflow-y-auto">
-					{recentTransactions.map((transaction) => {
-						const Icon = getTransactionIcon(transaction);
+				<div className="min-h-0 flex-1 overflow-y-auto">
+					{recentTransactions.map((transaction, index) => {
 						const isPositive = transaction.type === 'income';
 						const isTransfer = transaction.type === 'transfer';
-						const amountPrefix = isPositive ? '+' : isTransfer ? '' : '-';
-						const amountTone = isPositive
-							? 'text-green-600 dark:text-green-400'
-							: isTransfer
-								? 'text-muted-foreground'
-								: 'text-red-600 dark:text-red-400';
 						const date = parseDbDate(transaction.date ?? transaction.createdAt);
-						const color = accountColorMap.get(transaction.accountId) ?? '#6366f1';
 
 						return (
 							<button
@@ -110,48 +82,47 @@ const RecentTransactionsPanel: React.FC<RecentTransactionsPanelProps> = ({
 								type="button"
 								onClick={() => onSelect(transaction)}
 								className={cn(
-									'group flex w-full items-center gap-3 px-1 text-left transition-colors hover:bg-muted/50 sm:px-2',
-									rowPadding
+									'group flex w-full items-center justify-between py-2.5 text-left transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-800/30',
+									index < recentTransactions.length - 1 && rowDivider
 								)}
 							>
-								<span
-									className={cn(
-										'flex flex-shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground',
-										iconSize
-									)}
-									style={{ borderLeftColor: color, borderLeftWidth: 4 }}
-								>
-									<Icon className="h-4 w-4" />
-								</span>
-								<span className="min-w-0 flex-1">
-									<span className="block truncate text-sm font-medium">
+								<div className="min-w-0">
+									<p className="truncate text-sm font-medium text-gray-700 dark:text-gray-300">
 										{transaction.title}
-									</span>
-									<span className="block truncate text-xs text-muted-foreground">
-										{isTransfer
-											? 'Transfer'
-											: getCategoryPathLabel(
-													transaction.category,
-													transaction.subcategory
-												)}{' '}
-										-{' '}
+									</p>
+									<p className="text-xs text-gray-400 dark:text-gray-500">
 										{date.toLocaleDateString('en-ZA', {
 											day: 'numeric',
 											month: 'short',
 										})}
-									</span>
-								</span>
-								<span className="min-w-[6rem] text-right">
+										{!isTransfer &&
+											` · ${getCategoryPathLabel(transaction.category, transaction.subcategory)}`}
+										{isTransfer && ' · Transfer'}
+									</p>
+								</div>
+								{isPositive ? (
+									<Currency
+										amount={transaction.amount}
+										tone="income"
+										className="ml-3 flex-shrink-0 text-sm"
+										showSign
+									/>
+								) : isTransfer ? (
+									<Currency
+										amount={transaction.amount}
+										className="ml-3 flex-shrink-0 text-sm"
+									/>
+								) : (
 									<span
-										className={cn('block text-sm font-semibold tabular-nums', amountTone)}
+										className={cn(
+											currencyBase,
+											currencyExpense,
+											'ml-3 flex-shrink-0 text-sm'
+										)}
 									>
-										{amountPrefix}
-										{formatCurrency(transaction.amount)}
+										-{formatCurrency(transaction.amount).replace(/^-/, '')}
 									</span>
-									<span className="text-xs text-muted-foreground">
-										{transaction.type}
-									</span>
-								</span>
+								)}
 							</button>
 						);
 					})}

--- a/apps/desktop/src/pages/dashboard/components/SettingsModal.tsx
+++ b/apps/desktop/src/pages/dashboard/components/SettingsModal.tsx
@@ -31,6 +31,8 @@ import { useTransactionsContext } from '@/domains/transactions/context/Transacti
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { useFilterPreferences, FilterPreferences } from '@/shared/filters/context/FilterPreferencesContext';
+import { modalShell, navItemActive, navItemInactive } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/formatCurrency';
 
 interface SettingsModalProps {
@@ -281,7 +283,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 	return (
 		<>
 			<Dialog open={open} onOpenChange={onClose}>
-				<DialogContent className="sm:max-w-3xl max-h-modal overflow-hidden flex flex-col">
+				<DialogContent className={cn('sm:max-w-3xl max-h-modal overflow-hidden flex flex-col', modalShell)}>
 					<DialogHeader>
 						<DialogTitle>Settings</DialogTitle>
 						<DialogDescription>Manage your app preferences and data</DialogDescription>
@@ -292,17 +294,17 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 							<div
 								role="tablist"
 								aria-label="Settings sections"
-								className="flex gap-1 rounded-lg border p-1 sm:flex-col"
+								className="flex gap-1 rounded-2xl border border-gray-200 bg-gray-50/40 p-1 dark:border-gray-800 dark:bg-gray-800/20 sm:flex-col"
 							>
 								<button
 									role="tab"
 									aria-selected={activeTab === 'general'}
 									aria-controls="settings-tab-general"
 									onClick={() => setActiveTab('general')}
-									className={`flex-1 sm:flex-none flex items-center justify-center sm:justify-start gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${activeTab === 'general'
-										? 'bg-accent text-accent-foreground'
-										: 'text-muted-foreground hover:bg-muted'
-										}`}
+									className={cn(
+										'flex flex-1 items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors sm:flex-none sm:justify-start',
+										activeTab === 'general' ? navItemActive : navItemInactive
+									)}
 								>
 									<FiSettings className="h-4 w-4" />
 									General
@@ -312,10 +314,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 									aria-selected={activeTab === 'data'}
 									aria-controls="settings-tab-data"
 									onClick={() => setActiveTab('data')}
-									className={`flex-1 sm:flex-none flex items-center justify-center sm:justify-start gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${activeTab === 'data'
-										? 'bg-accent text-accent-foreground'
-										: 'text-muted-foreground hover:bg-muted'
-										}`}
+									className={cn(
+										'flex flex-1 items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors sm:flex-none sm:justify-start',
+										activeTab === 'data' ? navItemActive : navItemInactive
+									)}
 								>
 									<FiDatabase className="h-4 w-4" />
 									Data
@@ -325,10 +327,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 									aria-selected={activeTab === 'categories'}
 									aria-controls="settings-tab-categories"
 									onClick={() => setActiveTab('categories')}
-									className={`flex-1 sm:flex-none flex items-center justify-center sm:justify-start gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${activeTab === 'categories'
-										? 'bg-accent text-accent-foreground'
-										: 'text-muted-foreground hover:bg-muted'
-										}`}
+									className={cn(
+										'flex flex-1 items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors sm:flex-none sm:justify-start',
+										activeTab === 'categories' ? navItemActive : navItemInactive
+									)}
 								>
 									<FiTag className="h-4 w-4" />
 									Categories
@@ -338,10 +340,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 									aria-selected={activeTab === 'filters'}
 									aria-controls="settings-tab-filters"
 									onClick={() => setActiveTab('filters')}
-									className={`flex-1 sm:flex-none flex items-center justify-center sm:justify-start gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${activeTab === 'filters'
-										? 'bg-accent text-accent-foreground'
-										: 'text-muted-foreground hover:bg-muted'
-										}`}
+									className={cn(
+										'flex flex-1 items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors sm:flex-none sm:justify-start',
+										activeTab === 'filters' ? navItemActive : navItemInactive
+									)}
 								>
 									<FiFilter className="h-4 w-4" />
 									Filters
@@ -353,10 +355,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 							{activeTab === 'general' && (
 								<div className="space-y-4" id="settings-tab-general" role="tabpanel">
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											General
 										</h3>
-										<div className="space-y-4 rounded-lg border p-4 sm:p-5">
+										<div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 											<div className="flex items-center justify-between">
 												<Label
 													htmlFor="dark-mode"
@@ -399,7 +401,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 														))
 													)}
 												</select>
-												<p className="text-xs text-muted-foreground">
+												<p className="text-xs text-gray-500 dark:text-gray-400">
 													Used as the default account in desktop and mobisite
 													transaction capture. You can still pick another account
 													per transaction.
@@ -413,11 +415,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 							{activeTab === 'data' && (
 								<div className="space-y-4" id="settings-tab-data" role="tabpanel">
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											Data
 										</h3>
-										<div className="space-y-4 rounded-lg border p-4 sm:p-5">
-											<p className="text-sm text-muted-foreground">
+										<div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
+											<p className="text-sm text-gray-500 dark:text-gray-400">
 												Import transactions from CSV/JSON. Duplicates are
 												automatically skipped.
 											</p>
@@ -462,7 +464,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 													Export JSON
 												</Button>
 											</div>
-											<p className="text-sm text-muted-foreground">
+											<p className="text-sm text-gray-500 dark:text-gray-400">
 												Delete all transactions from your account. This
 												action cannot be undone.
 											</p>
@@ -481,16 +483,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 							{activeTab === 'filters' && (
 								<div className="space-y-6" id="settings-tab-filters" role="tabpanel">
-									<p className="text-sm text-muted-foreground">
+									<p className="text-sm text-gray-500 dark:text-gray-400">
 										Choose which filters to show in each section. Hidden filters can always be re-enabled here.
 									</p>
 
 									{/* Recurring Transactions */}
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											Recurring Transactions
 										</h3>
-										<div className="space-y-3 rounded-lg border p-4 sm:p-5">
+										<div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 											{(
 												[
 													['frequency', 'Frequency filter'],
@@ -518,10 +520,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 									{/* Transaction History (table) */}
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											Transaction History
 										</h3>
-										<div className="space-y-3 rounded-lg border p-4 sm:p-5">
+										<div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 											{(
 												[
 													['search', 'Search bar'],
@@ -549,10 +551,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 									{/* Transaction List */}
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											Transaction List
 										</h3>
-										<div className="space-y-3 rounded-lg border p-4 sm:p-5">
+										<div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 											<div className="flex items-center justify-between">
 												<Label htmlFor="tl-search" className="cursor-pointer">
 													Search bar
@@ -570,10 +572,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 									{/* Reports */}
 									<div>
-										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+										<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
 											Reports
 										</h3>
-										<div className="space-y-3 rounded-lg border p-4 sm:p-5">
+										<div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 											{(
 												[
 													['dateRange', 'Date range filter'],
@@ -605,12 +607,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 							{activeTab === 'categories' && (
 								<div className="space-y-4" id="settings-tab-categories" role="tabpanel">
-									<p className="text-sm text-muted-foreground">
+									<p className="text-sm text-gray-500 dark:text-gray-400">
 										Manage the categories used by transactions, recurring transactions,
 										budgets, and category filters. Changes save immediately.
 									</p>
 
-									<div className="space-y-4 rounded-lg border p-4 sm:p-5">
+									<div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 sm:p-5">
 										<div className="flex flex-col gap-2 sm:flex-row">
 											<Input
 												value={newCategoryLabel}
@@ -635,7 +637,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 										)}
 
 										{categoriesLoading ? (
-											<p className="text-sm text-muted-foreground">
+											<p className="text-sm text-gray-500 dark:text-gray-400">
 												Loading categories...
 											</p>
 										) : (
@@ -688,7 +690,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 																			className="min-w-0 flex-1 text-left"
 																		>
 																			<p className="font-medium">{category.label}</p>
-																			<p className="text-xs text-muted-foreground">
+																			<p className="text-xs text-gray-500 dark:text-gray-400">
 																				{category.value}
 																				{` • ${category.subcategories.length} ${
 																					category.subcategories.length === 1
@@ -757,7 +759,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
 															{isExpanded && (
 															<div className="mt-3 space-y-2 border-t pt-3">
-																<p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+																<p className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
 																	Subcategories
 																</p>
 																{category.subcategories.length > 0 ? (
@@ -785,7 +787,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 																							<p className="text-sm font-medium">
 																								{subcategory.label}
 																							</p>
-																							<p className="text-xs text-muted-foreground">
+																							<p className="text-xs text-gray-500 dark:text-gray-400">
 																								{subcategory.value}
 																							</p>
 																						</div>
@@ -857,7 +859,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 																		})}
 																	</div>
 																) : (
-																	<p className="text-sm text-muted-foreground">
+																	<p className="text-sm text-gray-500 dark:text-gray-400">
 																		No subcategories yet.
 																	</p>
 																)}

--- a/apps/desktop/src/pages/dashboard/components/Sidebar.tsx
+++ b/apps/desktop/src/pages/dashboard/components/Sidebar.tsx
@@ -19,7 +19,14 @@ import { useTheme } from '@/app/theme/context/ThemeContext';
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { Button } from '@/components/app/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/app/ui/avatar';
-import { formatCurrency } from '@/utils/formatCurrency';
+import Currency from '@/components/marketing/Currency';
+import {
+	frostedPanel,
+	navItemActive,
+	navItemInactive,
+	sectionLabel,
+} from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
 
 interface SidebarProps {
 	onCreate: () => void;
@@ -118,18 +125,20 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 			<aside
 				aria-hidden={collapsed}
-				className={`fixed left-0 top-0 z-40 h-screen-safe w-72 border-r bg-card transition-transform duration-300 ease-in-out md:relative md:z-auto md:transition-all ${
+				className={cn(
+					'fixed left-0 top-0 z-40 h-screen-safe w-72 border-r backdrop-blur transition-transform duration-300 ease-in-out md:relative md:z-auto md:transition-all',
+					frostedPanel,
 					collapsed
 						? '-translate-x-full md:translate-x-0 md:w-0'
 						: 'translate-x-0 md:w-72'
-				}`}
+				)}
 			>
 				<div
 					className={`flex h-full flex-col transition-opacity duration-300 ${
 						collapsed ? 'md:opacity-0 md:pointer-events-none' : 'opacity-100'
 					}`}
 				>
-					<div className="flex items-center justify-between border-b bg-muted/20 p-4">
+					<div className="flex items-center justify-between border-b border-gray-200/80 bg-gray-50/40 p-4 dark:border-gray-800/80 dark:bg-gray-800/20">
 						<div className="flex min-w-0 flex-1 items-center gap-2">
 							<img
 								src={logo}
@@ -137,13 +146,16 @@ const Sidebar: React.FC<SidebarProps> = ({
 								className="h-8 flex-shrink-0 md:h-10"
 							/>
 							<div className="min-w-0 flex-1">
-								<h3 className="text-lg font-bold leading-tight tracking-tight md:text-xl">
+								<h3 className="text-lg font-semibold leading-tight tracking-tight text-gray-900 dark:text-gray-50 md:text-xl">
 									CashFlow
 								</h3>
 								{accounts.length > 0 && (
-									<p className="mt-0.5 truncate text-xs text-muted-foreground">
-										{formatCurrency(availableBalance)}
-									</p>
+									<div className="mt-0.5 truncate">
+										<p className={cn(sectionLabel, 'normal-case tracking-normal')}>
+											Available
+										</p>
+										<Currency amount={availableBalance} className="text-sm" />
+									</div>
 								)}
 							</div>
 						</div>
@@ -172,10 +184,8 @@ const Sidebar: React.FC<SidebarProps> = ({
 					</div>
 
 					{!collapsed && (
-						<div className="border-b p-3">
-							<p className="px-3 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-								Admin
-							</p>
+						<div className="border-b border-gray-200/80 p-3 dark:border-gray-800/80">
+							<p className={cn(sectionLabel, 'px-3 pb-2 pt-1')}>Admin</p>
 							<div className="space-y-1">
 								{NAV_ITEMS.map(({ id, label, icon: Icon }) => {
 									const isActive =
@@ -186,11 +196,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 										<button
 											key={id}
 											onClick={() => handleViewClick(id)}
-											className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-												isActive
-													? 'bg-primary text-primary-foreground shadow-sm'
-													: 'text-muted-foreground hover:bg-muted hover:text-foreground'
-											}`}
+											className={cn(
+												'flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors',
+												isActive ? navItemActive : navItemInactive
+											)}
 										>
 											<Icon className="h-4 w-4 flex-shrink-0" />
 											<span>{label}</span>
@@ -204,8 +213,9 @@ const Sidebar: React.FC<SidebarProps> = ({
 					<div className="flex-1" />
 
 					{!collapsed && (
-						<div className="border-t p-3">
+						<div className="border-t border-gray-200/80 p-3 dark:border-gray-800/80">
 							<Button
+								variant="marketing"
 								onClick={handleCreateTransaction}
 								className="h-10 w-full text-sm md:text-base"
 							>
@@ -215,32 +225,33 @@ const Sidebar: React.FC<SidebarProps> = ({
 						</div>
 					)}
 
-					<div className="border-t bg-muted/20 p-3">
+					<div className="border-t border-gray-200/80 bg-gray-50/40 p-3 dark:border-gray-800/80 dark:bg-gray-800/20">
 						{currentUser ? (
 							<button
 								onClick={() => {
 									onOpenSettings?.();
 									if (window.innerWidth < 768) toggleSidebar();
 								}}
-								className="flex w-full items-center gap-3 rounded-lg border bg-background p-2 text-left transition-colors hover:bg-muted"
+								className="flex w-full items-center gap-3 rounded-xl border border-gray-200 bg-white p-2 text-left transition-colors hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-900 dark:hover:bg-gray-800/50"
 							>
 								<Avatar className="h-8 w-8 flex-shrink-0">
 									{currentUser.photoURL && (
 										<AvatarImage src={currentUser.photoURL} alt="User" />
 									)}
-									<AvatarFallback className="bg-primary text-xs text-primary-foreground">
+									<AvatarFallback className="bg-blue-600 text-xs text-white">
 										{currentUser.email?.[0]?.toUpperCase() ?? '?'}
 									</AvatarFallback>
 								</Avatar>
 								<div className="min-w-0 flex-1">
-									<p className="truncate text-sm font-medium">
+									<p className="truncate text-sm font-medium text-gray-900 dark:text-gray-50">
 										{currentUser.displayName || currentUser.email || 'User'}
 									</p>
 								</div>
-								<FiSettings className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+								<FiSettings className="h-4 w-4 flex-shrink-0 text-gray-400" />
 							</button>
 						) : (
 							<Button
+								variant="marketing"
 								onClick={() => onOpenLogin?.()}
 								className="h-9 w-full text-sm md:h-10 md:text-base"
 							>

--- a/apps/desktop/src/pages/mobisite/MobisiteFrame.tsx
+++ b/apps/desktop/src/pages/mobisite/MobisiteFrame.tsx
@@ -1,57 +1,77 @@
 import MobisiteApp from '@mobisite/App';
-import { BookOpen, ChevronLeft, ChevronRight, Lock, MoreHorizontal, Share, Square } from 'lucide-react';
+import { Battery, Signal, Wifi } from 'lucide-react';
 import type { CSSProperties } from 'react';
+
+/** iPhone 15 logical viewport (points). */
+const IPHONE_15_WIDTH = 393;
+const IPHONE_15_HEIGHT = 852;
+/** Usable app height below status bar + home indicator. */
+const IPHONE_15_APP_HEIGHT = 759;
 
 const MobisiteFrame = () => {
 	return (
-		<div className="min-h-screen-safe bg-[radial-gradient(circle_at_top,hsl(var(--muted)),hsl(var(--background))_58%)] px-0 py-0 text-foreground sm:flex sm:items-center sm:justify-center sm:px-6 sm:py-8">
+		<div className="min-h-screen-safe bg-[radial-gradient(ellipse_80%_60%_at_50%_0%,rgba(148,163,184,0.22),transparent_55%),linear-gradient(180deg,#e2e8f0_0%,#cbd5e1_100%)] px-0 py-0 text-foreground dark:bg-[radial-gradient(ellipse_80%_60%_at_50%_0%,rgba(59,130,246,0.12),transparent_55%),linear-gradient(180deg,#0f172a_0%,#020617_100%)] sm:flex sm:items-center sm:justify-center sm:px-6 sm:py-10">
 			<div className="hidden sm:block">
 				<div
 					data-testid="mobile-browser-frame"
-					className="rounded-[2.75rem] bg-zinc-950 p-3 shadow-2xl shadow-black/30"
+					className="relative rounded-[3.25rem] bg-gradient-to-b from-zinc-400 via-zinc-600 to-zinc-800 p-[10px] shadow-[0_40px_80px_-20px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.35)] ring-1 ring-black/40"
+					style={{ width: IPHONE_15_WIDTH + 20, height: IPHONE_15_HEIGHT + 20 }}
 				>
-					<div className="flex h-[844px] w-[390px] flex-col overflow-hidden rounded-[2.2rem] border border-zinc-800 bg-zinc-100 text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50">
-						<div className="flex h-9 items-center justify-between px-7 pt-2 text-[11px] font-semibold">
+					{/* Side buttons */}
+					<div
+						className="absolute -left-[2px] top-[148px] h-8 w-[3px] rounded-l-sm bg-zinc-500/90"
+						aria-hidden
+					/>
+					<div
+						className="absolute -left-[2px] top-[196px] h-14 w-[3px] rounded-l-sm bg-zinc-500/90"
+						aria-hidden
+					/>
+					<div
+						className="absolute -left-[2px] top-[252px] h-14 w-[3px] rounded-l-sm bg-zinc-500/90"
+						aria-hidden
+					/>
+					<div
+						className="absolute -right-[2px] top-[210px] h-20 w-[3px] rounded-r-sm bg-zinc-500/90"
+						aria-hidden
+					/>
+
+					<div
+						className="relative flex h-full w-full flex-col overflow-hidden rounded-[2.65rem] bg-black"
+						style={{ width: IPHONE_15_WIDTH, height: IPHONE_15_HEIGHT }}
+					>
+						{/* Dynamic Island */}
+						<div
+							className="pointer-events-none absolute left-1/2 top-[11px] z-20 h-[37px] w-[126px] -translate-x-1/2 rounded-full bg-black shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06),0_1px_3px_rgba(0,0,0,0.45)]"
+							aria-hidden
+						/>
+
+						{/* Status bar */}
+						<div className="relative z-10 flex h-[54px] shrink-0 items-end justify-between px-7 pb-1 text-[13px] font-semibold text-white">
 							<span>9:41</span>
 							<span className="flex items-center gap-1.5">
-								<span className="h-2.5 w-3.5 rounded-sm border border-current" />
-								<span className="h-2.5 w-2.5 rounded-full bg-current" />
+								<Signal className="h-3.5 w-3.5" strokeWidth={2.5} />
+								<Wifi className="h-3.5 w-3.5" strokeWidth={2.5} />
+								<Battery className="h-3.5 w-5" strokeWidth={2.5} />
 							</span>
 						</div>
-						<div className="border-b border-zinc-300/70 bg-zinc-100 px-3 pb-2 pt-1 dark:border-zinc-800 dark:bg-zinc-950">
-							<div className="flex h-9 items-center gap-2 rounded-full bg-white px-3 text-xs shadow-sm ring-1 ring-zinc-200 dark:bg-zinc-900 dark:ring-zinc-800">
-								<Lock className="h-3.5 w-3.5 text-zinc-500" />
-								<span className="min-w-0 flex-1 truncate text-center font-medium text-zinc-700 dark:text-zinc-200">
-									cashflow.local/mobisite
-								</span>
-								<MoreHorizontal className="h-4 w-4 text-zinc-500" />
-							</div>
-						</div>
+
+						{/* App viewport */}
 						<div
-							className="min-h-0 flex-1 overflow-y-auto bg-background"
-							style={{ '--vh-screen': '730px' } as CSSProperties}
+							className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-background"
+							style={{ '--vh-screen': `${IPHONE_15_APP_HEIGHT}px` } as CSSProperties}
 						>
 							<MobisiteApp />
 						</div>
-						<div className="grid h-14 grid-cols-5 items-center border-t border-zinc-300/70 bg-zinc-100 px-4 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
-							<button type="button" className="flex justify-center" aria-label="Back">
-								<ChevronLeft className="h-5 w-5" />
-							</button>
-							<button type="button" className="flex justify-center" aria-label="Forward">
-								<ChevronRight className="h-5 w-5" />
-							</button>
-							<button type="button" className="flex justify-center" aria-label="Share">
-								<Share className="h-5 w-5" />
-							</button>
-							<button type="button" className="flex justify-center" aria-label="Bookmarks">
-								<BookOpen className="h-5 w-5" />
-							</button>
-							<button type="button" className="flex justify-center" aria-label="Tabs">
-								<Square className="h-5 w-5" />
-							</button>
+
+						{/* Home indicator */}
+						<div className="flex h-[34px] shrink-0 items-center justify-center bg-background pb-2">
+							<div className="h-[5px] w-[134px] rounded-full bg-zinc-900/80 dark:bg-white/30" />
 						</div>
 					</div>
 				</div>
+				<p className="mt-4 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
+					iPhone 15 preview
+				</p>
 			</div>
 			<div className="block sm:hidden">
 				<MobisiteApp />

--- a/apps/desktop/src/styles/marketingStyles.ts
+++ b/apps/desktop/src/styles/marketingStyles.ts
@@ -1,0 +1,67 @@
+/** Marketing-style Tailwind class maps with dark-mode variants. */
+
+export const pageBg = 'bg-gray-50 dark:bg-gray-950';
+
+export const pageBgAlt = 'bg-white dark:bg-gray-900';
+
+export const cardSurface =
+	'rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow duration-200 hover:shadow-md dark:border-gray-800 dark:bg-gray-900';
+
+export const cardSurfaceMuted =
+	'rounded-xl border border-gray-100 bg-gray-50/60 dark:border-gray-800 dark:bg-gray-800/40';
+
+export const cardSurfaceInner =
+	'rounded-xl border border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-900';
+
+export const sectionLabel =
+	'text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500';
+
+export const pageTitle = 'text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-50';
+
+export const pageSubtitle = 'text-base leading-relaxed text-gray-500 dark:text-gray-400';
+
+export const pillBadge =
+	'inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3.5 py-1.5 text-xs font-medium text-blue-600 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-400';
+
+export const primaryCta =
+	'rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-500';
+
+export const outlinePill =
+	'rounded-full border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800';
+
+export const navItemActive =
+	'bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400';
+
+export const navItemInactive =
+	'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-50';
+
+export const currencyBase = 'font-mono font-semibold';
+
+export const currencyPositive = 'text-blue-600 dark:text-blue-400';
+
+export const currencyNegative = 'text-gray-700 dark:text-gray-300';
+
+export const currencyIncome = 'text-blue-600 dark:text-blue-400';
+
+export const currencyExpense = 'text-gray-700 dark:text-gray-300';
+
+export const balancePositive = 'text-emerald-600 dark:text-emerald-400';
+
+export const balanceNegative = 'text-red-500 dark:text-red-400';
+
+export const frostedPanel =
+	'border border-gray-200/80 bg-white/95 backdrop-blur dark:border-gray-800/80 dark:bg-gray-900/95';
+
+export const modalShell =
+	'rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-800 dark:bg-gray-900';
+
+export const progressTrack = 'bg-blue-100 dark:bg-blue-950';
+
+export const progressFill = 'bg-blue-500 dark:bg-blue-400';
+
+export const rowDivider = 'border-b border-gray-50 dark:border-gray-800/60';
+
+export const selectedRow = 'bg-blue-50/50 dark:bg-blue-950/30';
+
+export const radialWash =
+	'pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-10%,rgba(59,130,246,0.10),transparent)] dark:bg-[radial-gradient(ellipse_80%_50%_at_50%_-10%,rgba(59,130,246,0.06),transparent)]';

--- a/apps/mobisite/src/App.tsx
+++ b/apps/mobisite/src/App.tsx
@@ -1,5 +1,12 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { ArrowDownCircle, ArrowUpCircle, List, LogOut, PlusCircle } from 'lucide-react';
+import {
+	ArrowDownCircle,
+	ArrowUpCircle,
+	ChevronRight,
+	List,
+	LogOut,
+	PlusCircle,
+} from 'lucide-react';
 import {
 	createUserWithEmailAndPassword,
 	onAuthStateChanged,
@@ -19,10 +26,13 @@ import {
 	useTransactions,
 } from '@cash-flow/shared';
 
-type MobileTab = 'add' | 'list';
+type MobileView = 'home' | 'add' | 'list';
 type MobileTransactionType = 'income' | 'expense';
 
-const MOBILE_TAB_STORAGE_KEY = 'cashflow-mobisite-tab';
+const MOBILE_VIEW_STORAGE_KEY = 'cashflow-mobisite-view';
+
+const isMobileView = (value: string | null): value is Exclude<MobileView, 'home'> =>
+	value === 'add' || value === 'list';
 
 const formatDateKey = (transaction: Transaction) =>
 	getTransactionDateOrEpoch(transaction.date, transaction.createdAt).toLocaleDateString('en-ZA', {
@@ -389,17 +399,63 @@ const TransactionListView = () => {
 	);
 };
 
+const MobileHomeView = ({ onSelect }: { onSelect: (view: Exclude<MobileView, 'home'>) => void }) => (
+	<section
+		className="py-6 pl-[calc(1.25rem+env(safe-area-inset-left))] pr-[calc(1.25rem+env(safe-area-inset-right))] md:p-6"
+		data-testid="mobisite-home"
+	>
+		<div className="mx-auto max-w-sm space-y-3">
+			<p className="text-sm text-muted-foreground">What would you like to do?</p>
+			<button
+				type="button"
+				onClick={() => onSelect('add')}
+				className="flex w-full items-center gap-4 rounded-2xl border border-border/80 bg-card p-4 text-left shadow-sm transition-colors hover:bg-muted/40"
+			>
+				<span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+					<PlusCircle className="h-6 w-6" />
+				</span>
+				<span className="min-w-0 flex-1">
+					<span className="block text-base font-semibold">Add transaction</span>
+					<span className="mt-0.5 block text-sm text-muted-foreground">
+						Capture income or expenses on the go
+					</span>
+				</span>
+				<ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+			</button>
+			<button
+				type="button"
+				onClick={() => onSelect('list')}
+				className="flex w-full items-center gap-4 rounded-2xl border border-border/80 bg-card p-4 text-left shadow-sm transition-colors hover:bg-muted/40"
+			>
+				<span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+					<List className="h-6 w-6" />
+				</span>
+				<span className="min-w-0 flex-1">
+					<span className="block text-base font-semibold">View transactions</span>
+					<span className="mt-0.5 block text-sm text-muted-foreground">
+						Browse your recent activity by date
+					</span>
+				</span>
+				<ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+			</button>
+		</div>
+	</section>
+);
+
 const MobileApp = ({ user }: { user: User }) => {
-	const [tab, setTab] = useState<MobileTab>(() => {
-		if (typeof window === 'undefined') return 'add';
-		const savedTab = window.sessionStorage.getItem(MOBILE_TAB_STORAGE_KEY);
-		return savedTab === 'list' ? 'list' : 'add';
+	const [view, setView] = useState<MobileView>(() => {
+		if (typeof window === 'undefined') return 'home';
+		const savedView = window.sessionStorage.getItem(MOBILE_VIEW_STORAGE_KEY);
+		return isMobileView(savedView) ? savedView : 'home';
 	});
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		window.sessionStorage.setItem(MOBILE_TAB_STORAGE_KEY, tab);
-	}, [tab]);
+		window.sessionStorage.setItem(MOBILE_VIEW_STORAGE_KEY, view);
+	}, [view]);
+
+	const headerTitle =
+		view === 'home' ? 'Dashboard' : view === 'add' ? 'Add transaction' : 'Transactions';
 
 	return (
 		<div
@@ -412,9 +468,7 @@ const MobileApp = ({ user }: { user: User }) => {
 						<p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
 							CashFlow mobile
 						</p>
-						<h1 className="mt-1 truncate text-lg font-semibold tracking-tight">
-							{tab === 'add' ? 'Add transaction' : 'Transactions'}
-						</h1>
+						<h1 className="mt-1 truncate text-lg font-semibold tracking-tight">{headerTitle}</h1>
 					</div>
 					<button
 						type="button"
@@ -425,40 +479,47 @@ const MobileApp = ({ user }: { user: User }) => {
 						<LogOut className="h-4 w-4" />
 					</button>
 				</div>
-				<nav className="mx-auto mt-4 grid w-full max-w-sm grid-cols-2 gap-2 pb-3" data-testid="mobisite-nav">
-					<button
-						type="button"
-						onClick={() => setTab('add')}
-						aria-pressed={tab === 'add'}
-						className={`flex h-12 items-center justify-center gap-2 rounded-xl border text-sm font-semibold transition-colors ${
-							tab === 'add'
-								? 'border-primary bg-primary text-primary-foreground shadow-sm'
-								: 'border-border/80 bg-card text-foreground'
-						}`}
+				{view !== 'home' && (
+					<nav
+						className="mx-auto mt-4 grid w-full max-w-sm grid-cols-2 gap-2 pb-3"
+						data-testid="mobisite-nav"
 					>
-						<PlusCircle className="h-4 w-4" />
-						Add
-					</button>
-					<button
-						type="button"
-						onClick={() => setTab('list')}
-						aria-pressed={tab === 'list'}
-						className={`flex h-12 items-center justify-center gap-2 rounded-xl border text-sm font-semibold transition-colors ${
-							tab === 'list'
-								? 'border-primary bg-primary text-primary-foreground shadow-sm'
-								: 'border-border/80 bg-card text-foreground'
-						}`}
-					>
-						<List className="h-4 w-4" />
-						List
-					</button>
-				</nav>
+						<button
+							type="button"
+							onClick={() => setView('add')}
+							aria-pressed={view === 'add'}
+							className={`flex h-12 items-center justify-center gap-2 rounded-xl border text-sm font-semibold transition-colors ${
+								view === 'add'
+									? 'border-primary bg-primary text-primary-foreground shadow-sm'
+									: 'border-border/80 bg-card text-foreground'
+							}`}
+						>
+							<PlusCircle className="h-4 w-4" />
+							Add
+						</button>
+						<button
+							type="button"
+							onClick={() => setView('list')}
+							aria-pressed={view === 'list'}
+							className={`flex h-12 items-center justify-center gap-2 rounded-xl border text-sm font-semibold transition-colors ${
+								view === 'list'
+									? 'border-primary bg-primary text-primary-foreground shadow-sm'
+									: 'border-border/80 bg-card text-foreground'
+							}`}
+						>
+							<List className="h-4 w-4" />
+							List
+						</button>
+					</nav>
+				)}
 			</header>
 			<div
 				className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain"
 				data-testid="mobisite-content"
 			>
-				{tab === 'add' ? <AddTransactionView /> : <TransactionListView />}
+				{view === 'home' && <MobileHomeView onSelect={setView} />}
+				{view === 'add' && <AddTransactionView />}
+				{view === 'list' && <TransactionListView />}
 			</div>
 		</div>
 	);

--- a/apps/mobisite/src/__tests__/App.test.tsx
+++ b/apps/mobisite/src/__tests__/App.test.tsx
@@ -52,12 +52,14 @@ describe('Mobisite App', () => {
 		window.sessionStorage.clear();
 	});
 
-	it('exposes only the mobile add/list navigation', async () => {
+	it('starts on the home dashboard with add and list options', async () => {
 		render(<App />);
 
-		expect(await screen.findByRole('button', { name: 'Add' })).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'List' })).toBeInTheDocument();
-		expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+		expect(await screen.findByTestId('mobisite-home')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /add transaction/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /view transactions/i })).toBeInTheDocument();
+		expect(screen.queryByTestId('mobisite-nav')).not.toBeInTheDocument();
 		expect(screen.queryByText('Accounts')).not.toBeInTheDocument();
 		expect(screen.queryByText('Budgets')).not.toBeInTheDocument();
 		expect(screen.queryByText('Reports')).not.toBeInTheDocument();
@@ -65,15 +67,18 @@ describe('Mobisite App', () => {
 		expect(screen.queryByText('Settings')).not.toBeInTheDocument();
 	});
 
-	it('keeps the mobile shell navigation visible while switching tabs', async () => {
+	it('shows top nav after selecting a view and keeps it while switching', async () => {
 		const user = userEvent.setup();
 
 		render(<App />);
 
-		expect(await screen.findByTestId('mobisite-shell')).toBeInTheDocument();
-		expect(screen.getByTestId('mobisite-content')).toBeInTheDocument();
+		await user.click(await screen.findByRole('button', { name: /add transaction/i }));
+
 		expect(screen.getByTestId('mobisite-nav')).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Add transaction' })).toBeInTheDocument();
+		expect(screen.getByLabelText('Title')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'List' })).toBeInTheDocument();
 
 		await user.click(screen.getByRole('button', { name: 'List' }));
 
@@ -88,6 +93,15 @@ describe('Mobisite App', () => {
 		expect(screen.getByTestId('mobisite-nav')).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Add transaction' })).toBeInTheDocument();
 		expect(screen.getByLabelText('Title')).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Add transaction' })).toBeInTheDocument();
+	});
+
+	it('restores the last selected view on reload', async () => {
+		window.sessionStorage.setItem('cashflow-mobisite-view', 'list');
+
+		render(<App />);
+
+		expect(await screen.findByTestId('mobisite-nav')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument();
+		expect(screen.getByText('Coffee')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- Add shared marketing design primitives (`Currency`, `SectionHeader`, `MarketingCard`, `MotionReveal`, `marketingStyles.ts`) and a `marketing` button variant aligned with the landing page aesthetic
- Restyle the full authenticated desktop app (shell, overview, transactions, accounts, budgets, reports, recurring, forms, settings) with blue/gray palette, mono currency, rounded cards, and moderate motion
- Fix dashboard "Due today" recurring section rendering underneath widgets by switching from a collapsing grid row to a flex layout
- Upgrade Mobisite desktop preview to an iPhone 15 frame (Dynamic Island, status bar, home indicator) and add a home dashboard picker before add/list views with persistent top nav after selection
- Add agent git workflow standards: `.cursor/skills/git-workflow/`, root `AGENTS.md`, and README pointer for branch prefixes (`feat`, `fix`, `chore`, `docs`, `refactor`), commits, and PR creation

## Test plan
- [x] All 111 unit tests pass (`npm test`)
- [x] TypeScript compiles for desktop (`tsc -p tsconfig.app.json`)
- [ ] Visual pass: light + dark mode on `/dashboard`, transactions, accounts, budgets, reports, recurring, settings
- [ ] Verify "Due today" recurring cards appear above widget row on xl screens
- [ ] Mobisite: home picker → add/list with top nav; iPhone 15 frame on desktop `/mobisite`
- [ ] Confirm auth modals and mobile redirect to `/mobisite` still work
- [ ] Agents can follow `.cursor/skills/git-workflow/SKILL.md` for branch/PR conventions