### PR TITLE
feat: refresh budget planning experience

### DIFF
--- a/apps/desktop/src/components/app/ui/side-panel.tsx
+++ b/apps/desktop/src/components/app/ui/side-panel.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const SidePanel = DialogPrimitive.Root;
+const SidePanelClose = DialogPrimitive.Close;
+const SidePanelTitle = DialogPrimitive.Title;
+const SidePanelDescription = DialogPrimitive.Description;
+
+const SidePanelContent = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<DialogPrimitive.Portal>
+		<DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-gray-950/40 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+		<DialogPrimitive.Content
+			ref={ref}
+			className={cn(
+				'fixed inset-0 z-50 flex w-full flex-col border-l border-gray-200 bg-white text-gray-900 shadow-2xl outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right dark:border-gray-800 dark:bg-gray-900 dark:text-gray-50 sm:inset-y-0 sm:left-auto sm:right-0 sm:max-w-xl',
+				className
+			)}
+			{...props}
+		>
+			{children}
+			<DialogPrimitive.Close className="absolute right-5 top-5 rounded-full border border-gray-200 bg-white p-2 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-50">
+				<X className="h-4 w-4" />
+				<span className="sr-only">Close</span>
+			</DialogPrimitive.Close>
+		</DialogPrimitive.Content>
+	</DialogPrimitive.Portal>
+));
+SidePanelContent.displayName = 'SidePanelContent';
+
+export {
+	SidePanel,
+	SidePanelClose,
+	SidePanelContent,
+	SidePanelDescription,
+	SidePanelTitle,
+};

--- a/apps/desktop/src/domains/budgets/context/BudgetsContext.tsx
+++ b/apps/desktop/src/domains/budgets/context/BudgetsContext.tsx
@@ -1,41 +1,19 @@
-import React, { createContext, useContext, ReactNode } from 'react';
-import { useBudgetsController } from '@/domains/budgets/controllers/BudgetsController';
-import { Budget, BudgetProgress, DateRange, Transaction } from '@/types';
+import React, { createContext, useContext, type ReactNode } from 'react';
+import {
+	useBudgetsController,
+	type BudgetsControllerReturn,
+} from '@/domains/budgets/controllers/BudgetsController';
 
-type BudgetFormData = Omit<
-	Budget,
-	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
->;
+const BudgetsContext = createContext<BudgetsControllerReturn | undefined>(undefined);
 
-interface BudgetsContextValue {
-	budgets: Budget[];
-	loading: boolean;
-	addBudget: (budget: BudgetFormData) => Promise<void>;
-	addDraftBudget: (budget: BudgetFormData) => Promise<void>;
-	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
-	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
-	publishBudget: (id: string) => Promise<void>;
-	deleteBudget: (id: string) => Promise<void>;
-	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
-	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];
-}
+export const BudgetsProvider: React.FC<{ children: ReactNode }> = ({ children }) => (
+	<BudgetsContext.Provider value={useBudgetsController()}>
+		{children}
+	</BudgetsContext.Provider>
+);
 
