### PR TITLE
Fix rolling budget cycle periods

### DIFF
--- a/apps/desktop/src/domains/budgets/models/__tests__/BudgetModel.test.ts
+++ b/apps/desktop/src/domains/budgets/models/__tests__/BudgetModel.test.ts
@@ -1,6 +1,7 @@
 import {
 	budgetOverlapsMonth,
 	buildRepeatedBudget,
+	calculateBudgetProgress,
 	calculateBudgetRemaining,
 	calculateBudgetSpent,
 	calculateBudgetUsedPercentage,
@@ -88,6 +89,20 @@ describe('BudgetModel', () => {
 		});
 	});
 
+	it.each([
+		['2026-05-18T12:00:00', '2026-04-26', '2026-05-26'],
+		['2026-05-26T12:00:00', '2026-05-26', '2026-06-26'],
+		['2026-06-27T12:00:00', '2026-06-26', '2026-07-26'],
+	] as const)(
+		'resolves a day 26 cycle around %s',
+		(referenceDate, startDate, endDate) => {
+			expect(getBudgetCycleDateRange(26, new Date(referenceDate))).toEqual({
+				startDate,
+				endDate,
+			});
+		}
+	);
+
 	it('includes the cycle start and excludes the renewal boundary', () => {
 		const budget = makeBudget({
 			period: 'custom',
@@ -133,6 +148,15 @@ describe('BudgetModel', () => {
 			).toEqual({ startDate, endDate });
 		}
 	);
+
+	it('handles a recurring cycle across December and January', () => {
+		expect(
+			getBudgetCycleDateRange(26, new Date('2026-01-02T12:00:00'))
+		).toEqual({
+			startDate: '2025-12-26',
+			endDate: '2026-01-26',
+		});
+	});
 
 	it('normalizes legacy cycle fields into the canonical renewal day', () => {
 		expect(
@@ -214,6 +238,49 @@ describe('BudgetModel', () => {
 		expect(calculateBudgetSpent(transactions, budget)).toBe(450);
 		expect(calculateBudgetRemaining(400, 450)).toBe(-50);
 		expect(calculateBudgetUsedPercentage(400, 450)).toBe(112.5);
+	});
+
+	it('calculates progress only from transactions inside the active cycle', () => {
+		const budget = makeBudget({
+			amount: 1000,
+			period: 'custom',
+			month: undefined,
+			cycleDay: 26,
+			startDate: '2026-04-26',
+			endDate: '2026-05-26',
+		});
+		const transactions = [
+			makeTransaction({
+				id: 'previous-cycle',
+				amount: 100,
+				date: new Date('2026-05-25T12:00:00'),
+			}),
+			makeTransaction({
+				id: 'cycle-start',
+				amount: 200,
+				date: new Date('2026-05-26T12:00:00'),
+			}),
+			makeTransaction({
+				id: 'inside-cycle',
+				amount: 300,
+				date: new Date('2026-06-10T12:00:00'),
+			}),
+			makeTransaction({
+				id: 'renewal-boundary',
+				amount: 400,
+				date: new Date('2026-06-26T12:00:00'),
+			}),
+		];
+
+		const progress = calculateBudgetProgress(
+			budget,
+			transactions,
+			new Date('2026-06-13T12:00:00')
+		);
+
+		expect(progress.spent).toBe(500);
+		expect(progress.remaining).toBe(500);
+		expect(progress.usedPercentage).toBe(50);
 	});
 
 	it.each([

--- a/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
+++ b/apps/desktop/src/domains/budgets/views/BudgetsList.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/components/app/ui/dialog';
 import { cn } from '@/lib/utils';
 import { modalShell } from '@/styles/marketingStyles';
+import { useCurrentDate } from '@/hooks/useCurrentDate';
 import {
 	getBudgetTransactionFilters,
 	transactionFiltersToSearch,
@@ -316,6 +317,7 @@ const BudgetsList: React.FC = () => {
 	const [actionId, setActionId] = useState<string>();
 	const [draggingBudgetId, setDraggingBudgetId] = useState<string>();
 	const [actionError, setActionError] = useState('');
+	const referenceDate = useCurrentDate();
 	const serverOrderedBudgets = useMemo(
 		() => sortBudgetsByDisplayOrder(budgets),
 		[budgets]
@@ -352,13 +354,9 @@ const BudgetsList: React.FC = () => {
 			orderedBudgets
 				.filter((budget) => Boolean(budget.categoryId))
 				.map((budget) =>
-					calculateBudgetProgress(
-						budget,
-						transactions,
-						new Date(`${selectedMonth}-15T12:00:00`)
-					)
+					calculateBudgetProgress(budget, transactions, referenceDate)
 				),
-		[orderedBudgets, selectedMonth, transactions]
+		[orderedBudgets, referenceDate, transactions]
 	);
 	const progress = useMemo(
 		() =>
@@ -481,7 +479,7 @@ const BudgetsList: React.FC = () => {
 					getCategoryLabel={getCategoryLabel}
 					getSubcategoryLabel={getSubcategoryLabel}
 					actionId={actionId}
-					referenceDate={new Date(`${selectedMonth}-15T12:00:00`)}
+					referenceDate={referenceDate}
 					onEdit={openEdit}
 					onDelete={setBudgetToDelete}
 					onPublish={(budget) =>
@@ -505,10 +503,7 @@ const BudgetsList: React.FC = () => {
 					onViewTransactions={(budget) =>
 						navigate(
 							`/dashboard/transactions${transactionFiltersToSearch(
-								getBudgetTransactionFilters(
-									budget,
-									new Date(`${selectedMonth}-15T12:00:00`)
-								)
+								getBudgetTransactionFilters(budget, referenceDate)
 							)}`
 						)
 					}

--- a/apps/desktop/src/domains/budgets/views/__tests__/BudgetsList.test.tsx
+++ b/apps/desktop/src/domains/budgets/views/__tests__/BudgetsList.test.tsx
@@ -2,17 +2,22 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import BudgetsList from '../BudgetsList';
 import {
-	getCurrentBudgetMonth,
 	getMonthDateRange,
 } from '@/domains/budgets/models/BudgetModel';
 
-const mockMonth = getCurrentBudgetMonth();
+const mockMonth = '2026-06';
 const mockRange = getMonthDateRange(mockMonth);
 const mockPublishBudget = jest.fn();
 const mockRepeatBudget = jest.fn();
 const mockDeleteBudget = jest.fn();
 const mockReorderBudgets = jest.fn();
 const mockNavigate = jest.fn();
+const categoryLabels: Record<string, string> = {
+	bills: 'Bills',
+	food: 'Food',
+	petrol: 'Petrol',
+	travel: 'Travel',
+};
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
@@ -25,6 +30,11 @@ const renderBudgets = () =>
 			<BudgetsList />
 		</MemoryRouter>
 	);
+
+const textContentMatches = (expected: RegExp) => (
+	_content: string,
+	element: Element | null
+) => Boolean(element?.textContent?.replace(/\s/g, ' ').match(expected));
 
 jest.mock('@/domains/budgets/context/BudgetsContext', () => ({
 	useBudgetsContext: () => ({
@@ -91,6 +101,18 @@ jest.mock('@/domains/budgets/context/BudgetsContext', () => ({
 				lifecycleStatus: 'draft',
 				displayOrder: 4,
 			},
+			{
+				id: 'cycle-bills',
+				userId: 'user-1',
+				categoryId: 'bills',
+				amount: 1000,
+				period: 'custom',
+				cycleDay: 26,
+				startDate: '2026-05-26',
+				endDate: '2026-06-26',
+				lifecycleStatus: 'published',
+				displayOrder: 5,
+			},
 		],
 		deleteBudget: mockDeleteBudget,
 		publishBudget: mockPublishBudget,
@@ -134,6 +156,36 @@ jest.mock('@/domains/transactions/context/TransactionsContext', () => ({
 				category: 'petrol',
 				date: new Date(`${mockMonth}-12T12:00:00`),
 			},
+			{
+				id: 'old-cycle-bill',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Old bill',
+				amount: 700,
+				type: 'expense',
+				category: 'bills',
+				date: new Date('2026-06-25T12:00:00'),
+			},
+			{
+				id: 'current-cycle-bill',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Current bill',
+				amount: 500,
+				type: 'expense',
+				category: 'bills',
+				date: new Date('2026-06-26T12:00:00'),
+			},
+			{
+				id: 'renewal-boundary-bill',
+				userId: 'user-1',
+				accountId: 'account-1',
+				title: 'Next bill',
+				amount: 900,
+				type: 'expense',
+				category: 'bills',
+				date: new Date('2026-07-26T12:00:00'),
+			},
 		],
 	}),
 }));
@@ -162,17 +214,31 @@ jest.mock('@/domains/categories/context/CategoriesContext', () => ({
 				label: 'Travel',
 				subcategories: [],
 			},
+			{
+				id: 'bills',
+				value: 'bills',
+				label: 'Bills',
+				subcategories: [],
+			},
 		],
-		getCategoryLabel: (category: string) =>
-			category === 'food' ? 'Food' : category === 'travel' ? 'Travel' : 'Petrol',
+		getCategoryLabel: (category: string) => categoryLabels[category] ?? 'Petrol',
 		getSubcategoryLabel: (_category: string, subcategory?: string) =>
 			subcategory === 'groceries' ? 'Groceries' : 'Takeaways',
 	}),
 }));
 
 describe('BudgetsList', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
 	beforeEach(() => {
 		jest.clearAllMocks();
+		jest.setSystemTime(new Date('2026-06-27T12:00:00'));
 	});
 
 	it('separates drafts and active budgets with explicit titles', () => {
@@ -185,7 +251,7 @@ describe('BudgetsList', () => {
 		expect(screen.getAllByText('Tracks all Petrol expenses').length).toBeGreaterThan(0);
 		expect(screen.getByText('Other budget periods')).toBeInTheDocument();
 		expect(screen.getByText('Travel')).toBeInTheDocument();
-		expect(screen.getByText('5 of 8 budgets created')).toBeInTheDocument();
+		expect(screen.getByText('6 of 8 budgets created')).toBeInTheDocument();
 	});
 
 	it('shows concise dates, sentence metrics, and status states', () => {
@@ -196,7 +262,7 @@ describe('BudgetsList', () => {
 		);
 		expect(screen.getAllByText(monthLabel).length).toBeGreaterThan(0);
 		expect(screen.getAllByText(/spent of/).length).toBeGreaterThan(0);
-		expect(screen.getByText('On track')).toBeInTheDocument();
+		expect(screen.getAllByText('On track').length).toBeGreaterThan(0);
 		expect(screen.getByText('Watch spending')).toBeInTheDocument();
 		expect(screen.getByText('Over budget')).toBeInTheDocument();
 		expect(screen.getByRole('img', { name: '61 percent used' })).toBeInTheDocument();
@@ -233,6 +299,7 @@ describe('BudgetsList', () => {
 				'over-petrol',
 				'warning-food',
 				'next-month-travel',
+				'cycle-bills',
 			])
 		);
 	});
@@ -256,6 +323,36 @@ describe('BudgetsList', () => {
 		);
 		expect(mockNavigate).toHaveBeenCalledWith(
 			expect.stringContaining(`to=${mockRange.endDate}`)
+		);
+	});
+
+	it('uses the active rolling cycle for custom budget display and history links', () => {
+		renderBudgets();
+
+		expect(screen.getByText('Bills')).toBeInTheDocument();
+		expect(screen.getByText('26 Jun – 26 Jul 2026')).toBeInTheDocument();
+		expect(
+			screen.getByText(textContentMatches(/^R 500,00 spent of R 1 000,00$/))
+		).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: '50 percent used' })).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'View transactions for Bills',
+			})
+		);
+
+		expect(mockNavigate).toHaveBeenCalledWith(
+			expect.stringContaining('/dashboard/transactions?category=bills&type=expense')
+		);
+		expect(mockNavigate).toHaveBeenCalledWith(
+			expect.stringContaining('from=2026-06-26')
+		);
+		expect(mockNavigate).toHaveBeenCalledWith(
+			expect.stringContaining('to=2026-07-26')
+		);
+		expect(mockNavigate).toHaveBeenCalledWith(
+			expect.stringContaining('endExclusive=1')
 		);
 	});
 });

--- a/apps/desktop/src/hooks/useCurrentDate.ts
+++ b/apps/desktop/src/hooks/useCurrentDate.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const getMillisecondsUntilNextDay = (date: Date): number => {
+	const nextDay = new Date(date);
+	nextDay.setHours(24, 0, 1, 0);
+	return Math.max(1000, nextDay.getTime() - date.getTime());
+};
+
+export const useCurrentDate = (): Date => {
+	const [currentDate, setCurrentDate] = useState(() => new Date());
+
+	useEffect(() => {
+		let timeoutId: ReturnType<typeof setTimeout>;
+
+		const scheduleNextDay = () => {
+			timeoutId = setTimeout(() => {
+				setCurrentDate(new Date());
+				scheduleNextDay();
+			}, getMillisecondsUntilNextDay(new Date()));
+		};
+
+		scheduleNextDay();
+		return () => clearTimeout(timeoutId);
+	}, []);
+
+	return currentDate;
+};

--- a/apps/desktop/src/pages/dashboard/components/BudgetSummary.tsx
+++ b/apps/desktop/src/pages/dashboard/components/BudgetSummary.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/shared/filters/utils/transactionFilters';
 import { formatCurrency } from '@/utils/formatCurrency';
 import { cn } from '@/lib/utils';
+import { useCurrentDate } from '@/hooks/useCurrentDate';
 
 interface BudgetSummaryProps {
 	onOpenBudgets: () => void;
@@ -55,7 +56,7 @@ const BudgetSummary: React.FC<BudgetSummaryProps> = ({
 	const { budgets } = useBudgetsContext();
 	const { transactions } = useTransactionsContext();
 	const { getCategoryLabel, getSubcategoryLabel } = useCategoriesContext();
-	const referenceDate = useMemo(() => new Date(), []);
+	const referenceDate = useCurrentDate();
 	const progress = useMemo(() => {
 		const month = getCurrentBudgetMonth(referenceDate);
 		return sortBudgetsByDisplayOrder(budgets)


### PR DESCRIPTION
## Summary
- Use a live current-date reference for rolling budget cycle progress, labels, and transaction-history links.
- Keep the selected budget month for grouping/form defaults only, so cycle budgets are not calculated from the 15th of the selected calendar month.
- Add coverage for day-26 cycles, short months, December to January, exclusive renewal boundaries, and the rendered budget list behavior.

## Root Cause
Custom cycle budgets already had a shared `getBudgetCycleDateRange` helper, but `BudgetsList` passed `new Date("${selectedMonth}-15")` into progress, display labels, and transaction filters. That made active cycle calculations depend on the selected calendar month instead of the actual rolling period.

## Impact
Budgets with a renewal day such as the 26th now display and calculate against the active rolling period, and open dashboard/list views refresh after local midnight without rewriting stored budget period fields.

## Validation
- `npm test -- --runTestsByPath apps/desktop/src/domains/budgets/models/__tests__/BudgetModel.test.ts apps/desktop/src/domains/budgets/views/__tests__/BudgetsList.test.tsx apps/desktop/src/shared/filters/utils/__tests__/transactionFilters.test.ts`
- `npm test`
- `cd apps/desktop && npx tsc -p tsconfig.app.json`