### PR TITLE
fix(desktop): restore scrolling on full-page and dialog forms

### DIFF
--- a/apps/desktop/src/components/app/page-layout.tsx
+++ b/apps/desktop/src/components/app/page-layout.tsx
@@ -1,8 +1,39 @@
 import React from 'react';
 import SectionHeader from '@/components/marketing/SectionHeader';
 import Currency from '@/components/marketing/Currency';
-import { pageBg, sectionLabel } from '@/styles/marketingStyles';
+import { modalShell, pageBg, sectionLabel } from '@/styles/marketingStyles';
 import { cn } from '@/lib/utils';
+
+/** Scrollable shell for full-page forms rendered inside the dashboard's fixed viewport. */
+export const FormPageShell: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+	className,
+	children,
+	...props
+}) => (
+	<div
+		className={cn(
+			'min-h-0 flex-1 overflow-y-auto overscroll-y-contain',
+			pageBg,
+			className
+		)}
+		{...props}
+	>
+		<div className="flex justify-center p-4 py-8">{children}</div>
+	</div>
+);
+
+export const FormPageCard: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+	className,
+	children,
+	...props
+}) => (
+	<div
+		className={cn('w-full max-w-2xl self-start p-8 backdrop-blur-sm', modalShell, className)}
+		{...props}
+	>
+		{children}
+	</div>
+);
 
 export const PageShell: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
 	className,

--- a/apps/desktop/src/components/app/ui/dialog.tsx
+++ b/apps/desktop/src/components/app/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background text-foreground p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-dialog',
+				'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background text-foreground p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-dialog',
 				className
 			)}
 			{...props}

--- a/apps/desktop/src/domains/accounts/views/AccountForm.tsx
+++ b/apps/desktop/src/domains/accounts/views/AccountForm.tsx
@@ -6,6 +6,7 @@ import {
 	ACCOUNT_TYPE_LABELS,
 	normalizeAccountType,
 } from '@/domains/accounts/models/AccountModel';
+import { FormPageCard, FormPageShell } from '@/components/app/page-layout';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
 import {
@@ -78,8 +79,8 @@ const AccountForm: React.FC<AccountFormProps> = ({ onClose, account }) => {
 	};
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4">
-			<div className="w-full max-w-lg rounded-2xl border bg-card p-8 shadow-xl">
+		<FormPageShell className="bg-background">
+			<FormPageCard className="max-w-lg rounded-2xl border bg-card shadow-xl backdrop-blur-none">
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">
 						{account ? 'Edit Account' : 'New Account'}
@@ -205,8 +206,8 @@ const AccountForm: React.FC<AccountFormProps> = ({ onClose, account }) => {
 						</Button>
 					</div>
 				</form>
-			</div>
-		</div>
+			</FormPageCard>
+		</FormPageShell>
 	);
 };
 

--- a/apps/desktop/src/domains/accounts/views/ReconcileForm.tsx
+++ b/apps/desktop/src/domains/accounts/views/ReconcileForm.tsx
@@ -4,8 +4,7 @@ import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { ACCOUNT_TYPE_LABELS } from '@/domains/accounts/models/AccountModel';
-import { modalShell, pageBg } from '@/styles/marketingStyles';
-import { cn } from '@/lib/utils';
+import { FormPageCard, FormPageShell } from '@/components/app/page-layout';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
@@ -85,8 +84,8 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 
 	if (step === 'done') {
 		return (
-			<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
-				<div className={cn('w-full max-w-md p-8 text-center', modalShell)}>
+			<FormPageShell>
+				<FormPageCard className="max-w-md text-center">
 					<div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
 						<FiCheckCircle className="h-7 w-7 text-green-600 dark:text-green-400" />
 					</div>
@@ -112,14 +111,14 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 					<Button className="w-full" onClick={onClose}>
 						Done
 					</Button>
-				</div>
-			</div>
+				</FormPageCard>
+			</FormPageShell>
 		);
 	}
 
 	return (
-		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
-			<div className={cn('w-full max-w-lg p-8', modalShell)}>
+		<FormPageShell>
+			<FormPageCard className="max-w-lg">
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">Reconcile Account</h2>
 					<p className="mt-1.5 text-sm text-muted-foreground">
@@ -283,8 +282,8 @@ const ReconcileForm: React.FC<ReconcileFormProps> = ({ onClose }) => {
 						</div>
 					</div>
 				)}
-			</div>
-		</div>
+			</FormPageCard>
+		</FormPageShell>
 	);
 };
 