-const BudgetsContext = createContext<BudgetsContextValue | undefined>(undefined);
-
-export const BudgetsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-	const controller = useBudgetsController();
-
-	return (
-		<BudgetsContext.Provider value={controller}>
-			{children}
-		</BudgetsContext.Provider>
-	);
-};
-
-export const useBudgetsContext = (): BudgetsContextValue => {
+export const useBudgetsContext = (): BudgetsControllerReturn => {
 	const context = useContext(BudgetsContext);
-	if (!context) {
-		throw new Error('useBudgetsContext must be used within a BudgetsProvider');
-	}
+	if (!context) throw new Error('useBudgetsContext must be used within a BudgetsProvider');
 	return context;
 };

--- a/apps/desktop/src/domains/budgets/controllers/BudgetsController.ts
+++ b/apps/desktop/src/domains/budgets/controllers/BudgetsController.ts
@@ -1,52 +1,33 @@
-import { useBudgets } from '@/domains/budgets/hooks/useBudgets';
-import { Budget, BudgetProgress, DateRange, Transaction } from '@/types';
-import { calculateBudgetUsage } from '@/domains/budgets/models/BudgetModel';
+import { useBudgets, type BudgetFormData } from '@/domains/budgets/hooks/useBudgets';
+import { Budget, BudgetProgress, Transaction } from '@/types';
+import { calculateBudgetProgress } from '@/domains/budgets/models/BudgetModel';
+import { UpdateBudgetInput } from '@/domains/budgets/services/budgetService';
 
-type BudgetFormData = Omit<
-	Budget,
-	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
->;
-
-interface BudgetsControllerReturn {
+export interface BudgetsControllerReturn {
 	budgets: Budget[];
 	loading: boolean;
 	addBudget: (budget: BudgetFormData) => Promise<void>;
-	addDraftBudget: (budget: BudgetFormData) => Promise<void>;
-	updateBudget: (id: string, updates: Partial<Budget>) => Promise<void>;
-	startBudget: (id: string, actualRange: DateRange) => Promise<void>;
-	publishBudget: (id: string) => Promise<void>;
+	updateBudget: (id: string, updates: UpdateBudgetInput) => Promise<void>;
 	deleteBudget: (id: string) => Promise<void>;
-	getBudgetProgress: (budgetId: string, transactions: Transaction[]) => BudgetProgress | null;
+	publishBudget: (id: string) => Promise<void>;
+	repeatBudget: (id: string) => Promise<void>;
+	reorderBudgets: (orderedBudgetIds: string[]) => Promise<void>;
+	getBudgetProgress: (
+		budgetId: string,
+		transactions: Transaction[]
+	) => BudgetProgress | null;
 	getAllBudgetProgress: (transactions: Transaction[]) => BudgetProgress[];
 }
 
 export const useBudgetsController = (): BudgetsControllerReturn => {
-	const {
-		budgets,
-		addBudget,
-		addDraftBudget,
-		updateBudget,
-		startBudget,
-		publishBudget,
-		deleteBudget,
-		loading,
-	} = useBudgets();
-
+	const data = useBudgets();
 	return {
-		budgets,
-		loading,
-		addBudget,
-		addDraftBudget,
-		updateBudget,
-		startBudget,
-		publishBudget,
-		deleteBudget,
+		...data,
 		getBudgetProgress: (budgetId, transactions) => {
-			const budget = budgets.find((b) => b.id === budgetId);
-			if (!budget) return null;
-			return calculateBudgetUsage(budget, transactions);
+			const budget = data.budgets.find((item) => item.id === budgetId);
+			return budget ? calculateBudgetProgress(budget, transactions) : null;
 		},
 		getAllBudgetProgress: (transactions) =>
-			budgets.map((b) => calculateBudgetUsage(b, transactions)),
+			data.budgets.map((budget) => calculateBudgetProgress(budget, transactions)),
 	};
 };

--- a/apps/desktop/src/domains/budgets/hooks/__tests__/useBudgets.test.ts
+++ b/apps/desktop/src/domains/budgets/hooks/__tests__/useBudgets.test.ts
@@ -1,23 +1,30 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useBudgets } from '../useBudgets';
 import { auth } from '@/services/firebase';
+import {
+	createBudget,
+	deleteBudget,
+	publishBudget,
+	reorderBudgets,
+	repeatBudget,
+	updateBudget,
+} from '@/domains/budgets/services/budgetService';
 
-const mockAddDoc = jest.fn();
-const mockUpdateDoc = jest.fn();
-const mockDeleteDoc = jest.fn();
 const mockOnSnapshot = jest.fn();
 
 jest.mock('firebase/firestore', () => ({
 	collection: jest.fn((...path: string[]) => ({ path })),
-	addDoc: (...args: unknown[]) => mockAddDoc(...args),
-	deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
-	updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
-	doc: jest.fn((...path: string[]) => ({ path })),
 	query: jest.fn((collectionRef: unknown) => collectionRef),
 	onSnapshot: (...args: unknown[]) => mockOnSnapshot(...args),
-	Timestamp: {
-		now: jest.fn(() => 'timestamp-now'),
-	},
+}));
+
+jest.mock('@/domains/budgets/services/budgetService', () => ({
+	createBudget: jest.fn(),
+	updateBudget: jest.fn(),
+	deleteBudget: jest.fn(),
+	publishBudget: jest.fn(),
+	repeatBudget: jest.fn(),
+	reorderBudgets: jest.fn(),
 }));
 
 const mockUser = { uid: 'user-1' };
@@ -40,25 +47,17 @@ describe('useBudgets', () => {
 				next({
 					docs: [
 						{
-							id: 'draft-1',
+							id: 'budget-1',
 							data: () => ({
-								category: 'groceries',
-								amount: 1000,
+								userId: 'user-1',
+								categoryId: 'food',
+								subCategoryId: 'takeaways',
+								amount: 1500,
 								period: 'monthly',
-								status: 'draft',
-								plannedStartDate: '2026-05-01',
-								plannedEndDate: '2026-05-31',
-							}),
-						},
-						{
-							id: 'published-1',
-							data: () => ({
-								category: 'groceries',
-								amount: 500,
-								period: 'monthly',
-								status: 'published',
-								plannedStartDate: '2026-05-01',
-								plannedEndDate: '2026-05-31',
+								month: '2026-05',
+								startDate: '2026-05-01',
+								endDate: '2026-05-31',
+								lifecycleStatus: 'draft',
 							}),
 						},
 					],
@@ -68,48 +67,41 @@ describe('useBudgets', () => {
 		);
 	});
 
-	it('creates draft budgets with draft status', async () => {
+	it('subscribes to and normalizes user budgets', async () => {
 		const { result } = renderHook(() => useBudgets());
-
-		await act(async () => {
-			await result.current.addDraftBudget({
-				category: 'groceries',
-				amount: 1000,
-				period: 'monthly',
-				plannedStartDate: '2026-05-01',
-				plannedEndDate: '2026-05-31',
-			});
-		});
-
-		expect(mockAddDoc).toHaveBeenCalledWith(expect.anything(), {
-			category: 'groceries',
-			amount: 1000,
-			period: 'monthly',
-			plannedStartDate: '2026-05-01',
-			plannedEndDate: '2026-05-31',
-			status: 'draft',
-			userId: 'user-1',
-			createdAt: 'timestamp-now',
-		});
+		await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+		expect(result.current.budgets[0].subCategoryId).toBe('takeaways');
 	});
 
-	it('publishes a draft by updating status and using the planned period', async () => {
+	it('delegates create, update, and delete operations with ownership', async () => {
 		const { result } = renderHook(() => useBudgets());
-
-		await waitFor(() => {
-			expect(result.current.budgets).toHaveLength(2);
-		});
+		const input = {
+			categoryId: 'food',
+			subCategoryId: 'takeaways',
+			amount: 1500,
+			period: 'monthly' as const,
+			month: '2026-05',
+			startDate: '2026-05-01',
+			endDate: '2026-05-31',
+			lifecycleStatus: 'draft' as const,
+		};
 
 		await act(async () => {
-			await result.current.publishBudget('draft-1');
+			await result.current.addBudget(input);
+			await result.current.updateBudget('budget-1', { amount: 1700 });
+			await result.current.deleteBudget('budget-1');
+			await result.current.publishBudget('budget-1');
+			await result.current.repeatBudget('budget-1');
+			await result.current.reorderBudgets(['budget-1']);
 		});
 
-		expect(mockUpdateDoc).toHaveBeenCalledWith(expect.anything(), {
-			status: 'published',
-			actualStartDate: '2026-05-01',
-			actualEndDate: '2026-05-31',
+		expect(createBudget).toHaveBeenCalledWith({ ...input, userId: 'user-1' });
+		expect(updateBudget).toHaveBeenCalledWith('user-1', 'budget-1', {
+			amount: 1700,
 		});
-		expect(mockAddDoc).not.toHaveBeenCalled();
-		expect(mockDeleteDoc).not.toHaveBeenCalled();
+		expect(deleteBudget).toHaveBeenCalledWith('user-1', 'budget-1');
+		expect(publishBudget).toHaveBeenCalledWith('user-1', 'budget-1');
+		expect(repeatBudget).toHaveBeenCalledWith('user-1', 'budget-1');
+		expect(reorderBudgets).toHaveBeenCalledWith('user-1', ['budget-1']);
 	});
 });

--- a/apps/desktop/src/domains/budgets/hooks/useBudgets.ts
+++ b/apps/desktop/src/domains/budgets/hooks/useBudgets.ts
@@ -1,35 +1,30 @@
-import { useState, useEffect } from 'react';
-import { db, auth } from '@/services/firebase';
-import {
-	collection,
-	addDoc,
-	deleteDoc,
-	updateDoc,
-	doc,
-	query,
-	onSnapshot,
-	Timestamp,
-	type UpdateData,
-} from 'firebase/firestore';
-import { Budget, DateRange } from '@/types';
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot, query } from 'firebase/firestore';
+import { auth, db } from '@/services/firebase';
+import { Budget } from '@/types';
 import { normalizeBudget } from '@/domains/budgets/models/BudgetModel';
+import {
+	createBudget,
+	deleteBudget as deleteBudgetDocument,
+	publishBudget as publishBudgetDocument,
+	repeatBudget as repeatBudgetDocument,
+	reorderBudgets as reorderBudgetsDocument,
+	updateBudget as updateBudgetDocument,
+	type CreateBudgetInput,
+	type UpdateBudgetInput,
+} from '@/domains/budgets/services/budgetService';
 
-type BudgetFormData = Omit<
-	Budget,
-	'id' | 'createdAt' | 'userId' | 'status' | 'actualStartDate' | 'actualEndDate'
->;
+export type BudgetFormData = Omit<CreateBudgetInput, 'userId'>;
 
 export const useBudgets = () => {
 	const [budgets, setBudgets] = useState<Budget[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [user, setUser] = useState(() => auth.currentUser);
 
-	useEffect(() => {
-		const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
-			setUser(firebaseUser);
-		});
-		return () => unsubscribe();
-	}, []);
+	useEffect(
+		() => auth.onAuthStateChanged((firebaseUser) => setUser(firebaseUser)),
+		[]
+	);
 
 	useEffect(() => {
 		if (!user) {
@@ -39,94 +34,61 @@ export const useBudgets = () => {
 		}
 
 		setLoading(true);
-		const col = collection(db, 'users', user.uid, 'budgets');
-		const q = query(col);
-
-		const unsubscribe = onSnapshot(q, (snapshot) => {
-			const fetched = snapshot.docs.map((d) =>
-				normalizeBudget({ id: d.id, ...d.data() })
-			);
-			setBudgets(fetched);
-			setLoading(false);
-		}, (error) => {
-			console.error('Error fetching budgets:', error);
-			setLoading(false);
-		});
-
-		return () => unsubscribe();
+		return onSnapshot(
+			query(collection(db, 'users', user.uid, 'budgets')),
+			(snapshot) => {
+				setBudgets(
+					snapshot.docs.map((budgetDoc) =>
+						normalizeBudget({ id: budgetDoc.id, ...budgetDoc.data() })
+					)
+				);
+				setLoading(false);
+			},
+			(error) => {
+				console.error('Error fetching budgets:', error);
+				setLoading(false);
+			}
+		);
 	}, [user]);
 
 	const addBudget = async (budget: BudgetFormData) => {
 		if (!user) throw new Error('User not authenticated');
-
-		const col = collection(db, 'users', user.uid, 'budgets');
-		await addDoc(col, {
-			...budget,
-			status: 'published',
-			userId: user.uid,
-			createdAt: Timestamp.now(),
-		});
+		await createBudget({ ...budget, userId: user.uid });
 	};
 
-	const addDraftBudget = async (budget: BudgetFormData) => {
+	const updateBudget = async (id: string, updates: UpdateBudgetInput) => {
 		if (!user) throw new Error('User not authenticated');
-
-		const col = collection(db, 'users', user.uid, 'budgets');
-		await addDoc(col, {
-			...budget,
-			status: 'draft',
-			userId: user.uid,
-			createdAt: Timestamp.now(),
-		});
-	};
-
-	const updateBudget = async (id: string, updates: Partial<Budget>) => {
-		if (!user) throw new Error('User not authenticated');
-		const ref = doc(db, 'users', user.uid, 'budgets', id);
-		await updateDoc(ref, updates as UpdateData<Budget>);
-	};
-
-	const startBudget = async (id: string, actualRange: DateRange) => {
-		if (!user) throw new Error('User not authenticated');
-		if (!actualRange.startDate || !actualRange.endDate) {
-			throw new Error('Please select a start and end date before starting a budget.');
-		}
-
-		const ref = doc(db, 'users', user.uid, 'budgets', id);
-		await updateDoc(ref, {
-			actualStartDate: actualRange.startDate,
-			actualEndDate: actualRange.endDate,
-		});
-	};
-
-	const publishBudget = async (id: string) => {
-		if (!user) throw new Error('User not authenticated');
-
-		const budget = budgets.find((item) => item.id === id);
-		if (!budget) throw new Error('Budget not found');
-
-		const ref = doc(db, 'users', user.uid, 'budgets', id);
-		await updateDoc(ref, {
-			status: 'published',
-			actualStartDate: budget.plannedStartDate,
-			actualEndDate: budget.plannedEndDate,
-		});
+		await updateBudgetDocument(user.uid, id, updates);
 	};
 
 	const deleteBudget = async (id: string) => {
 		if (!user) throw new Error('User not authenticated');
-		const ref = doc(db, 'users', user.uid, 'budgets', id);
-		await deleteDoc(ref);
+		await deleteBudgetDocument(user.uid, id);
+	};
+
+	const publishBudget = async (id: string) => {
+		if (!user) throw new Error('User not authenticated');
+		await publishBudgetDocument(user.uid, id);
+	};
+
+	const repeatBudget = async (id: string) => {
+		if (!user) throw new Error('User not authenticated');
+		await repeatBudgetDocument(user.uid, id);
+	};
+
+	const reorderBudgets = async (orderedBudgetIds: string[]) => {
+		if (!user) throw new Error('User not authenticated');
+		await reorderBudgetsDocument(user.uid, orderedBudgetIds);
 	};
 
 	return {
 		budgets,
 		addBudget,
-		addDraftBudget,
 		updateBudget,
-		startBudget,
-		publishBudget,
 		deleteBudget,
+		publishBudget,
+		repeatBudget,
+		reorderBudgets,
 		loading,
 	};
 };

--- a/apps/desktop/src/domains/budgets/models/BudgetModel.ts
+++ b/apps/desktop/src/domains/budgets/models/BudgetModel.ts
@@ -1,42 +1,24 @@
-import { Budget, BudgetProgress, DateRange, Transaction } from '@/types';
-import { filterTransactionsByDateRangeObject } from '@/shared/filters/utils/dateRangeFilter';
+import { Budget, BudgetProgress, BudgetStatus, Transaction } from '@/types';
 import { parseDbDateOrNull } from '@/utils/date';
 
 export type { Budget };
 
-const toIsoDate = (value: Date): string => value.toISOString().split('T')[0];
-
-const getMonthBounds = (baseDate: Date): DateRange => {
-	const start = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
-	const end = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, 0);
-
-	return {
-		startDate: toIsoDate(start),
-		endDate: toIsoDate(end),
-	};
-};
-
-type BudgetDocForLegacy = {
-	createdAt?: unknown;
-	updatedAt?: unknown;
-};
-
-const getLegacyBudgetRange = (doc: BudgetDocForLegacy): DateRange => {
-	const createdAt =
-		parseDbDateOrNull(doc.createdAt) ??
-		parseDbDateOrNull(doc.updatedAt) ??
-		new Date();
-
-	return getMonthBounds(createdAt);
-};
-
 type BudgetDoc = {
 	id: string;
 	userId?: string;
+	accountId?: string;
+	categoryId?: string;
+	subCategoryId?: string;
 	category?: string;
+	subcategory?: string;
 	amount?: number;
 	period?: Budget['period'];
-	status?: Budget['status'];
+	month?: string;
+	startDate?: string;
+	endDate?: string;
+	lifecycleStatus?: Budget['lifecycleStatus'];
+	displayOrder?: number;
+	status?: string;
 	plannedStartDate?: string;
 	plannedEndDate?: string;
 	actualStartDate?: string;
@@ -45,76 +27,236 @@ type BudgetDoc = {
 	updatedAt?: unknown;
 };
 
+const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+export const MAX_BUDGETS = 8;
+
+const toDateKey = (date: Date): string => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+};
+
+export const getCurrentBudgetMonth = (date = new Date()): string =>
+	`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+export const isValidBudgetMonth = (month: string): boolean => MONTH_PATTERN.test(month);
+
+export const getMonthDateRange = (
+	month: string
+): { startDate: string; endDate: string } => {
+	const [year, monthNumber] = month.split('-').map(Number);
+	const start = new Date(year, monthNumber - 1, 1);
+	const end = new Date(year, monthNumber, 0);
+	return { startDate: toDateKey(start), endDate: toDateKey(end) };
+};
+
+export const getNextBudgetMonth = (month: string): string => {
+	const [year, monthNumber] = month.split('-').map(Number);
+	return getCurrentBudgetMonth(new Date(year, monthNumber, 1));
+};
+
 export const normalizeBudget = (doc: BudgetDoc): Budget => {
-	const legacyRange = getLegacyBudgetRange(doc);
-	const budget: Budget = {
+	const createdAt = parseDbDateOrNull(doc.createdAt);
+	const updatedAt = parseDbDateOrNull(doc.updatedAt);
+	const fallbackMonth =
+		doc.month ??
+		doc.plannedStartDate?.slice(0, 7) ??
+		getCurrentBudgetMonth(createdAt ?? new Date());
+	const period = doc.period === 'custom' ? 'custom' : 'monthly';
+	const monthlyRange = getMonthDateRange(fallbackMonth);
+	const startDate =
+		doc.startDate ??
+		doc.actualStartDate ??
+		doc.plannedStartDate ??
+		monthlyRange.startDate;
+	const endDate =
+		doc.endDate ??
+		doc.actualEndDate ??
+		doc.plannedEndDate ??
+		monthlyRange.endDate;
+
+	return {
 		id: doc.id,
-		userId: doc.userId,
-		category: doc.category ?? '',
+		userId: doc.userId ?? '',
+		accountId: doc.accountId || undefined,
+		categoryId: doc.categoryId ?? doc.category ?? '',
+		subCategoryId: doc.subCategoryId ?? doc.subcategory ?? undefined,
 		amount: doc.amount ?? 0,
-		period: doc.period ?? 'monthly',
-		status: doc.status ?? 'published',
-		plannedStartDate: doc.plannedStartDate ?? legacyRange.startDate,
-		plannedEndDate: doc.plannedEndDate ?? legacyRange.endDate,
-		actualStartDate: doc.actualStartDate ?? undefined,
-		actualEndDate: doc.actualEndDate ?? undefined,
+		period,
+		month: period === 'monthly' ? fallbackMonth : undefined,
+		startDate,
+		endDate,
+		lifecycleStatus:
+			doc.lifecycleStatus ?? (doc.status === 'draft' ? 'draft' : 'published'),
+		displayOrder:
+			typeof doc.displayOrder === 'number' ? doc.displayOrder : undefined,
+		...(createdAt ? { createdAt } : {}),
+		...(updatedAt ? { updatedAt } : {}),
 	};
-
-	const createdParsed = doc.createdAt != null ? parseDbDateOrNull(doc.createdAt) : null;
-	if (createdParsed) {
-		budget.createdAt = createdParsed;
-	}
-
-	return budget;
 };
 
 export const normalizeBudgets = (docs: BudgetDoc[]): Budget[] => docs.map(normalizeBudget);
 
-export const calculateBudgetUsage = (
+export const isTransactionInBudgetPeriod = (
+	transaction: Transaction,
+	budget: Pick<Budget, 'startDate' | 'endDate'>
+): boolean => {
+	const transactionDate =
+		parseDbDateOrNull(transaction.date) ?? parseDbDateOrNull(transaction.createdAt);
+	if (!transactionDate) return false;
+	const dateKey = toDateKey(transactionDate);
+	return dateKey >= budget.startDate && dateKey <= budget.endDate;
+};
+
+export const isTransactionInBudgetMonth = (
+	transaction: Transaction,
+	month: string
+): boolean =>
+	isTransactionInBudgetPeriod(transaction, getMonthDateRange(month));
+
+export const transactionMatchesBudget = (
+	transaction: Transaction,
+	budget: Budget
+): boolean =>
+	transaction.type === 'expense' &&
+	(!transaction.userId || transaction.userId === budget.userId) &&
+	transaction.category === budget.categoryId &&
+	(!budget.subCategoryId || transaction.subcategory === budget.subCategoryId) &&
+	(!budget.accountId || transaction.accountId === budget.accountId) &&
+	isTransactionInBudgetPeriod(transaction, budget);
+
+export const calculateBudgetSpent = (
+	transactions: Transaction[],
+	budget: Budget
+): number =>
+	transactions
+		.filter((transaction) => transactionMatchesBudget(transaction, budget))
+		.reduce((sum, transaction) => sum + transaction.amount, 0);
+
+export const calculateBudgetRemaining = (
+	budgetAmount: number,
+	spent: number
+): number => budgetAmount - spent;
+
+export const calculateBudgetUsedPercentage = (
+	budgetAmount: number,
+	spent: number
+): number => (budgetAmount > 0 ? (spent / budgetAmount) * 100 : 0);
+
+export const getBudgetStatus = (
+	budgetAmount: number,
+	spent: number
+): BudgetStatus => {
+	const percentage = calculateBudgetUsedPercentage(budgetAmount, spent);
+	if (percentage >= 100) return 'over';
+	if (percentage >= 75) return 'warning';
+	return 'safe';
+};
+
+export const budgetOverlapsMonth = (budget: Budget, month: string): boolean => {
+	const range = getMonthDateRange(month);
+	return budget.startDate <= range.endDate && budget.endDate >= range.startDate;
+};
+
+export const isBudgetPeriodDone = (budget: Budget, now = new Date()): boolean =>
+	budget.endDate < toDateKey(now);
+
+export const isDuplicateBudget = (
+	budgets: Budget[],
+	candidate: Pick<
+		Budget,
+		'accountId' | 'categoryId' | 'subCategoryId' | 'startDate' | 'endDate'
+	>,
+	ignoreBudgetId?: string
+): boolean =>
+	budgets.some(
+		(budget) =>
+			budget.id !== ignoreBudgetId &&
+			(budget.accountId ?? '') === (candidate.accountId ?? '') &&
+			budget.categoryId === candidate.categoryId &&
+			(budget.subCategoryId ?? '') === (candidate.subCategoryId ?? '') &&
+			budget.startDate === candidate.startDate &&
+			budget.endDate === candidate.endDate
+	);
+
+export const buildRepeatedBudget = (
+	budget: Budget
+): Omit<Budget, 'id' | 'createdAt' | 'updatedAt'> => {
+	const sourceStart = new Date(`${budget.startDate}T12:00:00`);
+	const sourceEnd = new Date(`${budget.endDate}T12:00:00`);
+	const month =
+		budget.period === 'monthly'
+			? getNextBudgetMonth(budget.month ?? budget.startDate.slice(0, 7))
+			: undefined;
+	let range = month ? getMonthDateRange(month) : undefined;
+
+	if (!range) {
+		const durationMs = sourceEnd.getTime() - sourceStart.getTime();
+		const nextStart = new Date(sourceEnd);
+		nextStart.setDate(nextStart.getDate() + 1);
+		const nextEnd = new Date(nextStart.getTime() + durationMs);
+		range = { startDate: toDateKey(nextStart), endDate: toDateKey(nextEnd) };
+	}
+
+	return {
+		userId: budget.userId,
+		accountId: budget.accountId,
+		categoryId: budget.categoryId,
+		subCategoryId: budget.subCategoryId,
+		amount: budget.amount,
+		period: budget.period,
+		month,
+		startDate: range.startDate,
+		endDate: range.endDate,
+		lifecycleStatus: 'draft',
+	};
+};
+
+export const sortBudgetsByDisplayOrder = (budgets: Budget[]): Budget[] =>
+	[...budgets].sort((left, right) => {
+		const leftOrder = left.displayOrder ?? Number.MAX_SAFE_INTEGER;
+		const rightOrder = right.displayOrder ?? Number.MAX_SAFE_INTEGER;
+		if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+
+		const leftCreatedAt = parseDbDateOrNull(left.createdAt)?.getTime() ?? 0;
+		const rightCreatedAt = parseDbDateOrNull(right.createdAt)?.getTime() ?? 0;
+		if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt - rightCreatedAt;
+		return left.id.localeCompare(right.id);
+	});
+
+export const calculateBudgetProgress = (
 	budget: Budget,
 	transactions: Transaction[]
 ): BudgetProgress => {
-	const isDraft = budget.status === 'draft';
-	const started = Boolean(budget.actualStartDate && budget.actualEndDate);
-	const calculating = isDraft || started;
-	const comparisonRange: DateRange = {
-		startDate: isDraft ? budget.plannedStartDate : budget.actualStartDate ?? '',
-		endDate: isDraft ? budget.plannedEndDate : budget.actualEndDate ?? '',
-	};
-
-	const actualSpent = calculating
-		? filterTransactionsByDateRangeObject(
-				transactions.filter(
-					(transaction) =>
-						transaction.type === 'expense' && transaction.category === budget.category
-				),
-				comparisonRange
-		  ).reduce((sum, transaction) => sum + transaction.amount, 0)
-		: 0;
-
-	const remaining = calculating ? Math.max(0, budget.amount - actualSpent) : budget.amount;
-	const overBudget = calculating ? Math.max(0, actualSpent - budget.amount) : 0;
-	const percent =
-		calculating && budget.amount > 0
-			? Math.min(100, (actualSpent / budget.amount) * 100)
-			: 0;
-
+	const spent = calculateBudgetSpent(transactions, budget);
 	return {
 		budget,
-		status: budget.status,
-		isDraft,
-		plannedAmount: budget.amount,
-		plannedStartDate: budget.plannedStartDate,
-		plannedEndDate: budget.plannedEndDate,
-		actualStartDate: budget.actualStartDate,
-		actualEndDate: budget.actualEndDate,
-		comparisonStartDate: comparisonRange.startDate,
-		comparisonEndDate: comparisonRange.endDate,
-		started,
-		calculating,
-		actualSpent,
-		remaining,
-		overBudget,
-		percent,
+		spent,
+		remaining: calculateBudgetRemaining(budget.amount, spent),
+		usedPercentage: calculateBudgetUsedPercentage(budget.amount, spent),
+		status: getBudgetStatus(budget.amount, spent),
+	};
+};
+
+export const calculateBudgetSummary = (
+	budgets: Budget[],
+	transactions: Transaction[],
+	month: string
+) => {
+	const progress = budgets
+		.filter(
+			(budget) =>
+				budget.lifecycleStatus === 'published' &&
+				budgetOverlapsMonth(budget, month)
+		)
+		.map((budget) => calculateBudgetProgress(budget, transactions));
+
+	return {
+		totalBudget: progress.reduce((sum, item) => sum + item.budget.amount, 0),
+		totalSpent: progress.reduce((sum, item) => sum + item.spent, 0),
+		remaining: progress.reduce((sum, item) => sum + item.remaining, 0),
+		overCount: progress.filter((item) => item.status === 'over').length,
+		warningCount: progress.filter((item) => item.status === 'warning').length,
 	};
 };

--- a/apps/desktop/src/domains/budgets/models/__tests__/BudgetModel.test.ts
+++ b/apps/desktop/src/domains/budgets/models/__tests__/BudgetModel.test.ts
@@ -1,114 +1,182 @@
-import { calculateBudgetUsage, normalizeBudget } from '../BudgetModel';
+import {
+	budgetOverlapsMonth,
+	buildRepeatedBudget,
+	calculateBudgetRemaining,
+	calculateBudgetSpent,
+	calculateBudgetUsedPercentage,
+	getBudgetStatus,
+	getMonthDateRange,
+	isDuplicateBudget,
+	isTransactionInBudgetMonth,
+	normalizeBudget,
+	transactionMatchesBudget,
+} from '../BudgetModel';
 import { Budget, Transaction } from '@/types';
 
 const makeBudget = (overrides: Partial<Budget> = {}): Budget => ({
 	id: 'budget-1',
-	category: 'groceries',
-	amount: 1000,
+	userId: 'user-1',
+	categoryId: 'food',
+	subCategoryId: 'takeaways',
+	amount: 1500,
 	period: 'monthly',
-	status: 'published',
-	plannedStartDate: '2026-05-01',
-	plannedEndDate: '2026-05-31',
+	month: '2026-05',
+	startDate: '2026-05-01',
+	endDate: '2026-05-31',
+	lifecycleStatus: 'published',
 	...overrides,
 });
 
-const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+const makeTransaction = (
+	overrides: Partial<Transaction> = {}
+): Transaction => ({
 	id: 'transaction-1',
+	userId: 'user-1',
 	accountId: 'account-1',
-	title: 'Groceries',
+	title: 'Dinner',
 	amount: 250,
 	type: 'expense',
-	category: 'groceries',
+	category: 'food',
+	subcategory: 'takeaways',
 	date: new Date('2026-05-10T12:00:00Z'),
 	...overrides,
 });
 
 describe('BudgetModel', () => {
-	describe('normalizeBudget', () => {
-		it('defaults legacy budgets to published status', () => {
-			const budget = normalizeBudget({
-				id: 'legacy-budget',
-				category: 'groceries',
-				amount: 1000,
-				plannedStartDate: '2026-05-01',
-				plannedEndDate: '2026-05-31',
-			});
-
-			expect(budget.status).toBe('published');
-		});
-
-		it('preserves draft status', () => {
-			const budget = normalizeBudget({
-				id: 'draft-budget',
-				category: 'groceries',
-				amount: 1000,
+	it('normalizes legacy monthly budgets and preserves draft state', () => {
+		expect(
+			normalizeBudget({
+				id: 'budget-1',
+				userId: 'user-1',
+				category: 'food',
+				amount: 1500,
+				period: 'monthly',
+				month: '2026-05',
 				status: 'draft',
-				plannedStartDate: '2026-05-01',
-				plannedEndDate: '2026-05-31',
-			});
+			})
+		).toEqual(
+			expect.objectContaining({
+				categoryId: 'food',
+				subCategoryId: undefined,
+				startDate: '2026-05-01',
+				endDate: '2026-05-31',
+				lifecycleStatus: 'draft',
+			})
+		);
+	});
 
-			expect(budget.status).toBe('draft');
+	it('builds correct month date ranges', () => {
+		expect(getMonthDateRange('2024-02')).toEqual({
+			startDate: '2024-02-01',
+			endDate: '2024-02-29',
 		});
 	});
 
-	describe('calculateBudgetUsage', () => {
-		it('uses the planned range for draft live calculations', () => {
-			const budget = makeBudget({ status: 'draft' });
-			const progress = calculateBudgetUsage(budget, [
-				makeTransaction(),
-				makeTransaction({
-					id: 'outside-range',
-					amount: 300,
-					date: new Date('2026-06-01T12:00:00Z'),
-				}),
-			]);
+	it('filters transactions by YYYY-MM using transaction date', () => {
+		expect(isTransactionInBudgetMonth(makeTransaction(), '2026-05')).toBe(true);
+		expect(isTransactionInBudgetMonth(makeTransaction(), '2026-06')).toBe(false);
+	});
 
-			expect(progress.isDraft).toBe(true);
-			expect(progress.comparisonStartDate).toBe('2026-05-01');
-			expect(progress.comparisonEndDate).toBe('2026-05-31');
-			expect(progress.actualSpent).toBe(250);
-			expect(progress.remaining).toBe(750);
+	it('matches category budgets without requiring a sub-category', () => {
+		const categoryBudget = makeBudget({ subCategoryId: undefined });
+		expect(transactionMatchesBudget(makeTransaction(), categoryBudget)).toBe(true);
+		expect(
+			transactionMatchesBudget(
+				makeTransaction({ subcategory: 'groceries' }),
+				categoryBudget
+			)
+		).toBe(true);
+	});
+
+	it('narrows matching when a sub-category is selected', () => {
+		const budget = makeBudget({ accountId: 'account-1' });
+		expect(transactionMatchesBudget(makeTransaction(), budget)).toBe(true);
+		expect(
+			transactionMatchesBudget(
+				makeTransaction({ subcategory: 'groceries' }),
+				budget
+			)
+		).toBe(false);
+		expect(
+			transactionMatchesBudget(
+				makeTransaction({ accountId: 'account-2' }),
+				budget
+			)
+		).toBe(false);
+	});
+
+	it('matches custom date ranges and filters outside transactions', () => {
+		const budget = makeBudget({
+			period: 'custom',
+			month: undefined,
+			startDate: '2026-05-10',
+			endDate: '2026-05-20',
 		});
+		expect(transactionMatchesBudget(makeTransaction(), budget)).toBe(true);
+		expect(
+			transactionMatchesBudget(
+				makeTransaction({ date: new Date('2026-05-21T12:00:00Z') }),
+				budget
+			)
+		).toBe(false);
+	});
 
-		it('uses the active actual range for published calculations', () => {
-			const budget = makeBudget({
-				actualStartDate: '2026-06-01',
-				actualEndDate: '2026-06-30',
-			});
-			const progress = calculateBudgetUsage(budget, [
-				makeTransaction({
-					id: 'planned-range-only',
-					amount: 250,
-					date: new Date('2026-05-10T12:00:00Z'),
-				}),
-				makeTransaction({
-					id: 'actual-range',
-					amount: 400,
-					date: new Date('2026-06-10T12:00:00Z'),
-				}),
-			]);
+	it('calculates spent, remaining, and percentage without capping overspend', () => {
+		const budget = makeBudget({ amount: 400 });
+		const transactions = [
+			makeTransaction({ amount: 250 }),
+			makeTransaction({ id: 'transaction-2', amount: 200 }),
+		];
+		expect(calculateBudgetSpent(transactions, budget)).toBe(450);
+		expect(calculateBudgetRemaining(400, 450)).toBe(-50);
+		expect(calculateBudgetUsedPercentage(400, 450)).toBe(112.5);
+	});
 
-			expect(progress.isDraft).toBe(false);
-			expect(progress.started).toBe(true);
-			expect(progress.comparisonStartDate).toBe('2026-06-01');
-			expect(progress.comparisonEndDate).toBe('2026-06-30');
-			expect(progress.actualSpent).toBe(400);
-			expect(progress.remaining).toBe(600);
+	it.each([
+		[1000, 749, 'safe'],
+		[1000, 750, 'warning'],
+		[1000, 999, 'warning'],
+		[1000, 1000, 'over'],
+	] as const)(
+		'returns the expected status for %s budget and %s spent',
+		(amount, spent, expected) => {
+			expect(getBudgetStatus(amount, spent)).toBe(expected);
+		}
+	);
+
+	it('detects duplicates by optional sub-category and exact date range', () => {
+		const budgets = [makeBudget({ subCategoryId: undefined })];
+		expect(
+			isDuplicateBudget(budgets, makeBudget({ subCategoryId: undefined }))
+		).toBe(true);
+		expect(
+			isDuplicateBudget(
+				budgets,
+				makeBudget({ subCategoryId: undefined, startDate: '2026-06-01' })
+			)
+		).toBe(false);
+	});
+
+	it('finds custom budgets that overlap the selected month', () => {
+		const budget = makeBudget({
+			period: 'custom',
+			month: undefined,
+			startDate: '2026-05-20',
+			endDate: '2026-06-10',
 		});
+		expect(budgetOverlapsMonth(budget, '2026-05')).toBe(true);
+		expect(budgetOverlapsMonth(budget, '2026-06')).toBe(true);
+		expect(budgetOverlapsMonth(budget, '2026-07')).toBe(false);
+	});
 
-		it('returns zero spend and the full remaining amount when nothing matches', () => {
-			const budget = makeBudget({ status: 'draft' });
-			const progress = calculateBudgetUsage(budget, [
-				makeTransaction({
-					category: 'transport',
-					amount: 500,
-				}),
-			]);
-
-			expect(progress.actualSpent).toBe(0);
-			expect(progress.remaining).toBe(1000);
-			expect(progress.overBudget).toBe(0);
-			expect(progress.percent).toBe(0);
-		});
+	it('repeats a monthly budget into the next month as a draft', () => {
+		expect(buildRepeatedBudget(makeBudget())).toEqual(
+			expect.objectContaining({
+				month: '2026-06',
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+				lifecycleStatus: 'draft',
+			})
+		);
 	});
 });

--- a/apps/desktop/src/domains/budgets/services/__tests__/budgetService.test.ts
+++ b/apps/desktop/src/domains/budgets/services/__tests__/budgetService.test.ts
@@ -1,0 +1,124 @@
+import { createBudget, reorderBudgets, updateBudget } from '../budgetService';
+
+const mockUpdateDoc = jest.fn();
+const mockAddDoc = jest.fn();
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+
+jest.mock('@/services/firebase', () => ({
+	db: {},
+}));
+
+jest.mock('firebase/firestore', () => ({
+	Timestamp: {
+		now: jest.fn(() => 'timestamp-now'),
+	},
+	addDoc: (...args: unknown[]) => mockAddDoc(...args),
+	collection: jest.fn((...path: string[]) => ({ path })),
+	deleteDoc: jest.fn(),
+	doc: jest.fn((...path: string[]) => ({ path })),
+	getDoc: (...args: unknown[]) => mockGetDoc(...args),
+	getDocs: (...args: unknown[]) => mockGetDocs(...args),
+	query: jest.fn((value: unknown) => value),
+	updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+	writeBatch: jest.fn(() => ({
+		update: mockBatchUpdate,
+		commit: mockBatchCommit,
+	})),
+}));
+
+describe('budgetService updateBudget', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockGetDoc.mockResolvedValue({
+			exists: () => true,
+			id: 'budget-1',
+			data: () => ({
+				userId: 'user-1',
+				categoryId: 'food',
+				amount: 1500,
+				period: 'monthly',
+				month: '2026-06',
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+				lifecycleStatus: 'draft',
+			}),
+		});
+		mockGetDocs.mockResolvedValue({ docs: [] });
+	});
+
+	it('never sends undefined optional fields to Firestore', async () => {
+		await updateBudget('user-1', 'budget-1', {
+			accountId: undefined,
+			subCategoryId: undefined,
+			amount: 1700,
+			period: 'monthly',
+			month: '2026-06',
+			startDate: '2026-06-01',
+			endDate: '2026-06-30',
+		});
+
+		expect(mockUpdateDoc).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				accountId: null,
+				subCategoryId: null,
+				amount: 1700,
+			})
+		);
+		const payload = mockUpdateDoc.mock.calls[0][1];
+		expect(Object.values(payload)).not.toContain(undefined);
+	});
+
+	it('prevents creating more than eight budgets', async () => {
+		mockGetDocs.mockResolvedValue({
+			docs: Array.from({ length: 8 }, (_, index) => ({
+				id: `budget-${index}`,
+				data: () => ({
+					userId: 'user-1',
+					categoryId: `category-${index}`,
+					amount: 100,
+					period: 'monthly',
+					month: '2026-06',
+					startDate: '2026-06-01',
+					endDate: '2026-06-30',
+					lifecycleStatus: 'draft',
+				}),
+			})),
+		});
+
+		await expect(
+			createBudget({
+				userId: 'user-1',
+				categoryId: 'food',
+				amount: 1000,
+				period: 'monthly',
+				month: '2026-06',
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+				lifecycleStatus: 'draft',
+			})
+		).rejects.toThrow('You can create up to 8 budgets.');
+		expect(mockAddDoc).not.toHaveBeenCalled();
+	});
+
+	it('persists the complete display order in one batch', async () => {
+		mockBatchCommit.mockResolvedValue(undefined);
+
+		await reorderBudgets('user-1', ['budget-2', 'budget-1']);
+
+		expect(mockBatchUpdate).toHaveBeenNthCalledWith(
+			1,
+			expect.anything(),
+			expect.objectContaining({ displayOrder: 0 })
+		);
+		expect(mockBatchUpdate).toHaveBeenNthCalledWith(
+			2,
+			expect.anything(),
+			expect.objectContaining({ displayOrder: 1 })
+		);
+		expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/domains/budgets/services/budgetService.ts
+++ b/apps/desktop/src/domains/budgets/services/budgetService.ts
@@ -1,0 +1,202 @@
+import {
+	Timestamp,
+	addDoc,
+	collection,
+	deleteDoc,
+	doc,
+	getDoc,
+	getDocs,
+	query,
+	updateDoc,
+	writeBatch,
+	type UpdateData,
+} from 'firebase/firestore';
+import { db } from '@/services/firebase';
+import { Budget } from '@/types';
+import {
+	budgetOverlapsMonth,
+	buildRepeatedBudget,
+	isDuplicateBudget,
+	MAX_BUDGETS,
+	normalizeBudget,
+} from '@/domains/budgets/models/BudgetModel';
+
+export type CreateBudgetInput = Omit<
+	Budget,
+	'id' | 'createdAt' | 'updatedAt'
+>;
+
+export type UpdateBudgetInput = Partial<
+	Pick<
+		Budget,
+		| 'accountId'
+		| 'categoryId'
+		| 'subCategoryId'
+		| 'amount'
+		| 'period'
+		| 'month'
+		| 'startDate'
+		| 'endDate'
+		| 'lifecycleStatus'
+		| 'displayOrder'
+	>
+>;
+
+const budgetCollection = (userId: string) =>
+	collection(db, 'users', userId, 'budgets');
+
+const omitUndefined = <T extends Record<string, unknown>>(value: T) =>
+	Object.fromEntries(
+		Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined)
+	);
+
+const validateBudget = (
+	budget: Pick<Budget, 'amount' | 'categoryId' | 'startDate' | 'endDate'>
+) => {
+	if (!budget.categoryId) throw new Error('Please select a category.');
+	if (budget.amount <= 0) throw new Error('Budget amount must be greater than zero.');
+	if (!budget.startDate || !budget.endDate) {
+		throw new Error('Please select a budget start and end date.');
+	}
+	if (budget.startDate > budget.endDate) {
+		throw new Error('Budget end date must be on or after its start date.');
+	}
+};
+
+export const getBudgets = async (
+	userId: string,
+	month?: string
+): Promise<Budget[]> => {
+	const snapshot = await getDocs(query(budgetCollection(userId)));
+	const budgets = snapshot.docs.map((budgetDoc) =>
+		normalizeBudget({ id: budgetDoc.id, ...budgetDoc.data() })
+	);
+	return month
+		? budgets.filter((budget) => budgetOverlapsMonth(budget, month))
+		: budgets;
+};
+
+export const createBudget = async (
+	input: CreateBudgetInput
+): Promise<string> => {
+	validateBudget(input);
+	const existing = await getBudgets(input.userId);
+	if (existing.length >= MAX_BUDGETS) {
+		throw new Error(`You can create up to ${MAX_BUDGETS} budgets.`);
+	}
+	if (isDuplicateBudget(existing, input)) {
+		throw new Error('A budget already exists for this category and period.');
+	}
+
+	const created = await addDoc(
+		budgetCollection(input.userId),
+		omitUndefined({
+			...input,
+			displayOrder:
+				input.displayOrder ??
+				existing.reduce(
+					(highest, budget) =>
+						Math.max(highest, budget.displayOrder ?? -1),
+					-1
+				) +
+					1,
+			subCategoryId: input.subCategoryId || null,
+			month: input.period === 'monthly' ? input.month : null,
+			createdAt: Timestamp.now(),
+			updatedAt: Timestamp.now(),
+		})
+	);
+	return created.id;
+};
+
+export const reorderBudgets = async (
+	userId: string,
+	orderedBudgetIds: string[]
+): Promise<void> => {
+	const uniqueIds = new Set(orderedBudgetIds);
+	if (uniqueIds.size !== orderedBudgetIds.length) {
+		throw new Error('Budget order contains duplicate entries.');
+	}
+
+	const batch = writeBatch(db);
+	const updatedAt = Timestamp.now();
+	orderedBudgetIds.forEach((budgetId, displayOrder) => {
+		batch.update(doc(db, 'users', userId, 'budgets', budgetId), {
+			displayOrder,
+			updatedAt,
+		});
+	});
+	await batch.commit();
+};
+
+export const updateBudget = async (
+	userId: string,
+	id: string,
+	input: UpdateBudgetInput
+): Promise<void> => {
+	const budgetRef = doc(db, 'users', userId, 'budgets', id);
+	const snapshot = await getDoc(budgetRef);
+	if (!snapshot.exists()) throw new Error('Budget not found.');
+
+	const current = normalizeBudget({ id: snapshot.id, ...snapshot.data() });
+	const next = { ...current, ...input };
+	validateBudget(next);
+	const existing = await getBudgets(userId);
+	if (isDuplicateBudget(existing, next, id)) {
+		throw new Error('A budget already exists for this category and period.');
+	}
+
+	const updatesSubCategory = Object.prototype.hasOwnProperty.call(
+		input,
+		'subCategoryId'
+	);
+	const updatesAccount = Object.prototype.hasOwnProperty.call(input, 'accountId');
+	await updateDoc(
+		budgetRef,
+		omitUndefined({
+			...input,
+			...(updatesAccount ? { accountId: input.accountId || null } : {}),
+			...(updatesSubCategory
+				? { subCategoryId: input.subCategoryId || null }
+				: {}),
+			...(input.period === 'custom' ? { month: null } : {}),
+			updatedAt: Timestamp.now(),
+		}) as UpdateData<Budget>
+	);
+};
+
+export const publishBudget = async (
+	userId: string,
+	id: string
+): Promise<void> => {
+	await updateBudget(userId, id, { lifecycleStatus: 'published' });
+};
+
+export const repeatBudget = async (
+	userId: string,
+	id: string
+): Promise<string> => {
+	const snapshot = await getDoc(doc(db, 'users', userId, 'budgets', id));
+	if (!snapshot.exists()) throw new Error('Budget not found.');
+	const budget = normalizeBudget({ id: snapshot.id, ...snapshot.data() });
+	if (budget.lifecycleStatus !== 'published') {
+		throw new Error('Publish this budget before repeating it.');
+	}
+	return createBudget(buildRepeatedBudget(budget));
+};
+
+export const deleteBudget = async (
+	userId: string,
+	id: string
+): Promise<void> => {
+	await deleteDoc(doc(db, 'users', userId, 'budgets', id));
+};
+
+export const getBudgetForSubCategory = async (
+	userId: string,
+	subCategoryId: string,
+	month: string
+): Promise<Budget | null> => {
+	const budgets = await getBudgets(userId, month);
+	return budgets.find((budget) => budget.subCategoryId === subCategoryId) ?? null;
+};

--- a/apps/desktop/src/domains/budgets/views/BudgetForm.tsx
+++ b/apps/desktop/src/domains/budgets/views/BudgetForm.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { FiCalendar, FiDollarSign, FiTarget } from 'react-icons/fi';
 import { useBudgetsContext } from '@/domains/budgets/context/BudgetsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { Budget } from '@/types';
@@ -11,186 +12,416 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/app/ui/select';
-import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
-
-const getCurrentMonthRange = () => {
-	const now = new Date();
-	const start = new Date(now.getFullYear(), now.getMonth(), 1);
-	const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
-	return {
-		startDate: start.toISOString().split('T')[0],
-		endDate: end.toISOString().split('T')[0],
-	};
-};
+import {
+	SidePanelClose,
+	SidePanelContent,
+	SidePanelDescription,
+	SidePanelTitle,
+} from '@/components/app/ui/side-panel';
+import {
+	getMonthDateRange,
+	isDuplicateBudget,
+	MAX_BUDGETS,
+} from '@/domains/budgets/models/BudgetModel';
+import {
+	getBudgetScopeHelp,
+	getBudgetTitle,
+} from '@/domains/budgets/views/budgetDisplay';
+import { cn } from '@/lib/utils';
+import { useToast } from '@/components/app/ui/use-toast';
 
 interface BudgetFormProps {
 	onClose: () => void;
 	budget?: Budget;
+	defaultMonth: string;
 }
 
-const BudgetForm: React.FC<BudgetFormProps> = ({ onClose, budget }) => {
-	const { addDraftBudget, updateBudget } = useBudgetsContext();
-	const { categoryOptions } = useCategoriesContext();
+const NO_SUBCATEGORY = '__no_subcategory__';
 
-	const [category, setCategory] = useState('');
-	const [amount, setAmount] = useState(0);
-	const [plannedStartDate, setPlannedStartDate] = useState(getCurrentMonthRange().startDate);
-	const [plannedEndDate, setPlannedEndDate] = useState(getCurrentMonthRange().endDate);
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState('');
-	const availableCategories = React.useMemo(
-		() => mergeCategoryOptions(categoryOptions, category ? [category] : []),
-		[categoryOptions, category]
+const FieldError: React.FC<{ children?: string }> = ({ children }) =>
+	children ? <p className="mt-1.5 text-xs text-red-600 dark:text-red-400">{children}</p> : null;
+
+const BudgetForm: React.FC<BudgetFormProps> = ({
+	onClose,
+	budget,
+	defaultMonth,
+}) => {
+	const { budgets, addBudget, updateBudget } = useBudgetsContext();
+	const { toast } = useToast();
+	const {
+		categories,
+		getCategoryLabel,
+		getSubcategoryLabel,
+	} = useCategoriesContext();
+	const [period, setPeriod] = useState<Budget['period']>('monthly');
+	const [month, setMonth] = useState(defaultMonth);
+	const [startDate, setStartDate] = useState('');
+	const [endDate, setEndDate] = useState('');
+	const [categoryId, setCategoryId] = useState('');
+	const [subCategoryId, setSubCategoryId] = useState(NO_SUBCATEGORY);
+	const [amount, setAmount] = useState('');
+	const [saving, setSaving] = useState(false);
+	const [formError, setFormError] = useState('');
+	const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+	const selectedCategory = useMemo(
+		() => categories.find((category) => category.value === categoryId),
+		[categories, categoryId]
 	);
+	const previewBudget = {
+		categoryId,
+		subCategoryId:
+			subCategoryId === NO_SUBCATEGORY ? undefined : subCategoryId,
+	};
+	const previewTitle = categoryId
+		? getBudgetTitle(previewBudget, getCategoryLabel, getSubcategoryLabel)
+		: 'Choose a category';
+	const scopeHelp = categoryId
+		? getBudgetScopeHelp(previewBudget, getCategoryLabel)
+		: null;
 
 	useEffect(() => {
-		if (budget) {
-			setCategory(budget.category);
-			setAmount(budget.amount);
-			setPlannedStartDate(budget.plannedStartDate);
-			setPlannedEndDate(budget.plannedEndDate);
-		} else {
-			const defaultRange = getCurrentMonthRange();
-			setCategory('');
-			setAmount(0);
-			setPlannedStartDate(defaultRange.startDate);
-			setPlannedEndDate(defaultRange.endDate);
-		}
-	}, [budget]);
+		const initialPeriod = budget?.period ?? 'monthly';
+		const initialMonth = budget?.month ?? defaultMonth;
+		const monthlyRange = getMonthDateRange(initialMonth);
+		setPeriod(initialPeriod);
+		setMonth(initialMonth);
+		setStartDate(budget?.startDate ?? monthlyRange.startDate);
+		setEndDate(budget?.endDate ?? monthlyRange.endDate);
+		setCategoryId(budget?.categoryId ?? '');
+		setSubCategoryId(budget?.subCategoryId ?? NO_SUBCATEGORY);
+		setAmount(budget ? String(budget.amount) : '');
+		setFormError('');
+		setFieldErrors({});
+	}, [budget, defaultMonth]);
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!category) {
-			setError('Please select a category.');
+	const handleMonthChange = (value: string) => {
+		setMonth(value);
+		const range = getMonthDateRange(value);
+		setStartDate(range.startDate);
+		setEndDate(range.endDate);
+	};
+
+	const handleCategoryChange = (value: string) => {
+		setCategoryId(value);
+		setSubCategoryId(NO_SUBCATEGORY);
+		setFieldErrors((current) => ({ ...current, category: '' }));
+	};
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		const numericAmount = Number(amount);
+		const finalRange =
+			period === 'monthly' ? getMonthDateRange(month) : { startDate, endDate };
+		const finalSubCategoryId =
+			subCategoryId === NO_SUBCATEGORY ? undefined : subCategoryId;
+		const nextErrors: Record<string, string> = {};
+
+		if (!budget && budgets.length >= MAX_BUDGETS) {
+			setFormError(`You can create up to ${MAX_BUDGETS} budgets.`);
 			return;
 		}
-		if (Number(amount) <= 0) {
-			setError('Budget amount must be greater than zero.');
+		if (!categoryId) nextErrors.category = 'Choose a category.';
+		if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+			nextErrors.amount = 'Enter an amount greater than zero.';
+		}
+		if (!finalRange.startDate || !finalRange.endDate) {
+			nextErrors.period = 'Choose a start and end date.';
+		} else if (finalRange.startDate > finalRange.endDate) {
+			nextErrors.period = 'End date must be on or after the start date.';
+		}
+		if (Object.keys(nextErrors).length > 0) {
+			setFieldErrors(nextErrors);
 			return;
 		}
-		if (!plannedStartDate || !plannedEndDate) {
-			setError('Please choose both a planned start and end date.');
+		if (
+			isDuplicateBudget(
+				budgets,
+				{
+					accountId: budget?.accountId,
+					categoryId,
+					subCategoryId: finalSubCategoryId,
+					startDate: finalRange.startDate,
+					endDate: finalRange.endDate,
+				},
+				budget?.id
+			)
+		) {
+			setFormError('A budget already exists for this category and period.');
 			return;
 		}
-		if (plannedStartDate > plannedEndDate) {
-			setError('Planned end date must be on or after the planned start date.');
-			return;
-		}
-		setError('');
-		setLoading(true);
+
+		setSaving(true);
+		setFormError('');
+		setFieldErrors({});
 		try {
 			const data = {
-				category,
-				amount: Number(amount),
-				period: 'monthly' as const,
-				plannedStartDate,
-				plannedEndDate,
+				accountId: budget?.accountId,
+				categoryId,
+				subCategoryId: finalSubCategoryId,
+				amount: numericAmount,
+				period,
+				month: period === 'monthly' ? month : undefined,
+				startDate: finalRange.startDate,
+				endDate: finalRange.endDate,
+				lifecycleStatus: budget?.lifecycleStatus ?? ('draft' as const),
 			};
-			if (budget?.id) {
+			if (budget) {
 				await updateBudget(budget.id, data);
 			} else {
-				await addDraftBudget(data);
+				await addBudget(data);
 			}
+			toast({
+				title: budget ? 'Budget updated' : 'Budget draft created',
+				description: budget
+					? `${previewTitle} was updated successfully.`
+					: `${previewTitle} is ready for review and publishing.`,
+				duration: 3500,
+			});
 			onClose();
-		} catch (err: unknown) {
-			setError(err instanceof Error ? err.message : 'Failed to save budget. Please try again.');
+		} catch (saveError) {
+			setFormError(
+				saveError instanceof Error
+					? saveError.message
+					: 'Failed to save budget. Please try again.'
+			);
 		} finally {
-			setLoading(false);
+			setSaving(false);
 		}
 	};
 
+	const sectionClass =
+		'rounded-2xl border border-border bg-card p-5 text-card-foreground';
+	const inputClass = 'h-11 rounded-xl border-border bg-background';
+
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4">
-			<div className="w-full max-w-md rounded-2xl border bg-card p-8 shadow-xl">
-				<div className="mb-8 border-b pb-6">
-					<h2 className="text-3xl font-bold tracking-tight">
-						{budget ? 'Edit Budget' : 'New Draft Budget'}
-					</h2>
-					<p className="mt-1.5 text-sm text-muted-foreground">
-						{budget
-							? 'Update your planned budget amount and date range'
-							: 'Plan an amount and date range before publishing it'}
+		<SidePanelContent>
+			<form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+				<header className="border-b border-border bg-muted/30 px-6 py-6 pr-16">
+					<p className="text-xs font-semibold uppercase tracking-wider text-primary">
+						{budget ? 'Update budget' : 'New draft'}
 					</p>
+					<SidePanelTitle className="mt-2 text-2xl font-semibold tracking-tight">
+						{budget ? 'Edit budget' : 'Create a budget'}
+					</SidePanelTitle>
+					<SidePanelDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+						Set the spending goal, amount, and period. New budgets stay in draft
+						until published.
+					</SidePanelDescription>
+				</header>
+
+				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto bg-muted/20 p-4 sm:p-6">
+					{formError && (
+						<div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+							{formError}
+						</div>
+					)}
+
+					<div className="rounded-2xl border border-primary/20 bg-primary/5 p-5">
+						<div className="flex items-start gap-3">
+							<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background text-primary shadow-sm">
+								<FiTarget className="h-5 w-5" />
+							</div>
+							<div className="min-w-0">
+								<p className="text-xs font-medium uppercase tracking-wider text-primary">
+									Budget preview
+								</p>
+								<p className="mt-1 truncate text-xl font-semibold text-gray-950 dark:text-white">
+									{previewTitle}
+								</p>
+								<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+									{scopeHelp ?? 'Tracks expenses for this specific sub-category'}
+								</p>
+							</div>
+						</div>
+					</div>
+
+					<section className={sectionClass}>
+						<div className="mb-4 flex items-center gap-3">
+							<div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+								<FiTarget className="h-4 w-4" />
+							</div>
+							<div>
+								<h2 className="font-semibold">What are you budgeting?</h2>
+								<p className="text-xs text-gray-500 dark:text-gray-400">
+									Choose a category, then optionally narrow the goal.
+								</p>
+							</div>
+						</div>
+						<div className="space-y-4">
+							<div>
+								<label className="mb-1.5 block text-sm font-medium">Category</label>
+								<Select value={categoryId} onValueChange={handleCategoryChange}>
+									<SelectTrigger className={inputClass}>
+										<SelectValue placeholder="Select a category" />
+									</SelectTrigger>
+									<SelectContent>
+										{categories.map((category) => (
+											<SelectItem key={category.id} value={category.value}>
+												{category.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FieldError>{fieldErrors.category}</FieldError>
+							</div>
+
+							<div>
+								<label className="mb-1.5 block text-sm font-medium">
+									Sub-category <span className="font-normal text-gray-400">(optional)</span>
+								</label>
+								<Select
+									value={subCategoryId}
+									onValueChange={setSubCategoryId}
+									disabled={!selectedCategory}
+								>
+									<SelectTrigger className={inputClass}>
+										<SelectValue placeholder="No sub-category" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value={NO_SUBCATEGORY}>No sub-category</SelectItem>
+										{selectedCategory?.subcategories.map((subcategory) => (
+											<SelectItem key={subcategory.value} value={subcategory.value}>
+												{subcategory.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								{scopeHelp && (
+									<p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+										{scopeHelp}
+									</p>
+								)}
+							</div>
+						</div>
+					</section>
+
+					<section className={sectionClass}>
+						<div className="mb-4 flex items-center gap-3">
+							<div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+								<FiDollarSign className="h-4 w-4" />
+							</div>
+							<div>
+								<h2 className="font-semibold">How much?</h2>
+								<p className="text-xs text-gray-500 dark:text-gray-400">
+									Set the maximum planned spend in ZAR.
+								</p>
+							</div>
+						</div>
+						<label htmlFor="budget-amount" className="mb-1.5 block text-sm font-medium">
+							Budget amount
+						</label>
+						<div className="relative">
+							<span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-gray-500">
+								R
+							</span>
+							<Input
+								id="budget-amount"
+								type="number"
+								step="0.01"
+								min="0.01"
+								value={amount}
+								onChange={(event) => {
+									setAmount(event.target.value);
+									setFieldErrors((current) => ({ ...current, amount: '' }));
+								}}
+								placeholder="1 500"
+								className={cn(inputClass, 'pl-8 text-base')}
+								required
+							/>
+						</div>
+						<FieldError>{fieldErrors.amount}</FieldError>
+					</section>
+
+					<section className={sectionClass}>
+						<div className="mb-4 flex items-center gap-3">
+							<div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+								<FiCalendar className="h-4 w-4" />
+							</div>
+							<div>
+								<h2 className="font-semibold">For when?</h2>
+								<p className="text-xs text-gray-500 dark:text-gray-400">
+									Use a calendar month or set exact dates.
+								</p>
+							</div>
+						</div>
+						<div className="mb-4 grid grid-cols-2 gap-2 rounded-xl bg-muted p-1">
+							{(['monthly', 'custom'] as const).map((value) => (
+								<button
+									key={value}
+									type="button"
+									onClick={() => setPeriod(value)}
+									className={cn(
+										'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+										period === value
+											? 'bg-background text-foreground shadow-sm'
+											: 'text-muted-foreground hover:text-foreground'
+									)}
+								>
+									{value === 'monthly' ? 'Monthly' : 'Custom dates'}
+								</button>
+							))}
+						</div>
+
+						{period === 'monthly' ? (
+							<div>
+								<label htmlFor="budget-month" className="mb-1.5 block text-sm font-medium">
+									Month
+								</label>
+								<Input
+									id="budget-month"
+									type="month"
+									value={month}
+									onChange={(event) => handleMonthChange(event.target.value)}
+									className={inputClass}
+									required
+								/>
+							</div>
+						) : (
+							<div className="grid gap-4 sm:grid-cols-2">
+								<div>
+									<label htmlFor="budget-start" className="mb-1.5 block text-sm font-medium">
+										Start date
+									</label>
+									<Input
+										id="budget-start"
+										type="date"
+										value={startDate}
+										onChange={(event) => setStartDate(event.target.value)}
+										className={inputClass}
+										required
+									/>
+								</div>
+								<div>
+									<label htmlFor="budget-end" className="mb-1.5 block text-sm font-medium">
+										End date
+									</label>
+									<Input
+										id="budget-end"
+										type="date"
+										value={endDate}
+										onChange={(event) => setEndDate(event.target.value)}
+										className={inputClass}
+										required
+									/>
+								</div>
+							</div>
+						)}
+						<FieldError>{fieldErrors.period}</FieldError>
+					</section>
 				</div>
 
-				{error && (
-					<div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-						{error}
-					</div>
-				)}
-
-				<form onSubmit={handleSubmit} className="space-y-5">
-					<div className="space-y-1.5">
-						<label className="text-sm font-medium">Category</label>
-						<Select value={category} onValueChange={setCategory}>
-							<SelectTrigger className="h-11">
-								<SelectValue placeholder="Select a category" />
-							</SelectTrigger>
-							<SelectContent>
-								{availableCategories.map((c) => (
-									<SelectItem key={c.value} value={c.value}>
-										{c.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-
-					<div className="space-y-1.5">
-						<label className="text-sm font-medium">Planned Amount (ZAR)</label>
-						<Input
-							type="number"
-							step="0.01"
-							min="0.01"
-							value={amount}
-							onChange={(e) => setAmount(Number(e.target.value))}
-							placeholder="e.g. 2000"
-							required
-						/>
-					</div>
-
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-						<div className="space-y-1.5">
-							<label className="text-sm font-medium">Planned Start Date</label>
-							<Input
-								type="date"
-								value={plannedStartDate}
-								onChange={(e) => setPlannedStartDate(e.target.value)}
-								required
-							/>
-						</div>
-						<div className="space-y-1.5">
-							<label className="text-sm font-medium">Planned End Date</label>
-							<Input
-								type="date"
-								value={plannedEndDate}
-								onChange={(e) => setPlannedEndDate(e.target.value)}
-								required
-							/>
-						</div>
-					</div>
-
-					<div className="rounded-xl border bg-muted/30 p-3 text-sm text-muted-foreground">
-						Draft budgets show live spend for this planned period. Publish when
-						you are ready to make the period active.
-					</div>
-
-					<div className="flex gap-3 pt-2">
-						<Button type="submit" className="flex-1 h-12" disabled={loading}>
-							{loading
-								? 'Saving...'
-								: budget
-									? 'Update Budget'
-									: 'Create Draft'}
-						</Button>
-						<Button type="button" variant="outline" onClick={onClose}>
+				<footer className="sticky bottom-0 flex gap-3 border-t border-border bg-background px-4 py-4 sm:px-6">
+					<SidePanelClose asChild>
+						<Button type="button" variant="outline" className="h-11 flex-1 rounded-xl">
 							Cancel
 						</Button>
-					</div>
-				</form>
-			</div>
-		</div>
+					</SidePanelClose>
+					<Button type="submit" className="h-11 flex-[1.4] rounded-xl" disabled={saving}>
+						{saving ? 'Saving...' : budget ? 'Update budget' : 'Save draft'}
+					</Button>
+				</footer>
+			</form>
+		</SidePanelContent>
 	);
 };
 

--- a/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
+++ b/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
@@ -1,28 +1,39 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
-	FiAlertCircle,
 	FiCalendar,
+	FiChevronLeft,
+	FiChevronRight,
 	FiEdit2,
-	FiPlay,
+	FiMoreHorizontal,
+	FiMove,
 	FiPlus,
+	FiRepeat,
 	FiTarget,
 	FiTrash2,
 	FiUploadCloud,
 } from 'react-icons/fi';
 import { useBudgetsContext } from '@/domains/budgets/context/BudgetsContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
-import { Budget, BudgetProgress, DateRange } from '@/types';
-import { modalShell, pageBg } from '@/styles/marketingStyles';
-import { cn } from '@/lib/utils';
-import { formatCurrency } from '@/utils/formatCurrency';
-import {
-	filterTransactionsByDateRangeObject,
-	formatDateRange,
-} from '@/shared/filters/utils/dateRangeFilter';
-import { parseDbDate } from '@/utils/date';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
+import { Budget, BudgetProgress } from '@/types';
+import {
+	budgetOverlapsMonth,
+	calculateBudgetProgress,
+	getCurrentBudgetMonth,
+	isBudgetPeriodDone,
+	MAX_BUDGETS,
+	sortBudgetsByDisplayOrder,
+} from '@/domains/budgets/models/BudgetModel';
+import {
+	getBudgetPeriodLabel,
+	getBudgetScopeHelp,
+	getBudgetTitle,
+} from '@/domains/budgets/views/budgetDisplay';
+import { formatCurrency } from '@/utils/formatCurrency';
+import { useToast } from '@/components/app/ui/use-toast';
 import { Button } from '@/components/app/ui/button';
-import DateRangeFilter from '@/shared/filters/components/DateRangeFilter';
+import { Input } from '@/components/app/ui/input';
+import { SidePanel } from '@/components/app/ui/side-panel';
 import {
 	Dialog,
 	DialogContent,
@@ -31,518 +42,725 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/app/ui/dialog';
+import { cn } from '@/lib/utils';
+import {
+	cardSurface,
+	cardSurfaceMuted,
+	modalShell,
+	pageBg,
+	sectionLabel,
+} from '@/styles/marketingStyles';
 import BudgetForm from './BudgetForm';
 
-const getBarColour = (percent: number): string => {
-	if (percent >= 90) return 'bg-red-500 dark:bg-red-400';
-	if (percent >= 70) return 'bg-amber-500 dark:bg-amber-400';
-	return 'bg-blue-500 dark:bg-blue-400';
+const STATUS_STYLES = {
+	safe: {
+		label: 'On track',
+		ring: '#3b82f6',
+		text: 'text-blue-600 dark:text-blue-400',
+		badge: 'bg-blue-50 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300',
+	},
+	warning: {
+		label: 'Watch spending',
+		ring: '#f59e0b',
+		text: 'text-amber-600 dark:text-amber-400',
+		badge: 'bg-amber-50 text-amber-700 dark:bg-amber-950/60 dark:text-amber-300',
+	},
+	over: {
+		label: 'Over budget',
+		ring: '#ef4444',
+		text: 'text-red-600 dark:text-red-400',
+		badge: 'bg-red-50 text-red-700 dark:bg-red-950/60 dark:text-red-300',
+	},
+};
+
+const BudgetProgressRing: React.FC<{
+	percentage: number;
+	status: BudgetProgress['status'];
+}> = ({ percentage, status }) => {
+	const size = 112;
+	const strokeWidth = 9;
+	const radius = (size - strokeWidth) / 2;
+	const circumference = 2 * Math.PI * radius;
+	const normalized = Math.min(Math.max(percentage, 0), 100);
+	const offset = circumference - (normalized / 100) * circumference;
+	const styles = STATUS_STYLES[status];
+
+	return (
+		<div className="relative flex h-28 w-28 items-center justify-center">
+			<svg
+				viewBox={`0 0 ${size} ${size}`}
+				className="-rotate-90"
+				aria-label={`${Math.round(percentage)} percent used`}
+				role="img"
+			>
+				<circle
+					cx={size / 2}
+					cy={size / 2}
+					r={radius}
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={strokeWidth}
+					className="text-blue-100 dark:text-gray-800"
+				/>
+				<circle
+					cx={size / 2}
+					cy={size / 2}
+					r={radius}
+					fill="none"
+					stroke={styles.ring}
+					strokeWidth={strokeWidth}
+					strokeLinecap="round"
+					strokeDasharray={circumference}
+					strokeDashoffset={offset}
+					className="transition-all duration-500"
+				/>
+			</svg>
+			<div className="absolute text-center">
+				<p className={cn('text-2xl font-semibold tracking-tight', styles.text)}>
+					{Math.round(percentage)}%
+				</p>
+				<p className="text-[10px] font-medium uppercase tracking-wide text-gray-400">
+					used
+				</p>
+			</div>
+		</div>
+	);
+};
+
+interface BudgetCardProps {
+	item: BudgetProgress;
+	getCategoryLabel: (categoryId: string) => string;
+	getSubcategoryLabel: (categoryId: string, subCategoryId?: string) => string;
+	actionId?: string;
+	onEdit: (budget: Budget) => void;
+	onDelete: (budget: Budget) => void;
+	onPublish: (budget: Budget) => void;
+	onRepeat: (budgetId: string) => void;
+	onMove: (direction: -1 | 1) => void;
+	onDragStart: () => void;
+	onDragEnd: () => void;
+	onDragOver: (event: React.DragEvent<HTMLElement>) => void;
+	onDrop: () => void;
+	isFirst: boolean;
+	isLast: boolean;
+	isDragging: boolean;
+}
+
+const BudgetCard: React.FC<BudgetCardProps> = ({
+	item,
+	getCategoryLabel,
+	getSubcategoryLabel,
+	actionId,
+	onEdit,
+	onDelete,
+	onPublish,
+	onRepeat,
+	onMove,
+	onDragStart,
+	onDragEnd,
+	onDragOver,
+	onDrop,
+	isFirst,
+	isLast,
+	isDragging,
+}) => {
+	const styles = STATUS_STYLES[item.status];
+	const title = getBudgetTitle(
+		item.budget,
+		getCategoryLabel,
+		getSubcategoryLabel
+	);
+	const scopeHelp = getBudgetScopeHelp(item.budget, getCategoryLabel);
+	const canRepeat = isBudgetPeriodDone(item.budget);
+	const isDraft = item.budget.lifecycleStatus === 'draft';
+
+	return (
+		<article
+			className={cn(
+				'flex h-full min-h-[500px] flex-col overflow-hidden transition duration-200',
+				cardSurface,
+				isDragging && 'scale-[0.98] opacity-60'
+			)}
+			draggable
+			onDragStart={onDragStart}
+			onDragEnd={onDragEnd}
+			onDragOver={onDragOver}
+			onDrop={onDrop}
+		>
+			<div className="relative flex min-h-52 flex-col items-center justify-center border-b border-gray-100 bg-gradient-to-br from-blue-50/80 via-gray-50 to-white px-6 py-7 dark:border-gray-800 dark:from-blue-950/25 dark:via-gray-900 dark:to-gray-900">
+				<div className="absolute right-3 top-3 flex items-center gap-1">
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8 rounded-full"
+						onClick={() => onMove(-1)}
+						disabled={isFirst}
+						aria-label={`Move ${title} left`}
+					>
+						<FiChevronLeft className="h-4 w-4" />
+					</Button>
+					<span
+						className="flex h-8 w-8 cursor-grab items-center justify-center rounded-full text-gray-400 active:cursor-grabbing"
+						title="Drag to reorder"
+						aria-hidden="true"
+					>
+						<FiMove className="h-4 w-4" />
+					</span>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8 rounded-full"
+						onClick={() => onMove(1)}
+						disabled={isLast}
+						aria-label={`Move ${title} right`}
+					>
+						<FiChevronRight className="h-4 w-4" />
+					</Button>
+				</div>
+				<p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+					Set budget
+				</p>
+				<p className="mb-4 mt-1 text-2xl font-semibold tracking-tight text-gray-950 dark:text-white">
+					{formatCurrency(item.budget.amount)}
+				</p>
+				<BudgetProgressRing
+					percentage={item.usedPercentage}
+					status={item.status}
+				/>
+			</div>
+			<div className="flex flex-1 flex-col p-5">
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0">
+						<div className="mb-2 flex flex-wrap items-center gap-2">
+							<span
+								className={cn(
+									'rounded-full px-2.5 py-1 text-xs font-medium',
+									isDraft
+										? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+										: styles.badge
+								)}
+							>
+								{isDraft ? 'Draft' : styles.label}
+							</span>
+							<span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+								<FiCalendar className="h-3.5 w-3.5" />
+								{getBudgetPeriodLabel(item.budget)}
+							</span>
+						</div>
+						<h2 className="truncate text-lg font-semibold text-gray-950 dark:text-white">
+							{title}
+						</h2>
+						<p className="mt-1 min-h-8 text-xs text-gray-500 dark:text-gray-400">
+							{scopeHelp ?? 'Tracks this specific spending category'}
+						</p>
+					</div>
+					<div className="flex shrink-0 gap-1">
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="h-8 w-8 rounded-full"
+							onClick={() => onEdit(item.budget)}
+							aria-label={`Edit ${title}`}
+						>
+							<FiEdit2 className="h-3.5 w-3.5" />
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="h-8 w-8 rounded-full text-gray-400 hover:text-red-600"
+							onClick={() => onDelete(item.budget)}
+							aria-label={`Delete ${title}`}
+						>
+							<FiTrash2 className="h-3.5 w-3.5" />
+						</Button>
+					</div>
+				</div>
+
+				<div className="mt-5 min-h-[76px] rounded-xl bg-gray-50 p-4 dark:bg-gray-800/50">
+					<p className="text-sm text-gray-700 dark:text-gray-200">
+						<span className="font-semibold">{formatCurrency(item.spent)}</span>
+						{' spent of '}
+						<span className="font-semibold">{formatCurrency(item.budget.amount)}</span>
+					</p>
+					<p className={cn('mt-1 text-sm font-medium', styles.text)}>
+						{item.remaining >= 0
+							? `${formatCurrency(item.remaining)} remaining`
+							: `${formatCurrency(Math.abs(item.remaining))} over budget`}
+					</p>
+				</div>
+
+				<div className="mt-auto pt-4">
+					{isDraft ? (
+						<Button
+							type="button"
+							className="w-full rounded-xl"
+							onClick={() => onPublish(item.budget)}
+							disabled={actionId === item.budget.id}
+							aria-label={`Publish ${title}`}
+						>
+							<FiUploadCloud className="h-4 w-4" />
+							Publish budget
+						</Button>
+					) : canRepeat ? (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="w-full rounded-xl"
+						onClick={() => onRepeat(item.budget.id)}
+						disabled={actionId === item.budget.id}
+						aria-label={`Repeat ${title} for next period`}
+					>
+						<FiRepeat className="h-4 w-4" />
+						Repeat for next period
+					</Button>
+					) : (
+						<div className="flex h-9 items-center justify-center rounded-xl border border-transparent text-xs text-gray-400">
+							Active for this period
+						</div>
+					)}
+				</div>
+			</div>
+		</article>
+	);
 };
 
 const BudgetsList: React.FC = () => {
-	const { budgets, deleteBudget, getAllBudgetProgress, publishBudget, startBudget } =
+	const { budgets, deleteBudget, publishBudget, repeatBudget, reorderBudgets } =
 		useBudgetsContext();
-	const { getCategoryLabel } = useCategoriesContext();
 	const { transactions } = useTransactionsContext();
-
+	const {
+		categories,
+		getCategoryLabel,
+		getSubcategoryLabel,
+	} = useCategoriesContext();
+	const { toast } = useToast();
+	const [selectedMonth, setSelectedMonth] = useState(getCurrentBudgetMonth);
 	const [showForm, setShowForm] = useState(false);
-	const [editingBudget, setEditingBudget] = useState<Budget | undefined>(undefined);
-	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-	const [budgetToDelete, setBudgetToDelete] = useState<string | null>(null);
-	const [dateRange, setDateRange] = useState<DateRange>({ startDate: '', endDate: '' });
+	const [editingBudget, setEditingBudget] = useState<Budget>();
+	const [budgetToDelete, setBudgetToDelete] = useState<Budget>();
+	const [actionId, setActionId] = useState<string>();
+	const [draggingBudgetId, setDraggingBudgetId] = useState<string>();
 	const [actionError, setActionError] = useState('');
-	const [startingBudgetId, setStartingBudgetId] = useState<string | null>(null);
-	const [publishingBudgetId, setPublishingBudgetId] = useState<string | null>(null);
+	const serverOrderedBudgets = useMemo(
+		() => sortBudgetsByDisplayOrder(budgets),
+		[budgets]
+	);
+	const serverOrderSignature = JSON.stringify(
+		serverOrderedBudgets.map((budget) => ({
+			id: budget.id,
+			displayOrder: budget.displayOrder ?? null,
+		}))
+	);
+	const [localOrderIds, setLocalOrderIds] = useState<string[]>(() =>
+		serverOrderedBudgets.map((budget) => budget.id)
+	);
 
-	const allProgress: BudgetProgress[] = getAllBudgetProgress(transactions);
-	const draftProgress = useMemo(
-		() => allProgress.filter((progress) => progress.isDraft),
-		[allProgress]
-	);
-	const publishedProgress = useMemo(
-		() => allProgress.filter((progress) => !progress.isDraft),
-		[allProgress]
-	);
-	const activePublishedBudgets = useMemo(
-		() => publishedProgress.filter((progress) => progress.started),
-		[publishedProgress]
-	);
-	const draftCount = draftProgress.length;
-	const publishedCount = publishedProgress.length;
-	const startedBudgets = activePublishedBudgets;
-	const hasSelectedRange = Boolean(dateRange.startDate && dateRange.endDate);
+	useEffect(() => {
+		setLocalOrderIds(
+			(JSON.parse(serverOrderSignature) as Array<{ id: string }>).map(
+				(budget) => budget.id
+			)
+		);
+	}, [serverOrderSignature]);
 
-	const handleEdit = (budget: Budget) => {
-		setEditingBudget(budget);
-		setShowForm(true);
+	const orderedBudgets = useMemo(() => {
+		const byId = new Map(budgets.map((budget) => [budget.id, budget]));
+		const ordered = localOrderIds
+			.map((id) => byId.get(id))
+			.filter((budget): budget is Budget => Boolean(budget));
+		const orderedIds = new Set(ordered.map((budget) => budget.id));
+		return [...ordered, ...serverOrderedBudgets.filter((budget) => !orderedIds.has(budget.id))];
+	}, [budgets, localOrderIds, serverOrderedBudgets]);
+
+	const allProgress = useMemo(
+		() =>
+			orderedBudgets
+				.filter((budget) => Boolean(budget.categoryId))
+				.map((budget) => calculateBudgetProgress(budget, transactions)),
+		[orderedBudgets, transactions]
+	);
+	const progress = useMemo(
+		() =>
+			allProgress.filter((item) =>
+				budgetOverlapsMonth(item.budget, selectedMonth)
+			),
+		[allProgress, selectedMonth]
+	);
+	const otherProgress = allProgress.filter(
+		(item) => !budgetOverlapsMonth(item.budget, selectedMonth)
+	);
+	const draftProgress = progress.filter(
+		(item) => item.budget.lifecycleStatus === 'draft'
+	);
+	const publishedProgress = progress.filter(
+		(item) => item.budget.lifecycleStatus === 'published'
+	);
+	const totals = {
+		budget: publishedProgress.reduce(
+			(sum, item) => sum + item.budget.amount,
+			0
+		),
+		spent: publishedProgress.reduce((sum, item) => sum + item.spent, 0),
+		remaining: publishedProgress.reduce(
+			(sum, item) => sum + item.remaining,
+			0
+		),
 	};
 
-	const handleDeleteClick = (id: string) => {
-		setBudgetToDelete(id);
-		setDeleteDialogOpen(true);
-	};
-
-	const handleConfirmDelete = async () => {
-		if (budgetToDelete) await deleteBudget(budgetToDelete);
-		setDeleteDialogOpen(false);
-		setBudgetToDelete(null);
-	};
-
-	const handleCloseForm = () => {
+	const closeForm = () => {
 		setShowForm(false);
 		setEditingBudget(undefined);
 	};
 
-	const handleStartBudget = async (budgetId: string) => {
-		if (!dateRange.startDate || !dateRange.endDate) {
-			setActionError('Select a budget start and end date before starting a budget.');
-			return;
-		}
+	const openEdit = (budget: Budget) => {
+		setEditingBudget(budget);
+		setShowForm(true);
+	};
 
+	const confirmDelete = async () => {
+		if (budgetToDelete) await deleteBudget(budgetToDelete.id);
+		setBudgetToDelete(undefined);
+	};
+
+	const runAction = async (
+		budgetId: string,
+		action: (id: string) => Promise<void>,
+		successMessage?: string
+	) => {
+		setActionId(budgetId);
 		setActionError('');
-		setStartingBudgetId(budgetId);
-
 		try {
-			await startBudget(budgetId, dateRange);
+			await action(budgetId);
+			if (successMessage) {
+				toast({
+					title: 'Budget updated',
+					description: successMessage,
+					duration: 3500,
+				});
+			}
 		} catch (error) {
 			setActionError(
-				error instanceof Error
-					? error.message
-					: 'Unable to start this budget right now. Please try again.'
+				error instanceof Error ? error.message : 'Unable to update this budget.'
 			);
 		} finally {
-			setStartingBudgetId(null);
+			setActionId(undefined);
 		}
 	};
 
-	const handlePublishBudget = async (budgetId: string) => {
-		setActionError('');
-		setPublishingBudgetId(budgetId);
+	const reorderGroup = async (
+		group: BudgetProgress[],
+		sourceId: string,
+		targetId: string
+	) => {
+		if (sourceId === targetId) return;
+		const groupIds = group.map((item) => item.budget.id);
+		const sourceIndex = groupIds.indexOf(sourceId);
+		const targetIndex = groupIds.indexOf(targetId);
+		if (sourceIndex < 0 || targetIndex < 0) return;
 
+		const reorderedGroupIds = [...groupIds];
+		const [movedId] = reorderedGroupIds.splice(sourceIndex, 1);
+		reorderedGroupIds.splice(targetIndex, 0, movedId);
+		let groupIndex = 0;
+		const nextOrderIds = allProgress.map((item) =>
+			groupIds.includes(item.budget.id)
+				? reorderedGroupIds[groupIndex++]
+				: item.budget.id
+		);
+
+		setLocalOrderIds(nextOrderIds);
+		setActionError('');
 		try {
-			await publishBudget(budgetId);
+			await reorderBudgets(nextOrderIds);
 		} catch (error) {
+			setLocalOrderIds(serverOrderedBudgets.map((budget) => budget.id));
 			setActionError(
-				error instanceof Error
-					? error.message
-					: 'Unable to publish this budget right now. Please try again.'
+				error instanceof Error ? error.message : 'Unable to save the budget order.'
 			);
-		} finally {
-			setPublishingBudgetId(null);
 		}
 	};
 
-	if (showForm) {
-		return <BudgetForm onClose={handleCloseForm} budget={editingBudget} />;
-	}
+	const moveInGroup = (
+		group: BudgetProgress[],
+		budgetId: string,
+		direction: -1 | 1
+	) => {
+		const index = group.findIndex((item) => item.budget.id === budgetId);
+		const target = group[index + direction];
+		if (target) void reorderGroup(group, budgetId, target.budget.id);
+	};
 
-	const totalPlanned = startedBudgets.reduce(
-		(sum, progress) => sum + progress.plannedAmount,
-		0
+	const renderBudgetGrid = (items: BudgetProgress[]) => (
+		<div
+			className="grid items-stretch gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+			data-testid="budget-grid"
+		>
+			{items.map((item, index) => (
+				<BudgetCard
+					key={item.budget.id}
+					item={item}
+					getCategoryLabel={getCategoryLabel}
+					getSubcategoryLabel={getSubcategoryLabel}
+					actionId={actionId}
+					onEdit={openEdit}
+					onDelete={setBudgetToDelete}
+					onPublish={(budget) =>
+						void runAction(
+							budget.id,
+							publishBudget,
+							`${getBudgetTitle(
+								budget,
+								getCategoryLabel,
+								getSubcategoryLabel
+							)} is now active.`
+						)
+					}
+					onRepeat={(id) =>
+						void runAction(
+							id,
+							repeatBudget,
+							'A new draft was created for the next period.'
+						)
+					}
+					onMove={(direction) => moveInGroup(items, item.budget.id, direction)}
+					onDragStart={() => setDraggingBudgetId(item.budget.id)}
+					onDragEnd={() => setDraggingBudgetId(undefined)}
+					onDragOver={(event) => event.preventDefault()}
+					onDrop={() => {
+						if (draggingBudgetId) {
+							void reorderGroup(items, draggingBudgetId, item.budget.id);
+						}
+						setDraggingBudgetId(undefined);
+					}}
+					isFirst={index === 0}
+					isLast={index === items.length - 1}
+					isDragging={draggingBudgetId === item.budget.id}
+				/>
+			))}
+		</div>
 	);
-	const totalActual = startedBudgets.reduce(
-		(sum, progress) => sum + progress.actualSpent,
-		0
-	);
-	const totalRemaining = startedBudgets.reduce(
-		(sum, progress) => sum + progress.remaining,
-		0
-	);
-	const totalOverBudget = startedBudgets.reduce(
-		(sum, progress) => sum + progress.overBudget,
-		0
-	);
+	const atBudgetLimit = budgets.length >= MAX_BUDGETS;
 
 	return (
-		<div className={cn('flex min-h-screen flex-col', pageBg)}>
-			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+		<div className={cn('relative flex min-h-screen flex-col', pageBg)}>
+			<SidePanel open={showForm} onOpenChange={(open) => !open && closeForm()}>
+				{showForm && (
+					<BudgetForm
+						onClose={closeForm}
+						budget={editingBudget}
+						defaultMonth={selectedMonth}
+					/>
+				)}
+			</SidePanel>
+
+			<Dialog
+				open={Boolean(budgetToDelete)}
+				onOpenChange={(open) => !open && setBudgetToDelete(undefined)}
+			>
 				<DialogContent className={cn('w-[90vw] md:w-full', modalShell)}>
 					<DialogHeader>
-						<DialogTitle>Delete Budget</DialogTitle>
+						<DialogTitle>Delete budget</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to delete this budget? This action cannot be
-							undone.
+							Delete{' '}
+							{budgetToDelete
+								? getBudgetTitle(
+										budgetToDelete,
+										getCategoryLabel,
+										getSubcategoryLabel
+									)
+								: 'this budget'}
+							? Transactions will not be removed.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+						<Button variant="outline" onClick={() => setBudgetToDelete(undefined)}>
 							Cancel
 						</Button>
-						<Button variant="destructive" onClick={handleConfirmDelete}>
-							Delete
+						<Button variant="destructive" onClick={confirmDelete}>
+							Delete budget
 						</Button>
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
 
-			<div className="flex-1 overflow-y-auto p-4 md:p-8">
-				<div className="mb-6 flex items-center justify-between gap-4">
-					<div>
-						<h1 className="text-2xl font-bold tracking-tight md:text-3xl">Budgets</h1>
-						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-							Plan draft budgets with live spend, then publish them when the period
-							is ready.
-						</p>
-					</div>
-					<Button onClick={() => setShowForm(true)}>
-						<FiPlus className="mr-2 h-4 w-4" />
-						New Draft
-					</Button>
-				</div>
-
-				<div className="mb-6 rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-4">
-					<div className="mb-3 flex items-center gap-2">
-						<FiCalendar className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-						<p className="text-sm font-medium">Published Budget Period Override</p>
-					</div>
-					<DateRangeFilter
-						dateRange={dateRange}
-						onDateRangeChange={setDateRange}
-						onClear={() => {
-							setDateRange({ startDate: '', endDate: '' });
-							setActionError('');
-						}}
-					/>
-					<p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-						Published budgets use their published period by default. Choose a range
-						here only when you need to update a published budget comparison period.
-					</p>
-					{!hasSelectedRange && (
-						<div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
-							Select a start and end date to enable published period updates.
+			<div className="flex-1 overflow-y-auto px-4 py-5 md:px-6 lg:px-8">
+				<div className="mx-auto max-w-7xl">
+					<header className="mb-6 flex flex-col gap-4 border-b border-gray-200 pb-5 dark:border-gray-800 sm:flex-row sm:items-end sm:justify-between">
+						<div>
+							<p className="text-xs font-semibold uppercase tracking-wider text-blue-600 dark:text-blue-400">
+								Spending plans
+							</p>
+							<h1 className="mt-2 text-3xl font-semibold tracking-tight text-gray-950 dark:text-white">
+								Budgets
+							</h1>
+							<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+								Clear limits, live spending, and less time figuring out what each
+								budget means.
+							</p>
+							<p className="mt-2 text-xs font-medium text-gray-400 dark:text-gray-500">
+								{budgets.length} of {MAX_BUDGETS} budgets created
+								{atBudgetLimit ? ' · Limit reached' : ''}
+							</p>
 						</div>
-					)}
+						<div className="flex flex-wrap items-end gap-3">
+							<div>
+								<label
+									htmlFor="budget-list-month"
+									className="mb-1.5 block text-xs font-medium text-gray-500 dark:text-gray-400"
+								>
+									View month
+								</label>
+								<Input
+									id="budget-list-month"
+									type="month"
+									value={selectedMonth}
+									onChange={(event) => setSelectedMonth(event.target.value)}
+									className="h-10 w-40 rounded-xl border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+								/>
+							</div>
+							<Button
+								onClick={() => setShowForm(true)}
+								disabled={categories.length === 0 || atBudgetLimit}
+								className="h-10 rounded-xl px-4"
+							>
+								<FiPlus className="h-4 w-4" />
+								New budget
+							</Button>
+						</div>
+					</header>
+
 					{actionError && (
-						<div className="mt-3 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+						<div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
 							{actionError}
 						</div>
 					)}
-				</div>
 
-				{startedBudgets.length > 0 ? (
-					<div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
-							<p className="text-sm text-gray-500 dark:text-gray-400">Planned Total</p>
-							<p className="mt-1 text-xl font-bold">{formatCurrency(totalPlanned)}</p>
-						</div>
-						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
-							<p className="text-sm text-gray-500 dark:text-gray-400">Actual Total</p>
-							<p className="mt-1 text-xl font-bold">{formatCurrency(totalActual)}</p>
-						</div>
-						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
-							<p className="text-sm text-gray-500 dark:text-gray-400">Remaining</p>
-							<p className="mt-1 text-xl font-bold text-green-600 dark:text-green-400">
-								{formatCurrency(totalRemaining)}
-							</p>
-						</div>
-						<div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 p-5">
-							<p className="text-sm text-gray-500 dark:text-gray-400">Over Budget</p>
-							<p className="mt-1 text-xl font-bold text-red-600 dark:text-red-400">
-								{formatCurrency(totalOverBudget)}
-							</p>
-						</div>
-					</div>
-				) : budgets.length > 0 ? (
-					<div className="mb-8 rounded-xl border border-dashed bg-card px-4 py-5 text-sm text-gray-500 dark:text-gray-400">
-						No published budgets have an active comparison period yet. Drafts will
-						become active automatically when published.
-					</div>
-				) : null}
-
-				{budgets.length === 0 ? (
-					<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed py-16 text-center">
-						<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-950">
-							<FiPlus className="h-6 w-6 text-primary" />
-						</div>
-						<h3 className="text-lg font-semibold">No budgets yet</h3>
-						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-							Create a draft budget to plan a custom period by category
-						</p>
-						<Button className="mt-4" onClick={() => setShowForm(true)}>
-							Create Draft
-						</Button>
-					</div>
-				) : (
-					<div className="space-y-4">
-						{[...draftProgress, ...publishedProgress].map((progress, index) => {
-							const {
-								budget,
-								plannedAmount,
-								plannedStartDate,
-								plannedEndDate,
-								started,
-								isDraft,
-								calculating,
-								comparisonStartDate,
-								comparisonEndDate,
-								actualSpent,
-								remaining,
-								overBudget,
-								percent,
-							} = progress;
-							const label = getCategoryLabel(budget.category);
-							const isOverBudget = overBudget > 0;
-							const barColour = getBarColour(percent);
-							const matchingTransactions =
-								calculating && comparisonStartDate && comparisonEndDate
-									? filterTransactionsByDateRangeObject(
-											transactions.filter(
-												(transaction) =>
-													transaction.type === 'expense' &&
-													transaction.category === budget.category
-											),
-											{
-												startDate: comparisonStartDate,
-												endDate: comparisonEndDate,
-											}
-									  ).sort((left, right) => {
-											const leftDate = parseDbDate(left.date ?? left.createdAt);
-											const rightDate = parseDbDate(right.date ?? right.createdAt);
-											return rightDate.getTime() - leftDate.getTime();
-									  })
-									: [];
-
-							return (
-								<React.Fragment key={budget.id}>
-									{index === 0 && draftCount > 0 && (
-										<div className="flex items-center justify-between border-b pb-2">
-											<div>
-												<h2 className="text-lg font-semibold">Draft Budgets</h2>
-												<p className="text-sm text-gray-500 dark:text-gray-400">
-													Plan with live calculations before publishing.
-												</p>
-											</div>
-											<span className="text-sm text-gray-500 dark:text-gray-400">
-												{draftCount}
-											</span>
-										</div>
-									)}
-									{index === draftCount && publishedCount > 0 && (
-										<div className="flex items-center justify-between border-b pb-2 pt-4">
-											<div>
-												<h2 className="text-lg font-semibold">Published Budgets</h2>
-												<p className="text-sm text-gray-500 dark:text-gray-400">
-													Active budget periods and historical comparisons.
-												</p>
-											</div>
-											<span className="text-sm text-gray-500 dark:text-gray-400">
-												{publishedCount}
-											</span>
-										</div>
-									)}
-									<div className="group rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-800 dark:bg-gray-900 p-5">
-										<div className="mb-4 flex items-start justify-between gap-3">
-											<div className="min-w-0 flex-1">
-												<div className="flex items-center gap-2">
-													<h3 className="truncate font-semibold">{label}</h3>
-													<span className="rounded-full border px-2 py-0.5 text-xs capitalize text-gray-500 dark:text-gray-400">
-														{isDraft ? 'Draft' : 'Published'}
-													</span>
-													{isOverBudget && (
-														<FiAlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
-													)}
-												</div>
-												<p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-													{isDraft
-														? 'Live draft calculations for the planned period'
-														: 'Published budget tracking'}
-												</p>
-											</div>
-											<div className="flex flex-shrink-0 items-center gap-1">
-												{isDraft ? (
-													<Button
-														type="button"
-														size="sm"
-														className="h-8"
-														onClick={() => budget.id && handlePublishBudget(budget.id)}
-														disabled={publishingBudgetId === budget.id}
-													>
-														<FiUploadCloud className="mr-1.5 h-3.5 w-3.5" />
-														{publishingBudgetId === budget.id
-															? 'Publishing...'
-															: 'Publish'}
-													</Button>
-												) : (
-													<Button
-														type="button"
-														size="sm"
-														variant="outline"
-														className="h-8"
-														onClick={() => budget.id && handleStartBudget(budget.id)}
-														disabled={!hasSelectedRange || startingBudgetId === budget.id}
-													>
-														<FiPlay className="mr-1.5 h-3.5 w-3.5" />
-														{startingBudgetId === budget.id
-															? 'Updating...'
-															: started
-																? 'Update period'
-																: 'Set period'}
-													</Button>
-												)}
-											<Button
-												variant="ghost"
-												size="icon"
-												className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
-												onClick={() => handleEdit(budget)}
-												aria-label="Edit budget"
-											>
-												<FiEdit2 className="h-3.5 w-3.5" />
-											</Button>
-											<Button
-												variant="ghost"
-												size="icon"
-												className="h-8 w-8 opacity-0 transition-opacity text-gray-500 dark:text-gray-400 group-hover:opacity-100 hover:text-destructive"
-												onClick={() => budget.id && handleDeleteClick(budget.id)}
-												aria-label="Delete budget"
-											>
-												<FiTrash2 className="h-3.5 w-3.5" />
-											</Button>
-										</div>
-									</div>
-
-									<div className="mb-4 grid gap-3 md:grid-cols-2">
-										<div className="rounded-xl border border-gray-100 bg-gray-50/60 dark:border-gray-800 dark:bg-gray-800/40 p-3">
-											<div className="mb-1 flex items-center gap-2">
-												<FiTarget className="h-4 w-4 text-primary" />
-												<p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-													Planned
-												</p>
-											</div>
-											<p className="text-lg font-semibold">
-												{formatCurrency(plannedAmount)}
-											</p>
-											<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-												{formatDateRange({
-													startDate: plannedStartDate,
-													endDate: plannedEndDate,
-												})}
-											</p>
-										</div>
-										<div className="rounded-xl border border-gray-100 bg-gray-50/60 dark:border-gray-800 dark:bg-gray-800/40 p-3">
-											<div className="mb-1 flex items-center gap-2">
-												<FiCalendar className="h-4 w-4 text-primary" />
-												<p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-													{isDraft ? 'Live Spend' : 'Actual'}
-												</p>
-											</div>
-											{calculating ? (
-												<>
-													<p className="text-lg font-semibold">
-														{formatCurrency(actualSpent)}
-													</p>
-													<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-														{formatDateRange({
-															startDate: comparisonStartDate,
-															endDate: comparisonEndDate,
-														})}
-													</p>
-												</>
+					{publishedProgress.length > 0 && (
+						<section className="mb-8">
+							<div className="grid gap-3 sm:grid-cols-3">
+								{[
+									['Budgeted', totals.budget, 'Published limits'],
+									['Spent', totals.spent, 'Matched expenses'],
+									[
+										totals.remaining >= 0 ? 'Remaining' : 'Over budget',
+										Math.abs(totals.remaining),
+										totals.remaining >= 0 ? 'Available to spend' : 'Beyond limits',
+									],
+								].map(([label, value, note], index) => (
+									<div
+										key={String(label)}
+										className={cn(
+											'flex items-center gap-4 p-4',
+											cardSurfaceMuted
+										)}
+									>
+										<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-blue-600 shadow-sm dark:bg-gray-900 dark:text-blue-400">
+											{index === 0 ? (
+												<FiTarget className="h-4 w-4" />
+											) : index === 1 ? (
+												<FiMoreHorizontal className="h-4 w-4" />
 											) : (
-												<>
-													<p className="text-lg font-semibold">Not started</p>
-													<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-														Use the date filter to set a comparison period.
-													</p>
-												</>
+												<FiCalendar className="h-4 w-4" />
 											)}
 										</div>
-									</div>
-
-									<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-										<div
-											className={`h-full rounded-full transition-all ${barColour}`}
-											style={{ width: `${Math.min(100, percent)}%` }}
-										/>
-									</div>
-
-									{calculating ? (
-										<>
-											<div className="flex items-center justify-between text-sm">
-												<span className="text-gray-500 dark:text-gray-400">
-													{formatCurrency(actualSpent)} actual spend
-												</span>
-												<span
-													className={`font-medium ${
-														isOverBudget
-															? 'text-red-600 dark:text-red-400'
-															: 'text-gray-500 dark:text-gray-400'
-													}`}
-												>
-													{isOverBudget
-														? `${formatCurrency(overBudget)} over`
-														: `${formatCurrency(remaining)} remaining`}{' '}
-													of {formatCurrency(plannedAmount)}
-												</span>
-											</div>
-											<div className="mt-1 text-right text-xs text-gray-500 dark:text-gray-400">
-												{percent.toFixed(0)}% used
-											</div>
-											<div className="mt-4 border-t pt-4">
-												<div className="mb-3 flex items-center justify-between">
-													<h4 className="text-sm font-semibold">
-														Matching Transactions
-													</h4>
-													<span className="text-xs text-gray-500 dark:text-gray-400">
-														{matchingTransactions.length}{' '}
-														{matchingTransactions.length === 1
-															? 'transaction'
-															: 'transactions'}
-													</span>
-												</div>
-												{matchingTransactions.length === 0 ? (
-													<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-														No transactions matched this budget category in the
-														selected period.
-													</div>
-												) : (
-													<div className="space-y-2">
-														{matchingTransactions.map((transaction) => {
-															const transactionDate = parseDbDate(
-																transaction.date ?? transaction.createdAt
-															).toLocaleDateString('en-ZA', {
-																day: 'numeric',
-																month: 'short',
-																year: 'numeric',
-															});
-
-															return (
-																<div
-																	key={transaction.id}
-																	className="flex items-center justify-between rounded-xl border bg-background px-3 py-3"
-																>
-																	<div className="min-w-0">
-																		<p className="truncate text-sm font-medium">
-																			{transaction.title}
-																		</p>
-																		<p className="text-xs text-gray-500 dark:text-gray-400">
-																			{transactionDate}
-																			{transaction.description
-																				? ` • ${transaction.description}`
-																				: ''}
-																		</p>
-																	</div>
-																	<p className="ml-3 flex-shrink-0 font-semibold text-red-600 dark:text-red-400">
-																		{formatCurrency(transaction.amount)}
-																	</p>
-																</div>
-															);
-														})}
-													</div>
-												)}
-											</div>
-										</>
-									) : (
-										<div className="rounded-lg border border-dashed px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-											This budget has a planned amount and period, but no active
-											comparison period yet.
+										<div>
+											<p className={sectionLabel}>{label}</p>
+											<p className="mt-1 text-xl font-semibold text-gray-950 dark:text-white">
+												{formatCurrency(value as number)}
+											</p>
+											<p className="text-xs text-gray-500 dark:text-gray-400">
+												{note}
+											</p>
 										</div>
-									)}
-								</div>
-								</React.Fragment>
-							);
-						})}
-					</div>
-				)}
+									</div>
+								))}
+							</div>
+						</section>
+					)}
+
+					{categories.length === 0 ? (
+						<section className={cn('p-12 text-center', cardSurface)}>
+							<div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400">
+								<FiTarget className="h-6 w-6" />
+							</div>
+							<h2 className="mt-4 text-lg font-semibold">Create a category first</h2>
+							<p className="mx-auto mt-1 max-w-md text-sm text-gray-500 dark:text-gray-400">
+								Budgets can cover one category or a specific sub-category.
+							</p>
+						</section>
+					) : allProgress.length === 0 ? (
+						<section className={cn('p-12 text-center', cardSurface)}>
+							<div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400">
+								<FiTarget className="h-6 w-6" />
+							</div>
+							<h2 className="mt-4 text-lg font-semibold">
+								No budgets for this month
+							</h2>
+							<p className="mx-auto mt-1 max-w-md text-sm text-gray-500 dark:text-gray-400">
+								Create a clear spending goal and keep it as a draft until it is
+								ready.
+							</p>
+							<Button className="mt-5 rounded-xl" onClick={() => setShowForm(true)}>
+								<FiPlus className="h-4 w-4" />
+								Create budget
+							</Button>
+						</section>
+					) : (
+						<div className="space-y-10">
+							{draftProgress.length > 0 && (
+								<section>
+									<div className="mb-4 flex items-end justify-between">
+										<div>
+											<h2 className="text-lg font-semibold text-gray-950 dark:text-white">
+												Draft budgets
+											</h2>
+											<p className="text-sm text-gray-500 dark:text-gray-400">
+												Review the goal and period before tracking begins.
+											</p>
+										</div>
+										<span className="text-sm text-gray-400">
+											{draftProgress.length}
+										</span>
+									</div>
+									{renderBudgetGrid(draftProgress)}
+								</section>
+							)}
+
+							{publishedProgress.length > 0 && (
+								<section>
+									<div className="mb-4">
+										<h2 className="text-lg font-semibold text-gray-950 dark:text-white">
+											Active budgets
+										</h2>
+										<p className="text-sm text-gray-500 dark:text-gray-400">
+											Live spending against published goals.
+										</p>
+									</div>
+									{renderBudgetGrid(publishedProgress)}
+								</section>
+							)}
+
+							{otherProgress.length > 0 && (
+								<section>
+									<div className="mb-4">
+										<h2 className="text-lg font-semibold text-gray-950 dark:text-white">
+											Other budget periods
+										</h2>
+										<p className="text-sm text-gray-500 dark:text-gray-400">
+											These budgets do not overlap the selected month.
+										</p>
+									</div>
+									{renderBudgetGrid(otherProgress)}
+								</section>
+							)}
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/domains/budgets/views/__tests__/BudgetsList.test.tsx
+++ b/apps/desktop/src/domains/budgets/views/__tests__/BudgetsList.test.tsx
@@ -1,132 +1,225 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import BudgetsList from '../BudgetsList';
-import { BudgetProgress, Transaction } from '@/types';
+import {
+	getCurrentBudgetMonth,
+	getMonthDateRange,
+} from '@/domains/budgets/models/BudgetModel';
 
+const mockMonth = getCurrentBudgetMonth();
+const mockRange = getMonthDateRange(mockMonth);
 const mockPublishBudget = jest.fn();
-
-const mockDraftProgress: BudgetProgress = {
-	budget: {
-		id: 'draft-1',
-		category: 'groceries',
-		amount: 1000,
-		period: 'monthly',
-		status: 'draft',
-		plannedStartDate: '2026-05-01',
-		plannedEndDate: '2026-05-31',
-	},
-	status: 'draft',
-	isDraft: true,
-	plannedAmount: 1000,
-	plannedStartDate: '2026-05-01',
-	plannedEndDate: '2026-05-31',
-	comparisonStartDate: '2026-05-01',
-	comparisonEndDate: '2026-05-31',
-	started: false,
-	calculating: true,
-	actualSpent: 250,
-	remaining: 750,
-	overBudget: 0,
-	percent: 25,
-};
-
-const mockPublishedProgress: BudgetProgress = {
-	budget: {
-		id: 'published-1',
-		category: 'transport',
-		amount: 500,
-		period: 'monthly',
-		status: 'published',
-		plannedStartDate: '2026-05-01',
-		plannedEndDate: '2026-05-31',
-		actualStartDate: '2026-05-01',
-		actualEndDate: '2026-05-31',
-	},
-	status: 'published',
-	isDraft: false,
-	plannedAmount: 500,
-	plannedStartDate: '2026-05-01',
-	plannedEndDate: '2026-05-31',
-	actualStartDate: '2026-05-01',
-	actualEndDate: '2026-05-31',
-	comparisonStartDate: '2026-05-01',
-	comparisonEndDate: '2026-05-31',
-	started: true,
-	calculating: true,
-	actualSpent: 100,
-	remaining: 400,
-	overBudget: 0,
-	percent: 20,
-};
-
-const mockTransactions: Transaction[] = [
-	{
-		id: 'transaction-1',
-		accountId: 'account-1',
-		title: 'Supermarket',
-		amount: 250,
-		type: 'expense',
-		category: 'groceries',
-		date: new Date('2026-05-10T12:00:00Z'),
-	},
-];
+const mockRepeatBudget = jest.fn();
+const mockDeleteBudget = jest.fn();
+const mockReorderBudgets = jest.fn();
 
 jest.mock('@/domains/budgets/context/BudgetsContext', () => ({
 	useBudgetsContext: () => ({
-		budgets: [mockDraftProgress.budget, mockPublishedProgress.budget],
-		loading: false,
-		addBudget: jest.fn(),
-		addDraftBudget: jest.fn(),
-		updateBudget: jest.fn(),
-		startBudget: jest.fn(),
+		budgets: [
+			{
+				id: 'draft-petrol',
+				userId: 'user-1',
+				categoryId: 'petrol',
+				amount: 1000,
+				period: 'monthly',
+				month: mockMonth,
+				startDate: mockRange.startDate,
+				endDate: mockRange.endDate,
+				lifecycleStatus: 'draft',
+				displayOrder: 0,
+			},
+			{
+				id: 'active-takeaways',
+				userId: 'user-1',
+				categoryId: 'food',
+				subCategoryId: 'takeaways',
+				amount: 1500,
+				period: 'monthly',
+				month: mockMonth,
+				startDate: mockRange.startDate,
+				endDate: mockRange.endDate,
+				lifecycleStatus: 'published',
+				displayOrder: 1,
+			},
+			{
+				id: 'warning-food',
+				userId: 'user-1',
+				categoryId: 'food',
+				subCategoryId: 'groceries',
+				amount: 1000,
+				period: 'monthly',
+				month: mockMonth,
+				startDate: mockRange.startDate,
+				endDate: mockRange.endDate,
+				lifecycleStatus: 'published',
+				displayOrder: 2,
+			},
+			{
+				id: 'over-petrol',
+				userId: 'user-1',
+				categoryId: 'petrol',
+				amount: 100,
+				period: 'monthly',
+				month: mockMonth,
+				startDate: mockRange.startDate,
+				endDate: mockRange.endDate,
+				lifecycleStatus: 'published',
+				displayOrder: 3,
+			},
+			{
+				id: 'next-month-travel',
+				userId: 'user-1',
+				categoryId: 'travel',
+				amount: 2200,
+				period: 'monthly',
+				month: '2099-01',
+				startDate: '2099-01-01',
+				endDate: '2099-01-31',
+				lifecycleStatus: 'draft',
+				displayOrder: 4,
+			},
+		],
+		deleteBudget: mockDeleteBudget,
 		publishBudget: mockPublishBudget,
-		deleteBudget: jest.fn(),
-		getBudgetProgress: jest.fn(),
-		getAllBudgetProgress: jest.fn(() => [mockDraftProgress, mockPublishedProgress]),
+		repeatBudget: mockRepeatBudget,
+		reorderBudgets: mockReorderBudgets,
 	}),
 }));
 
 jest.mock('@/domains/transactions/context/TransactionsContext', () => ({
 	useTransactionsContext: () => ({
-		transactions: mockTransactions,
+		transactions: [
+			{
+				id: 'takeaways',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Dinner',
+				amount: 920,
+				type: 'expense',
+				category: 'food',
+				subcategory: 'takeaways',
+				date: new Date(`${mockMonth}-10T12:00:00`),
+			},
+			{
+				id: 'groceries',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Groceries',
+				amount: 800,
+				type: 'expense',
+				category: 'food',
+				subcategory: 'groceries',
+				date: new Date(`${mockMonth}-11T12:00:00`),
+			},
+			{
+				id: 'fuel',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Fuel',
+				amount: 120,
+				type: 'expense',
+				category: 'petrol',
+				date: new Date(`${mockMonth}-12T12:00:00`),
+			},
+		],
 	}),
 }));
 
 jest.mock('@/domains/categories/context/CategoriesContext', () => ({
 	useCategoriesContext: () => ({
-		getCategoryLabel: (category: string) =>
-			category === 'groceries' ? 'Groceries' : 'Transport',
-		categoryOptions: [
-			{ value: 'groceries', label: 'Groceries' },
-			{ value: 'transport', label: 'Transport' },
+		categories: [
+			{
+				id: 'food',
+				value: 'food',
+				label: 'Food',
+				subcategories: [
+					{ value: 'takeaways', label: 'Takeaways' },
+					{ value: 'groceries', label: 'Groceries' },
+				],
+			},
+			{
+				id: 'petrol',
+				value: 'petrol',
+				label: 'Petrol',
+				subcategories: [],
+			},
+			{
+				id: 'travel',
+				value: 'travel',
+				label: 'Travel',
+				subcategories: [],
+			},
 		],
+		getCategoryLabel: (category: string) =>
+			category === 'food' ? 'Food' : category === 'travel' ? 'Travel' : 'Petrol',
+		getSubcategoryLabel: (_category: string, subcategory?: string) =>
+			subcategory === 'groceries' ? 'Groceries' : 'Takeaways',
 	}),
 }));
 
-describe('BudgetsList draft publishing', () => {
+describe('BudgetsList', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
-	it('separates draft and published budgets and shows live draft calculations', () => {
+	it('separates drafts and active budgets with explicit titles', () => {
 		render(<BudgetsList />);
-
-		expect(screen.getByText('Draft Budgets')).toBeInTheDocument();
-		expect(screen.getByText('Published Budgets')).toBeInTheDocument();
-		expect(screen.getByText('Live draft calculations for the planned period')).toBeInTheDocument();
-		expect(screen.getByText(/250,00 actual spend/)).toBeInTheDocument();
-		expect(screen.getByText('Supermarket')).toBeInTheDocument();
+		expect(screen.getByText('Draft budgets')).toBeInTheDocument();
+		expect(screen.getByText('Active budgets')).toBeInTheDocument();
+		expect(screen.getAllByText('Petrol').length).toBeGreaterThan(0);
+		expect(screen.getByText('Food · Takeaways')).toBeInTheDocument();
+		expect(screen.queryByText('All category spending')).not.toBeInTheDocument();
+		expect(screen.getAllByText('Tracks all Petrol expenses').length).toBeGreaterThan(0);
+		expect(screen.getByText('Other budget periods')).toBeInTheDocument();
+		expect(screen.getByText('Travel')).toBeInTheDocument();
+		expect(screen.getByText('5 of 8 budgets created')).toBeInTheDocument();
 	});
 
-	it('publishes a draft without replacing existing published budgets', async () => {
-		const user = userEvent.setup();
+	it('shows concise dates, sentence metrics, and status states', () => {
+		render(<BudgetsList />);
+		const monthLabel = new Date(`${mockMonth}-01T12:00:00`).toLocaleDateString(
+			'en-ZA',
+			{ month: 'long', year: 'numeric' }
+		);
+		expect(screen.getAllByText(monthLabel).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/spent of/).length).toBeGreaterThan(0);
+		expect(screen.getByText('On track')).toBeInTheDocument();
+		expect(screen.getByText('Watch spending')).toBeInTheDocument();
+		expect(screen.getByText('Over budget')).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: '61 percent used' })).toBeInTheDocument();
+		expect(screen.getAllByText('Set budget').length).toBeGreaterThan(0);
+		expect(screen.getAllByTestId('budget-grid')[0]).toHaveClass('xl:grid-cols-4');
+	});
+
+	it('publishes a draft and opens the side-panel form', async () => {
+		render(<BudgetsList />);
+		fireEvent.click(screen.getByRole('button', { name: 'Publish Petrol' }));
+		await waitFor(() =>
+			expect(mockPublishBudget).toHaveBeenCalledWith('draft-petrol')
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'New budget' }));
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect(screen.getByText('Create a budget')).toBeInTheDocument();
+		expect(screen.getByText('What are you budgeting?')).toBeInTheDocument();
+		expect(screen.getByText('How much?')).toBeInTheDocument();
+		expect(screen.getByText('For when?')).toBeInTheDocument();
+	});
+
+	it('reorders budgets from the card controls and persists the order', async () => {
 		render(<BudgetsList />);
 
-		await user.click(screen.getByRole('button', { name: /publish/i }));
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Move Food · Groceries right' })
+		);
 
-		await waitFor(() => {
-			expect(mockPublishBudget).toHaveBeenCalledWith('draft-1');
-		});
-		expect(screen.getByText('Published Budgets')).toBeInTheDocument();
+		await waitFor(() =>
+			expect(mockReorderBudgets).toHaveBeenCalledWith([
+				'draft-petrol',
+				'active-takeaways',
+				'over-petrol',
+				'warning-food',
+				'next-month-travel',
+			])
+		);
 	});
 });

--- a/apps/desktop/src/domains/budgets/views/__tests__/budgetDisplay.test.ts
+++ b/apps/desktop/src/domains/budgets/views/__tests__/budgetDisplay.test.ts
@@ -1,0 +1,47 @@
+import {
+	getBudgetPeriodLabel,
+	getBudgetScopeHelp,
+	getBudgetTitle,
+} from '../budgetDisplay';
+
+const getCategoryLabel = (value: string) =>
+	value === 'food' ? 'Food' : 'Petrol';
+const getSubcategoryLabel = () => 'Takeaways';
+
+describe('budgetDisplay', () => {
+	it('uses only the category for category-wide budgets', () => {
+		const budget = { categoryId: 'petrol' };
+		expect(
+			getBudgetTitle(budget, getCategoryLabel, getSubcategoryLabel)
+		).toBe('Petrol');
+		expect(getBudgetScopeHelp(budget, getCategoryLabel)).toBe(
+			'Tracks all Petrol expenses'
+		);
+	});
+
+	it('uses the explicit category and sub-category path', () => {
+		const budget = { categoryId: 'food', subCategoryId: 'takeaways' };
+		expect(
+			getBudgetTitle(budget, getCategoryLabel, getSubcategoryLabel)
+		).toBe('Food · Takeaways');
+		expect(getBudgetScopeHelp(budget, getCategoryLabel)).toBeNull();
+	});
+
+	it('formats monthly and custom periods concisely', () => {
+		expect(
+			getBudgetPeriodLabel({
+				period: 'monthly',
+				month: '2026-06',
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+			})
+		).toBe('June 2026');
+		expect(
+			getBudgetPeriodLabel({
+				period: 'custom',
+				startDate: '2026-06-01',
+				endDate: '2026-07-18',
+			})
+		).toBe('1 Jun – 18 Jul 2026');
+	});
+});

--- a/apps/desktop/src/domains/budgets/views/budgetDisplay.ts
+++ b/apps/desktop/src/domains/budgets/views/budgetDisplay.ts
@@ -1,0 +1,61 @@
+import { Budget } from '@/types';
+
+type BudgetLabels = Pick<Budget, 'categoryId' | 'subCategoryId'>;
+
+export const getBudgetTitle = (
+	budget: BudgetLabels,
+	getCategoryLabel: (categoryId: string) => string,
+	getSubcategoryLabel: (
+		categoryId: string,
+		subCategoryId?: string
+	) => string
+): string => {
+	const categoryLabel = getCategoryLabel(budget.categoryId);
+	if (!budget.subCategoryId) return categoryLabel;
+
+	return `${categoryLabel} · ${getSubcategoryLabel(
+		budget.categoryId,
+		budget.subCategoryId
+	)}`;
+};
+
+const formatDate = (
+	value: string,
+	options: Intl.DateTimeFormatOptions
+): string =>
+	new Date(`${value}T12:00:00`)
+		.toLocaleDateString('en-ZA', options)
+		.replace(/^0/, '');
+
+export const getBudgetPeriodLabel = (
+	budget: Pick<Budget, 'period' | 'month' | 'startDate' | 'endDate'>
+): string => {
+	if (budget.period === 'monthly' && budget.month) {
+		return formatDate(`${budget.month}-01`, {
+			month: 'long',
+			year: 'numeric',
+		});
+	}
+
+	const sameYear = budget.startDate.slice(0, 4) === budget.endDate.slice(0, 4);
+	const startLabel = formatDate(budget.startDate, {
+		day: 'numeric',
+		month: 'short',
+		...(sameYear ? {} : { year: 'numeric' }),
+	});
+	const endLabel = formatDate(budget.endDate, {
+		day: 'numeric',
+		month: 'short',
+		year: 'numeric',
+	});
+
+	return `${startLabel} – ${endLabel}`;
+};
+
+export const getBudgetScopeHelp = (
+	budget: BudgetLabels,
+	getCategoryLabel: (categoryId: string) => string
+): string | null =>
+	budget.subCategoryId
+		? null
+		: `Tracks all ${getCategoryLabel(budget.categoryId)} expenses`;

--- a/apps/desktop/src/domains/categories/hooks/useCategories.ts
+++ b/apps/desktop/src/domains/categories/hooks/useCategories.ts
@@ -216,9 +216,10 @@ export const useCategories = () => {
 		);
 		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
 
-		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
+		const [transactionDocs, recurringDocs, budgetDocs, legacyBudgetDocs] = await Promise.all([
 			getDocs(query(transactionsRef, where('category', '==', category.value))),
 			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('categoryId', '==', category.value))),
 			getDocs(query(budgetsRef, where('category', '==', category.value))),
 		]);
 
@@ -226,6 +227,7 @@ export const useCategories = () => {
 			...transactionDocs.docs.map((docRef) => docRef.ref),
 			...recurringDocs.docs.map((docRef) => docRef.ref),
 			...budgetDocs.docs.map((docRef) => docRef.ref),
+			...legacyBudgetDocs.docs.map((docRef) => docRef.ref),
 		];
 
 		const categoryRef = doc(db, USERS_COLLECTION, user!.uid, 'categories', id);
@@ -251,9 +253,11 @@ export const useCategories = () => {
 			}
 
 			for (const ref of chunk) {
-				batch.update(ref, {
-					category: payload.value,
-				});
+				if (ref.parent.id === 'budgets') {
+					batch.update(ref, { categoryId: payload.value });
+				} else {
+					batch.update(ref, { category: payload.value });
+				}
 			}
 
 			await batch.commit();
@@ -277,14 +281,18 @@ export const useCategories = () => {
 		);
 		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
 
-		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
+		const [transactionDocs, recurringDocs, budgetDocs, legacyBudgetDocs] = await Promise.all([
 			getDocs(query(transactionsRef, where('category', '==', category.value))),
 			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('categoryId', '==', category.value))),
 			getDocs(query(budgetsRef, where('category', '==', category.value))),
 		]);
 
 		const usageCount =
-			transactionDocs.size + recurringDocs.size + budgetDocs.size;
+			transactionDocs.size +
+			recurringDocs.size +
+			budgetDocs.size +
+			legacyBudgetDocs.size;
 
 		if (usageCount > 0) {
 			throw new Error(
@@ -341,10 +349,12 @@ export const useCategories = () => {
 			user!.uid,
 			'recurringTransactions'
 		);
+		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
 
-		const [transactionDocs, recurringDocs] = await Promise.all([
+		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
 			getDocs(query(transactionsRef, where('category', '==', category.value))),
 			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('categoryId', '==', category.value))),
 		]);
 
 		const allRefs = [
@@ -353,6 +363,9 @@ export const useCategories = () => {
 				.map((docRef) => docRef.ref),
 			...recurringDocs.docs
 				.filter((docRef) => docRef.data().subcategory === subcategory.value)
+				.map((docRef) => docRef.ref),
+			...budgetDocs.docs
+				.filter((docRef) => docRef.data().subCategoryId === subcategory.value)
 				.map((docRef) => docRef.ref),
 		];
 		const categoryRef = doc(db, USERS_COLLECTION, user!.uid, 'categories', categoryId);
@@ -381,9 +394,11 @@ export const useCategories = () => {
 			}
 
 			for (const ref of chunk) {
-				batch.update(ref, {
-					subcategory: payload.value,
-				});
+				if (ref.parent.id === 'budgets') {
+					batch.update(ref, { subCategoryId: payload.value });
+				} else {
+					batch.update(ref, { subcategory: payload.value });
+				}
 			}
 
 			await batch.commit();
@@ -410,17 +425,22 @@ export const useCategories = () => {
 			user!.uid,
 			'recurringTransactions'
 		);
+		const budgetsRef = collection(db, USERS_COLLECTION, user!.uid, 'budgets');
 
-		const [transactionDocs, recurringDocs] = await Promise.all([
+		const [transactionDocs, recurringDocs, budgetDocs] = await Promise.all([
 			getDocs(query(transactionsRef, where('category', '==', category.value))),
 			getDocs(query(recurringRef, where('category', '==', category.value))),
+			getDocs(query(budgetsRef, where('categoryId', '==', category.value))),
 		]);
 
 		const usageCount =
 			transactionDocs.docs.filter((docRef) => docRef.data().subcategory === subcategory.value)
 				.length +
 			recurringDocs.docs.filter((docRef) => docRef.data().subcategory === subcategory.value)
-				.length;
+				.length +
+			budgetDocs.docs.filter(
+				(docRef) => docRef.data().subCategoryId === subcategory.value
+			).length;
 
 		if (usageCount > 0) {
 			throw new Error(

--- a/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
+++ b/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
@@ -25,12 +25,14 @@ import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
 
 interface TransactionFormProps {
 	onClose: () => void;
+	onSuccess?: (message: string) => void;
 	transaction?: Transaction;
 	recurringTransaction?: RecurringTransaction;
 }
 
 const TransactionForm: React.FC<TransactionFormProps> = ({
 	onClose,
+	onSuccess,
 	transaction,
 	recurringTransaction: initialRecurringTransaction,
 }) => {
@@ -245,6 +247,13 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 					date: date ? new Date(date) : new Date(),
 				});
 			}
+			onSuccess?.(
+				transaction
+					? 'Transaction updated successfully.'
+					: type === 'transfer'
+						? 'Transfer added successfully.'
+						: `${type === 'expense' ? 'Expense' : 'Income'} added successfully.`
+			);
 			onClose();
 		} catch (error) {
 			console.error('Failed to submit transaction:', error);

--- a/apps/desktop/src/pages/dashboard/Dashboard.tsx
+++ b/apps/desktop/src/pages/dashboard/Dashboard.tsx
@@ -232,6 +232,7 @@ const Dashboard: React.FC = () => {
 			setActiveView(view);
 			return;
 		}
+		setActiveView(view);
 		navigate(viewToRoute(view));
 	};
 
@@ -249,6 +250,13 @@ const Dashboard: React.FC = () => {
 					<TransactionForm
 						transaction={selectedTx || undefined}
 						onClose={handleCloseForm}
+						onSuccess={(message) =>
+							toast({
+								title: selectedTx ? 'Transaction updated' : 'Transaction created',
+								description: message,
+								duration: 3500,
+							})
+						}
 					/>
 				);
 			case 'table':

--- a/apps/desktop/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/apps/desktop/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -41,8 +41,17 @@ jest.mock('@/pages/dashboard/components/DashboardOverview', () => ({
 
 jest.mock('@/pages/dashboard/components/Sidebar', () => ({
 	__esModule: true,
-	default: ({ onCreate }: { onCreate: () => void }) => (
-		<button onClick={onCreate}>Create transaction</button>
+	default: ({
+		onCreate,
+		onViewChange,
+	}: {
+		onCreate: () => void;
+		onViewChange: (view: string) => void;
+	}) => (
+		<>
+			<button onClick={onCreate}>Create transaction</button>
+			<button onClick={() => onViewChange('budgets')}>Open budgets</button>
+		</>
 	),
 }));
 
@@ -53,10 +62,23 @@ jest.mock('@/pages/dashboard/components/SettingsModal', () => ({
 
 jest.mock('@/domains/transactions/views/TransactionForm', () => ({
 	__esModule: true,
-	default: ({ onClose }: { onClose: () => void }) => (
+	default: ({
+		onClose,
+		onSuccess,
+	}: {
+		onClose: () => void;
+		onSuccess?: (message: string) => void;
+	}) => (
 		<div>
 			<div>Transaction form</div>
-			<button onClick={onClose}>Finish add</button>
+			<button
+				onClick={() => {
+					onSuccess?.('Expense added successfully.');
+					onClose();
+				}}
+			>
+				Finish add
+			</button>
 		</div>
 	),
 }));
@@ -135,6 +157,30 @@ describe('Dashboard', () => {
 		fireEvent.click(screen.getByRole('button', { name: 'Finish add' }));
 
 		expect(screen.getByText('Dashboard overview')).toBeInTheDocument();
+		expect(screen.queryByText('Transaction form')).not.toBeInTheDocument();
+		expect(mockToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: 'Transaction created',
+				description: 'Expense added successfully.',
+			})
+		);
+	});
+
+	it('navigates from the transaction form to budgets without getting stuck', () => {
+		render(
+			<MemoryRouter initialEntries={['/dashboard']}>
+				<Routes>
+					<Route path="/dashboard" element={<Dashboard />} />
+					<Route path="/dashboard/budgets" element={<Dashboard />} />
+				</Routes>
+			</MemoryRouter>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create transaction' }));
+		expect(screen.getByText('Transaction form')).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Open budgets' }));
+		expect(screen.getByText('Budgets list')).toBeInTheDocument();
 		expect(screen.queryByText('Transaction form')).not.toBeInTheDocument();
 	});
 });

--- a/apps/desktop/src/pages/dashboard/components/BudgetSummary.tsx
+++ b/apps/desktop/src/pages/dashboard/components/BudgetSummary.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import { FiAlertTriangle, FiTarget } from 'react-icons/fi';
+import { useBudgetsContext } from '@/domains/budgets/context/BudgetsContext';
+import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
+import {
+	calculateBudgetSummary,
+	getCurrentBudgetMonth,
+} from '@/domains/budgets/models/BudgetModel';
+import { formatCurrency } from '@/utils/formatCurrency';
+import MarketingCard from '@/components/marketing/MarketingCard';
+
+const BudgetSummary: React.FC = () => {
+	const { budgets } = useBudgetsContext();
+	const { transactions } = useTransactionsContext();
+	const month = getCurrentBudgetMonth();
+	const summary = useMemo(
+		() => calculateBudgetSummary(budgets, transactions, month),
+		[budgets, month, transactions]
+	);
+
+	if (summary.totalBudget === 0) return null;
+
+	return (
+		<MarketingCard
+			header={
+				<div>
+					<h2 className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-50">
+						<FiTarget className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+						Monthly budgets
+					</h2>
+					<p className="text-xs text-gray-500 dark:text-gray-400">
+						Progress across published category budgets.
+					</p>
+				</div>
+			}
+		>
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+				{[
+					['Budget', formatCurrency(summary.totalBudget)],
+					['Spent', formatCurrency(summary.totalSpent)],
+					['Remaining', formatCurrency(summary.remaining)],
+					['Warning', String(summary.warningCount)],
+					['Over budget', String(summary.overCount)],
+				].map(([label, value]) => (
+					<div key={label} className="rounded-xl bg-gray-50/70 p-3 dark:bg-gray-800/40">
+						<p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
+						<p className="mt-1 flex items-center gap-1 text-sm font-semibold">
+							{label === 'Over budget' && summary.overCount > 0 && (
+								<FiAlertTriangle className="h-3.5 w-3.5 text-red-500" />
+							)}
+							{value}
+						</p>
+					</div>
+				))}
+			</div>
+		</MarketingCard>
+	);
+};
+
+export default BudgetSummary;

--- a/apps/desktop/src/pages/dashboard/components/DashboardOverview.tsx
+++ b/apps/desktop/src/pages/dashboard/components/DashboardOverview.tsx
@@ -16,6 +16,7 @@ import { Transaction } from '@/types';
 import AccountBalanceStrip from '@/pages/dashboard/components/AccountBalanceStrip';
 import MonthlyDigest from '@/pages/dashboard/components/MonthlyDigest';
 import RecentTransactionsPanel from '@/pages/dashboard/components/RecentTransactionsPanel';
+import BudgetSummary from '@/pages/dashboard/components/BudgetSummary';
 import { calculateDashboardSummary } from '@/pages/dashboard/utils/dashboardSummary';
 import {
 	DashboardDigestPeriod,
@@ -242,6 +243,10 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 							</MarketingCard>
 						</MotionReveal>
 					)}
+
+					<MotionReveal delay={0.16} className="shrink-0">
+						<BudgetSummary />
+					</MotionReveal>
 
 					<div className="grid min-h-0 flex-1 gap-3 xl:grid-cols-[minmax(280px,0.78fr)_minmax(360px,1fr)_minmax(320px,0.85fr)]">
 						<MotionReveal delay={0.18}>

--- a/apps/desktop/src/pages/dashboard/components/__tests__/DashboardOverview.test.tsx
+++ b/apps/desktop/src/pages/dashboard/components/__tests__/DashboardOverview.test.tsx
@@ -66,6 +66,12 @@ jest.mock('@/domains/transactions/context/TransactionsContext', () => ({
 	}),
 }));
 
+jest.mock('@/domains/budgets/context/BudgetsContext', () => ({
+	useBudgetsContext: () => ({
+		budgets: [],
+	}),
+}));
+
 jest.mock('@/components/app/ui/use-toast', () => ({
 	useToast: () => ({
 		toast: jest.fn(),

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -71,40 +71,31 @@ export interface Transaction {
 	recurringOccurrenceDate?: string;
 }
 
-// Budget
-export type BudgetStatus = 'draft' | 'published';
-
 export interface Budget {
-	id?: string;
-	userId?: string;
-	category: string;
+	id: string;
+	userId: string;
+	accountId?: string;
+	categoryId: string;
+	subCategoryId?: string;
 	amount: number;
-	period: 'monthly';
-	status: BudgetStatus;
-	plannedStartDate: string;
-	plannedEndDate: string;
-	actualStartDate?: string;
-	actualEndDate?: string;
+	period: 'monthly' | 'custom';
+	month?: string;
+	startDate: string;
+	endDate: string;
+	lifecycleStatus: 'draft' | 'published';
+	displayOrder?: number;
 	createdAt?: Date | { toDate: () => Date };
+	updatedAt?: Date | { toDate: () => Date };
 }
+
+export type BudgetStatus = 'safe' | 'warning' | 'over';
 
 export interface BudgetProgress {
 	budget: Budget;
-	status: BudgetStatus;
-	isDraft: boolean;
-	plannedAmount: number;
-	plannedStartDate: string;
-	plannedEndDate: string;
-	actualStartDate?: string;
-	actualEndDate?: string;
-	comparisonStartDate: string;
-	comparisonEndDate: string;
-	started: boolean;
-	calculating: boolean;
-	actualSpent: number;
+	spent: number;
 	remaining: number;
-	overBudget: number;
-	percent: number;
+	usedPercentage: number;
+	status: BudgetStatus;
 }
 
 // Report types

--- a/apps/mobisite/src/App.tsx
+++ b/apps/mobisite/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import {
 	ArrowDownCircle,
 	ArrowUpCircle,
+	CheckCircle2,
 	ChevronRight,
 	List,
 	LogOut,
@@ -164,10 +165,12 @@ const AddTransactionView = () => {
 	const selectedCategory = categories.find((item) => item.value === category);
 	const availableSubcategories = selectedCategory?.subcategories ?? [];
 	const [subcategory, setSubcategory] = useState('');
+	const [success, setSuccess] = useState('');
 
 	const handleSubmit = async (event: FormEvent) => {
 		event.preventDefault();
 		setError('');
+		setSuccess('');
 
 		if (!accountId) {
 			setError('Create an account in desktop admin first.');
@@ -189,6 +192,7 @@ const AddTransactionView = () => {
 				subcategory: subcategory || undefined,
 				date: date ? new Date(date) : new Date(),
 			});
+			setSuccess(`${type === 'expense' ? 'Expense' : 'Income'} "${title}" added successfully.`);
 			setTitle('');
 			setAmount('');
 			setSubcategory('');
@@ -222,6 +226,18 @@ const AddTransactionView = () => {
 	return (
 		<div className="py-4 pl-[calc(1.25rem+env(safe-area-inset-left))] pr-[calc(1.25rem+env(safe-area-inset-right))] md:p-4">
 			<form onSubmit={handleSubmit} className="mx-auto max-w-sm space-y-4">
+				{success && (
+					<div
+						role="status"
+						className="flex items-start gap-3 rounded-xl border border-primary/25 bg-primary/10 px-3 py-3 text-sm text-foreground shadow-sm"
+					>
+						<CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+						<div>
+							<p className="font-semibold">Transaction created</p>
+							<p className="mt-0.5 text-muted-foreground">{success}</p>
+						</div>
+					</div>
+				)}
 				{error && (
 					<div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
 						{error}
@@ -250,7 +266,10 @@ const AddTransactionView = () => {
 					<span>Title</span>
 					<input
 						value={title}
-						onChange={(event) => setTitle(event.target.value)}
+						onChange={(event) => {
+							setTitle(event.target.value);
+							setSuccess('');
+						}}
 						className="h-12 w-full rounded-md border bg-background px-3"
 						required
 					/>

--- a/apps/mobisite/src/__tests__/App.test.tsx
+++ b/apps/mobisite/src/__tests__/App.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../App';
+
+const addTransaction = jest.fn();
 
 jest.mock('firebase/auth', () => ({
 	createUserWithEmailAndPassword: jest.fn(),
@@ -43,13 +45,15 @@ jest.mock('@cash-flow/shared', () => ({
 				createdAt: new Date(2026, 4, 22),
 			},
 		],
-		addTransaction: jest.fn(),
+		addTransaction,
 	}),
 }));
 
 describe('Mobisite App', () => {
 	beforeEach(() => {
 		window.sessionStorage.clear();
+		addTransaction.mockReset();
+		addTransaction.mockResolvedValue(undefined);
 	});
 
 	it('starts on the home dashboard with add and list options', async () => {
@@ -103,5 +107,19 @@ describe('Mobisite App', () => {
 		expect(await screen.findByTestId('mobisite-nav')).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument();
 		expect(screen.getByText('Coffee')).toBeInTheDocument();
+	});
+
+	it('confirms when a transaction is created', async () => {
+		const user = userEvent.setup();
+
+		render(<App />);
+		await user.click(await screen.findByRole('button', { name: /add transaction/i }));
+		await user.type(screen.getByLabelText('Title'), 'Lunch');
+		await user.type(screen.getByLabelText('Amount'), '120');
+		await user.click(screen.getByRole('button', { name: 'Add transaction' }));
+
+		await waitFor(() => expect(addTransaction).toHaveBeenCalledTimes(1));
+		expect(screen.getByRole('status')).toHaveTextContent('Transaction created');
+		expect(screen.getByRole('status')).toHaveTextContent('Expense "Lunch" added successfully.');
 	});
 });

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -44,6 +44,8 @@ The friendly first-run path is:
 
 Core capabilities include Firebase auth, multi-account management for debit/credit/savings/cash, atomic income and expense writes, linked transfer records, account reconciliation, desktop dashboard/admin views, mobile transaction capture, recurring due-today drafts, import/export, reports, settings, and the AI assistant.
 
+Budget planning supports category-wide or optional sub-category scopes, monthly or custom date ranges, draft publishing, repeating completed periods, and persistent card ordering. A user can keep up to eight budgets, including budgets outside the currently selected month.
+
 ## Architecture Map
 
 The app now follows an app-flow structure with domain logic separated from pages and shared app services:
@@ -64,6 +66,7 @@ There is only one deployed SPA. `apps/mobisite` is internal separation, not a se
 
 - Accounts come before transactions in the user flow.
 - Transaction writes that change balances must stay atomic with Firestore `writeBatch` and `increment()`.
+- Budget reorder writes must stay atomic so every document receives a consistent `displayOrder`.
 - Transfers are represented as two linked transaction records and two account balance updates.
 - Keep data normalization in domain models and Firebase behavior in domain hooks.
 - Use shared types from `src/types/` instead of redefining domain shapes in UI components.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -59,9 +59,14 @@ Run `npm test` for the latest exact test count in your environment.
 - Recurring transaction CRUD and quick-fill behavior
 - Import/export flows (CSV/JSON, duplicate handling)
 - Dashboard/Table/List filtering and sorting behavior
+- Category budget create/edit/delete, optional sub-category matching, draft publishing, custom dates, repeating, duplicate validation, eight-budget enforcement, and progress totals
+- Budget cards remain equal height, render four per row at desktop widths, and preserve drag/button ordering after reload
+- Budget cards outside the selected month remain visible under other periods
+- Mobile-created expense transactions appearing in matching desktop budgets
+- Desktop/mobile transaction and budget creation show success feedback
 - Multi-account transfer and reconcile flows
 - Theme switching (dark/light mode)
-- Mobile responsiveness and sidebar navigation
+- Mobile responsiveness and sidebar navigation, including leaving an open transaction form for budgets
 
 ## High-Priority Missing Tests
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -35,12 +35,22 @@ A transfer is represented as **two Transaction documents** — both with `type: 
 
 **Budget:**
 
-- `id?: string`
-- `userId?: string`
-- `category: string`
+- `id: string`
+- `userId: string`
+- `accountId?: string`
+- `categoryId: string`
+- `subCategoryId?: string`
 - `amount: number`
-- `period: 'monthly'`
+- `period: 'monthly' | 'custom'`
+- `month?: string` (`YYYY-MM`, monthly budgets only)
+- `startDate: string`
+- `endDate: string`
+- `lifecycleStatus: 'draft' | 'published'`
+- `displayOrder?: number` (persisted card position; legacy budgets use a stable fallback)
 - `createdAt?: Date | { toDate: () => Date }`
+- `updatedAt?: Date | { toDate: () => Date }`
+
+Users can create up to eight budgets. New budgets begin as drafts, published budgets track matching expenses, and completed periods can be repeated into a new draft.
 
 **RecurringTransaction:**
 
@@ -67,7 +77,7 @@ All data is scoped to the authenticated user via subcollections:
 users/{userId}/
   transactions/{transactionId}   — income, expense, and transfer records
   accounts/{accountId}           — financial accounts (debit, credit, savings, cash)
-  budgets/{budgetId}             — monthly category budgets
+  budgets/{budgetId}             — category budgets with optional sub-category scope
   categories/{categoryId}        — custom categories and subcategories
   recurringTransactions/{id}     — recurring transaction templates (income or expense)
 ```
@@ -83,7 +93,7 @@ Legacy top-level `transactions` and `recurringExpenses` collections exist as **r
 | File | Responsibilities |
 |---|---|
 | `AccountModel.ts` | `Account` interface, `normalizeAccount()`, `calculateNetWorth()`, `ACCOUNT_TYPE_LABELS`, `ACCOUNT_COLORS` |
-| `BudgetModel.ts` | `Budget` interface, `normalizeBudget()`, `calculateBudgetUsage(budget, transactions)` |
+| `BudgetModel.ts` | Budget normalization, stable display ordering, draft/publish lifecycle, monthly/custom periods, optional sub-category matching, repeat helpers, and progress calculations |
 | `TransactionModel.ts` | `Transaction` interface, `normalizeTransaction()`, filter helpers (`filterExpenses`, `filterIncome`, `filterTransfers`, `filterByAccount`, `filterByCategory`, `groupByCategory`, `calculateTotals`) |
 | `RecurringTransactionModel.ts` | `RecurringTransaction` interface, `normalizeRecurringTransaction()`, `normalizeRecurringTransactions()`, `validateRecurringTransaction()` (validates title, amount > 0, category, frequency enum) |
 
@@ -92,7 +102,7 @@ Legacy top-level `transactions` and `recurringExpenses` collections exist as **r
 | Hook | Collection | Key operations |
 |---|---|---|
 | `useAccounts` | `users/{uid}/accounts` | `onSnapshot`, `addAccount`, `updateAccount`, `deleteAccount`, `updateBalance(delta)` |
-| `useBudgets` | `users/{uid}/budgets` | `onSnapshot`, `addBudget`, `updateBudget`, `deleteBudget` |
+| `useBudgets` | `users/{uid}/budgets` | `onSnapshot`, lifecycle-aware category budget CRUD and atomic reorder persistence via the budget service |
 | `useTransactions` | `users/{uid}/transactions` | `onSnapshot`, `addTransaction` (batch tx + balance; requires account), `addTransfer` (batch 2 tx + 2 balances; requires both accounts), `deleteTransaction` (batch delete + reverse balance; skips missing accounts) |
 | `useRecurringTransactions` | `users/{uid}/recurringTransactions` | `onSnapshot`, `addRecurringTransaction`, `updateRecurringTransaction`, `deleteRecurringTransaction` |
 
@@ -132,8 +142,8 @@ ThemeProvider
 | `AccountForm` | `views/Accounts/` | Create / edit account |
 | `TransferForm` | `views/Accounts/` | Transfer between two accounts |
 | `ReconcileForm` | `views/Accounts/` | 3-step reconciliation flow |
-| `BudgetsList` | `views/Budgets/` | Budget cards with progress bars |
-| `BudgetForm` | `views/Budgets/` | Create / edit budget |
+| `BudgetsList` | `domains/budgets/views/` | Equal-height draft/active cards, month filtering, progress, publish/repeat actions, and persisted reordering |
+| `BudgetForm` | `domains/budgets/views/` | Theme-aware side panel for category/sub-category, amount, and monthly/custom date selection |
 | `ReportsView` | `views/Reports/` | 4 charts: category pie, account bar, monthly trend, net worth |
 | `TransactionForm` | `views/Transactions/` | Create / edit; supports income, expense, transfer types + account selector |
 | `TransactionsTable` | `views/Transactions/` | Tabular transaction list |
@@ -178,9 +188,26 @@ TransferForm --submit--> TransactionsContext.addTransfer({ fromAccountId, toAcco
 ```
 BudgetsList --render--> useBudgetsContext.getAllBudgetProgress(transactions)
   --> BudgetsController.getAllBudgetProgress(transactions)
-      --> budgets.map(b => calculateBudgetUsage(b, transactions))
-          // pure: filter expenses by category + current month, sum amounts
-          --> { budget, spent, remaining, percent }
+      --> budgets.map(b => calculateBudgetProgress(b, transactions))
+          // pure: match expense by user, category, optional sub-category/account, and date range
+          --> { budget, spent, remaining, usedPercentage, status }
+```
+
+### Budget Lifecycle And Ordering
+
+```
+BudgetForm --save--> createBudget(...)
+  --> validates category, amount, dates, duplicates, and the eight-budget limit
+  --> stores lifecycleStatus: 'draft' and appends displayOrder
+
+BudgetsList --publish--> publishBudget(id)
+  --> lifecycleStatus: 'published'
+
+BudgetsList --repeat completed period--> repeatBudget(id)
+  --> creates the next monthly/custom period as a draft
+
+BudgetsList --drag or move controls--> reorderBudgets(orderedIds)
+  --> one Firestore batch updates displayOrder for every budget
 ```
 
 ### Reports

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -71,40 +71,31 @@ export interface Transaction {
 	recurringOccurrenceDate?: string;
 }
 
-// Budget
-export type BudgetStatus = 'draft' | 'published';
-
 export interface Budget {
-	id?: string;
-	userId?: string;
-	category: string;
+	id: string;
+	userId: string;
+	accountId?: string;
+	categoryId: string;
+	subCategoryId?: string;
 	amount: number;
-	period: 'monthly';
-	status: BudgetStatus;
-	plannedStartDate: string;
-	plannedEndDate: string;
-	actualStartDate?: string;
-	actualEndDate?: string;
+	period: 'monthly' | 'custom';
+	month?: string;
+	startDate: string;
+	endDate: string;
+	lifecycleStatus: 'draft' | 'published';
+	displayOrder?: number;
 	createdAt?: Date | { toDate: () => Date };
+	updatedAt?: Date | { toDate: () => Date };
 }
+
+export type BudgetStatus = 'safe' | 'warning' | 'over';
 
 export interface BudgetProgress {
 	budget: Budget;
-	status: BudgetStatus;
-	isDraft: boolean;
-	plannedAmount: number;
-	plannedStartDate: string;
-	plannedEndDate: string;
-	actualStartDate?: string;
-	actualEndDate?: string;
-	comparisonStartDate: string;
-	comparisonEndDate: string;
-	started: boolean;
-	calculating: boolean;
-	actualSpent: number;
+	spent: number;
 	remaining: number;
-	overBudget: number;
-	percent: number;
+	usedPercentage: number;
+	status: BudgetStatus;
 }
 
 // Report types


### PR DESCRIPTION
## Summary
- redesign the budget page and side-panel form with clear category/sub-category titles, monthly or custom periods, draft publishing, repeat actions, and consistent progress cards
- keep every budget visible, enforce the eight-budget limit, and persist drag or button-based card ordering with atomic Firestore writes
- fix undefined optional fields during updates, transaction-form sidebar navigation, and success feedback for desktop/mobile transaction and budget creation
- add the monthly dashboard budget summary and keep category/sub-category renames synchronized with budget documents
- update project context, data-flow, and regression-testing documentation

## Root causes addressed
- the selected-month filter hid valid budgets from other periods
- optional Firestore values such as `accountId` could reach `updateDoc` as `undefined`
- route navigation did not immediately clear the active transaction form view
- draft, active, and historical budgets used separate card layouts and inconsistent grid widths

## Test plan
- [x] `./node_modules/.bin/jest --runInBand` (24 suites, 130 tests)
- [x] `./node_modules/.bin/tsc -p apps/desktop/tsconfig.app.json`
- [x] `./node_modules/.bin/eslint .` (0 errors; 8 existing Fast Refresh warnings)
- [x] `git diff --check`
- [ ] Manual authenticated browser check in light and dark mode (local Vite startup is currently blocked by the installed Rollup native binary signature)
