### PR TITLE
Improve recurring transaction preferences

### DIFF
--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionForm.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionForm.tsx
@@ -3,6 +3,8 @@ import { getAppErrorMessage } from '@cash-flow/shared/errors';
 import { FiDollarSign, FiTag, FiInfo, FiSave, FiX, FiRefreshCw, FiArrowUpCircle, FiArrowDownCircle } from 'react-icons/fi';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
+import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
+import { useMainAccountPreference } from '@cash-flow/shared/accounts/mainAccountPreference';
 import { RecurringTransaction } from '@/domains/recurring/models/RecurringTransactionModel';
 import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
@@ -17,6 +19,7 @@ import {
 } from '@/components/app/ui/select';
 import { Loader2 } from 'lucide-react';
 import { mergeCategoryOptions } from '@/domains/categories/utils/categories';
+import { formatCurrency } from '@/utils/formatCurrency';
 
 interface RecurringTransactionFormProps {
 	onClose: () => void;
@@ -33,6 +36,8 @@ const FREQUENCIES = [
 const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onClose, transaction: expense }) => {
 	const { addRecurringTransaction, updateRecurringTransaction } = useTransactionsContext();
 	const { categories, categoryOptions } = useCategoriesContext();
+	const { accounts } = useAccountsContext();
+	const { mainAccountId } = useMainAccountPreference();
 	const [title, setTitle] = useState('');
 	const [amount, setAmount] = useState(0);
 	const [transactionType, setTransactionType] = useState<'expense' | 'income'>('expense');
@@ -43,6 +48,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 		'monthly'
 	);
 	const [expectedDate, setExpectedDate] = useState<number | ''>('');
+	const [accountId, setAccountId] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState('');
 	const availableCategories = React.useMemo(
@@ -61,6 +67,13 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			),
 		[selectedCategory, subcategory]
 	);
+	const defaultAccountId = React.useMemo(
+		() => {
+			const mainAccount = accounts.find((account) => account.id === mainAccountId);
+			return mainAccount?.id ?? accounts[0]?.id ?? '';
+		},
+		[accounts, mainAccountId]
+	);
 
 	const handleCategoryChange = (value: string) => {
 		setCategory(value);
@@ -78,6 +91,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			setDescription(expense.description ?? '');
 			setFrequency(expense.frequency ?? 'monthly');
 			setExpectedDate(expense.expectedDate ?? '');
+			setAccountId(expense.accountId ?? '');
 			setError('');
 		} else {
 			setTitle('');
@@ -88,6 +102,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			setDescription('');
 			setFrequency('monthly');
 			setExpectedDate('');
+			setAccountId('');
 			setError('');
 		}
 	}, [expense]);
@@ -99,6 +114,12 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			setSubcategory('');
 		}
 	}, [availableSubcategories, subcategory]);
+
+	useEffect(() => {
+		if (!accountId && defaultAccountId) {
+			setAccountId(defaultAccountId);
+		}
+	}, [accountId, defaultAccountId]);
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -124,6 +145,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 				| 'description'
 				| 'frequency'
 				| 'expectedDate'
+				| 'accountId'
 			> = {
 				title,
 				amount: Number(amount),
@@ -131,6 +153,7 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 				category: categoryForSubmit,
 				subcategory: subcategory || undefined,
 				description,
+				accountId: accountId || undefined,
 				frequency,
 				expectedDate: normalizedExpectedDate,
 			};
@@ -211,6 +234,33 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 						</button>
 					</div>
 				</div>