--- a/apps/desktop/src/domains/accounts/views/TransferForm.tsx
+++ b/apps/desktop/src/domains/accounts/views/TransferForm.tsx
@@ -3,7 +3,8 @@ import { FiArrowRight } from 'react-icons/fi';
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import Currency from '@/components/marketing/Currency';
-import { cardSurfaceInner, modalShell, pageBg } from '@/styles/marketingStyles';
+import { FormPageCard, FormPageShell } from '@/components/app/page-layout';
+import { cardSurfaceInner } from '@/styles/marketingStyles';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
@@ -74,8 +75,8 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 	};
 
 	return (
-		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
-			<div className={cn('w-full max-w-lg p-8', modalShell)}>
+		<FormPageShell>
+			<FormPageCard className="max-w-lg">
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">Transfer Money</h2>
 					<p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
@@ -234,8 +235,8 @@ const TransferForm: React.FC<TransferFormProps> = ({ onClose }) => {
 						</Button>
 					</div>
 				</form>
-			</div>
-		</div>
+			</FormPageCard>
+		</FormPageShell>
 	);
 };
 

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsList.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsList.tsx
@@ -92,7 +92,7 @@ const RecurringTransactionsList: React.FC = () => {
 			</div>
 
 			<Dialog open={isFormOpen} onOpenChange={(open) => { if (!open) handleCloseForm(); }}>
-				<DialogContent className="sm:max-w-lg">
+				<DialogContent className="sm:max-w-lg overflow-y-auto">
 					<RecurringTransactionForm transaction={editingTransaction} onClose={handleCloseForm} />
 				</DialogContent>
 			</Dialog>

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
@@ -573,7 +573,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 
 			{/* Add / Edit Form Dialog */}
 			<Dialog open={isFormOpen} onOpenChange={handleCloseForm}>
-				<DialogContent className="sm:max-w-lg">
+				<DialogContent className="sm:max-w-lg overflow-y-auto">
 					<RecurringTransactionForm transaction={editingTransaction} onClose={handleCloseForm} />
 				</DialogContent>
 			</Dialog>

--- a/apps/desktop/src/domains/reports/components/PieChart.tsx
+++ b/apps/desktop/src/domains/reports/components/PieChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { PieChart as RechartsPieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { DateRange, PieChartComponentProps } from '@/types';
 import DateRangeFilter from '@/shared/filters/components/DateRangeFilter';
+import { FormPageCard, FormPageShell } from '@/components/app/page-layout';
 import { Button } from '@/components/app/ui/button';
 import { X } from 'lucide-react';
 
@@ -28,8 +29,8 @@ const PieChartComponent: React.FC<PieChartComponentProps> = ({
 	}, [data]);
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-background p-4 md:p-6">
-			<div className="w-full max-w-4xl rounded-lg border bg-card p-4 md:p-6 shadow-lg">
+		<FormPageShell className="bg-background">
+			<FormPageCard className="max-w-4xl rounded-lg border bg-card p-4 shadow-lg backdrop-blur-none md:p-6">
 				<div className="mb-4 md:mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
 					<div>
 						<h2 className="text-xl md:text-2xl font-semibold">Expense Breakdown</h2>
@@ -145,8 +146,8 @@ const PieChartComponent: React.FC<PieChartComponentProps> = ({
 						</div>
 					</>
 				)}
-			</div>
-		</div>
+			</FormPageCard>
+		</FormPageShell>
 	);
 };
 

--- a/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
+++ b/apps/desktop/src/domains/transactions/views/TransactionForm.tsx
@@ -18,8 +18,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/app/ui/select';
-import { modalShell, pageBg } from '@/styles/marketingStyles';
-import { cn } from '@/lib/utils';
+import { FormPageCard, FormPageShell } from '@/components/app/page-layout';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
 
@@ -267,8 +266,8 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 	const availableTransferAccounts = accounts.filter((a) => a.id !== accountId);
 
 	return (
-		<div className={cn('flex min-h-screen items-center justify-center p-4', pageBg)}>
-			<div className={cn('w-full max-w-2xl p-8 backdrop-blur-sm', modalShell)}>
+		<FormPageShell>
+			<FormPageCard>
 				{/* Header */}
 				<div className="mb-8 border-b pb-6">
 					<h2 className="text-3xl font-bold tracking-tight">
@@ -535,8 +534,8 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 						</Button>
 					</div>
 				</form>
-			</div>
-		</div>
+			</FormPageCard>
+		</FormPageShell>
 	);
 };
 


### PR DESCRIPTION
## Summary
- Add `FormPageShell` and `FormPageCard` so full-page forms scroll inside the dashboard's fixed viewport instead of being clipped by `overflow-hidden`
- Migrate transaction, account, transfer, reconcile, and pie chart forms to the shared scrollable layout
- Enable `overflow-y-auto` on base `DialogContent` so recurring transaction dialogs scroll when content exceeds the viewport

## Test plan
- [x] `npm test`
- [x] `cd apps/desktop && npx tsc -p tsconfig.app.json`
- [ ] Open **New Transaction** on a short viewport (mobile or resized desktop) and confirm the full form scrolls to the submit/cancel buttons
- [ ] Repeat for **Transfer**, **Reconcile**, and **New/Edit Account** forms from the dashboard
- [ ] Open add/edit recurring transaction in a dialog and confirm long forms scroll

Made with [Cursor](https://cursor.com)