+
+				{/* Account selector */}
+				{accounts.length > 0 && (
+					<div className="space-y-2">
+						<Label htmlFor="re-account" className="text-sm font-medium">
+							Account
+						</Label>
+						<Select value={accountId} onValueChange={setAccountId}>
+							<SelectTrigger id="re-account" className="h-10 rounded-lg border-2 transition-all focus:border-primary">
+								<SelectValue placeholder="Select account" />
+							</SelectTrigger>
+							<SelectContent>
+								{accounts.map((a) => (
+									<SelectItem key={a.id} value={a.id!}>
+										<span className="flex items-center gap-2">
+											<span
+												className="inline-block h-2.5 w-2.5 rounded-full flex-shrink-0"
+												style={{ backgroundColor: a.color ?? '#6366f1' }}
+											/>
+											{a.name} ({formatCurrency(a.balance)})
+										</span>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
 
 				{/* Title and Amount */}
 				<div className="grid gap-5 md:grid-cols-2">

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsCalendar.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsCalendar.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { FiChevronLeft, FiChevronRight, FiEdit, FiTrash2 } from 'react-icons/fi';
+import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { RecurringTransaction } from '@/domains/recurring/models/RecurringTransactionModel';
 import { Button } from '@/components/app/ui/button';
 import { Badge } from '@/components/app/ui/badge';
@@ -36,6 +37,8 @@ const RecurringTransactionsCalendar: React.FC<Props> = ({
 	onDelete,
 	getCategoryPathLabel,
 }) => {
+	const { accounts } = useAccountsContext();
+
 	const [visibleMonth, setVisibleMonth] = useState(() => {
 		const now = new Date();
 		return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -285,6 +288,10 @@ const RecurringTransactionsCalendar: React.FC<Props> = ({
 												transaction.subcategory
 											)} •{' '}
 											{getRecurringFrequencyLabel(transaction.frequency)}
+											{transaction.accountId && (() => {
+												const acct = accounts.find((a) => a.id === transaction.accountId);
+												return acct ? <> • {acct.name}</> : null;
+											})()}
 										</p>
 										<p className="mt-1 text-sm font-medium">
 											{formatCurrency(transaction.amount)}

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsList.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { FiEdit, FiTrash2, FiPlus, FiDollarSign } from 'react-icons/fi';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
+import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { RecurringTransaction } from '@/domains/recurring/models/RecurringTransactionModel';
 import { Button } from '@/components/app/ui/button';
 import RecurringTransactionForm from './RecurringTransactionForm';
@@ -19,6 +20,7 @@ const RecurringTransactionsList: React.FC = () => {
 	const { recurringTransactions, deleteRecurringTransaction, recurringTransactionsLoading } =
 		useTransactionsContext();
 	const { getCategoryPathLabel } = useCategoriesContext();
+	const { accounts } = useAccountsContext();
 	const [editingTransaction, setEditingTransaction] = useState<RecurringTransaction | undefined>(undefined);
 	const [isFormOpen, setIsFormOpen] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -128,6 +130,18 @@ const RecurringTransactionsList: React.FC = () => {
 											transaction.subcategory
 										)}
 									</span>
+									{transaction.accountId && (() => {
+										const acct = accounts.find((a) => a.id === transaction.accountId);
+										return acct ? (
+											<>
+												<span className="hidden sm:inline">•</span>
+												<span className="flex items-center gap-1">
+													<span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: acct.color ?? '#6366f1' }} />
+													{acct.name}
+												</span>
+											</>
+										) : null;
+									})()}
 									{transaction.description && (
 										<>
 											<span className="hidden sm:inline">•</span>

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionsView.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FiEdit, FiTrash2, FiPlus, FiDollarSign, FiX, FiSettings } from 'react-icons/fi';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
+import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
 import { RecurringTransaction } from '@/domains/recurring/models/RecurringTransactionModel';
 import { Button } from '@/components/app/ui/button';
 import { Badge } from '@/components/app/ui/badge';
@@ -110,6 +111,7 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	const { recurringTransactions, deleteRecurringTransaction, recurringTransactionsLoading } =
 		useTransactionsContext();
 	const { categoryOptions, getCategoryPathLabel } = useCategoriesContext();
+	const { accounts } = useAccountsContext();
 
 	const { prefs } = useFilterPreferences();
 	const recurringPrefs = prefs.recurring;
@@ -119,8 +121,14 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 	const [typeFilter, setTypeFilter] = useState('all');
 	const [expectedDateFilter, setExpectedDateFilter] = useState('all');
 	const [sortBy, setSortBy] = useState<SortBy>('default');
-	const [viewMode, setViewMode] = useState<ViewMode>('list');
-	const [isDesktopCalendarAllowed, setIsDesktopCalendarAllowed] = useState(false);
+	const [viewMode, setViewMode] = useState<ViewMode>(() => {
+		if (typeof window === 'undefined') return 'list';
+		const stored = window.localStorage.getItem(RECURRING_VIEW_MODE_STORAGE_KEY);
+		return stored === 'list' || stored === 'calendar' ? stored : 'list';
+	});
+	const [isDesktopCalendarAllowed, setIsDesktopCalendarAllowed] = useState(
+		() => typeof window !== 'undefined' && window.matchMedia(DESKTOP_MEDIA_QUERY).matches
+	);
 	const [isFormOpen, setIsFormOpen] = useState(false);
 	const [editingTransaction, setEditingTransaction] = useState<RecurringTransaction | undefined>(undefined);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -136,6 +144,8 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 		[categoryOptions, recurringTransactions]
 	);
 
+	const isHydrated = useRef(false);
+
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
 		const mediaQuery = window.matchMedia(DESKTOP_MEDIA_QUERY);
@@ -143,7 +153,6 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 			setIsDesktopCalendarAllowed(event.matches);
 		};
 
-		setIsDesktopCalendarAllowed(mediaQuery.matches);
 		mediaQuery.addEventListener('change', handleViewportChange);
 
 		return () => {
@@ -153,21 +162,26 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		const storedMode = window.localStorage.getItem(RECURRING_VIEW_MODE_STORAGE_KEY);
-		if (storedMode === 'list' || (storedMode === 'calendar' && isDesktopCalendarAllowed)) {
-			setViewMode(storedMode);
-		} else if (!isDesktopCalendarAllowed) {
-			setViewMode('list');
-		}
+
+		const readViewMode = () => {
+			const storedMode = window.localStorage.getItem(RECURRING_VIEW_MODE_STORAGE_KEY);
+			if (storedMode === 'list' || (storedMode === 'calendar' && isDesktopCalendarAllowed)) {
+				setViewMode(storedMode);
+			} else if (!isDesktopCalendarAllowed) {
+				setViewMode('list');
+			}
+		};
+
+		readViewMode();
+		isHydrated.current = true;
+		window.addEventListener('recurring-view-mode-changed', readViewMode);
+		return () => window.removeEventListener('recurring-view-mode-changed', readViewMode);
 	}, [isDesktopCalendarAllowed]);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		if (!isDesktopCalendarAllowed && viewMode === 'calendar') {
-			setViewMode('list');
-			window.localStorage.setItem(RECURRING_VIEW_MODE_STORAGE_KEY, 'list');
-			return;
-		}
+		if (!isHydrated.current) return;
+		if (!isDesktopCalendarAllowed) return;
 		window.localStorage.setItem(RECURRING_VIEW_MODE_STORAGE_KEY, viewMode);
 	}, [viewMode, isDesktopCalendarAllowed]);
 
@@ -531,6 +545,18 @@ const RecurringTransactionsView: React.FC<{ onOpenSettings?: () => void }> = ({ 
 									</span>
 									<span>•</span>
 									<span>{getCategoryPathLabel(expense.category, expense.subcategory)}</span>
+									{expense.accountId && (() => {
+										const acct = accounts.find((a) => a.id === expense.accountId);
+										return acct ? (
+											<>
+												<span>•</span>
+												<span className="flex items-center gap-1">
+													<span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: acct.color ?? '#6366f1' }} />
+													{acct.name}
+												</span>
+											</>
+										) : null;
+									})()}
 									{expense.description && (
 										<>
 											<span>•</span>

--- a/apps/desktop/src/pages/dashboard/components/SettingsModal.tsx
+++ b/apps/desktop/src/pages/dashboard/components/SettingsModal.tsx
@@ -91,6 +91,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 	const [categoryError, setCategoryError] = useState('');
 	const [categoryBusy, setCategoryBusy] = useState(false);
 	const selectedMainAccountExists = accounts.some((account) => account.id === mainAccountId);
+	const [recurringViewMode, setRecurringViewMode] = useState<'list' | 'calendar'>(() => {
+		const stored = window.localStorage.getItem('recurringTransactions.viewMode');
+		return stored === 'list' || stored === 'calendar' ? stored : 'list';
+	});
+
+	useEffect(() => {
+		if (open) {
+			const stored = window.localStorage.getItem('recurringTransactions.viewMode');
+			if (stored === 'list' || stored === 'calendar') {
+				setRecurringViewMode(stored);
+			}
+		}
+	}, [open]);
+
+	useEffect(() => {
+		window.localStorage.setItem('recurringTransactions.viewMode', recurringViewMode);
+		window.dispatchEvent(new Event('recurring-view-mode-changed'));
+	}, [recurringViewMode]);
 
 	useEffect(() => {
 		setLocalTheme(theme);
@@ -425,6 +443,25 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 													Used as the default account in desktop and mobisite
 													transaction capture. You can still pick another account
 													per transaction.
+												</p>
+											</div>
+											<div className="space-y-2">
+												<Label htmlFor="recurring-view-mode">
+													Default recurring view
+												</Label>
+												<select
+													id="recurring-view-mode"
+													value={recurringViewMode}
+													onChange={(event) =>
+														setRecurringViewMode(event.target.value as 'list' | 'calendar')
+													}
+													className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+												>
+													<option value="list">List</option>
+													<option value="calendar">Calendar</option>
+												</select>
+												<p className="text-xs text-gray-500 dark:text-gray-400">
+													Calendar view is only available on screens wider than 1024px.
 												</p>
 											</div>
 										</div>


### PR DESCRIPTION
## Summary
- add account selection to recurring transaction forms and surface the selected account in recurring list and calendar views
- persist the recurring transactions list/calendar preference and expose it in Settings
- fix the settings modal so it does not overwrite a saved recurring view preference on dashboard load

## Why
- recurring transactions should inherit a sensible default account and make the chosen account visible in recurring management screens
- users need a stable default recurring view that can be managed from Settings
- the saved view preference was being reset because the always-mounted settings modal wrote its default state before hydrating from localStorage

## Validation
- npm test
- cd apps/desktop && npx tsc -p tsconfig.app.json