### PR TITLE
feat: add random notes workspace

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -85,6 +85,14 @@ function App() {
 											}
 										/>
 										<Route
+											path="/dashboard/random"
+											element={
+												<ProtectedRoute>
+													<Dashboard />
+												</ProtectedRoute>
+											}
+										/>
+										<Route
 											path="/dashboard/assistant"
 											element={
 												<ProtectedRoute>

--- a/apps/desktop/src/__tests__/AppRoutes.test.tsx
+++ b/apps/desktop/src/__tests__/AppRoutes.test.tsx
@@ -144,6 +144,12 @@ describe('App routing', () => {
 		expect(screen.getByText('Desktop dashboard')).toBeInTheDocument();
 	});
 
+	it('renders the desktop shell at /dashboard/random', () => {
+		mockInitialPath = '/dashboard/random';
+		render(<App />);
+		expect(screen.getByText('Desktop dashboard')).toBeInTheDocument();
+	});
+
 	it('redirects authenticated mobile dashboard routes to mobisite', async () => {
 		mockInitialPath = '/dashboard/reports';
 		setMobileViewport(true);

--- a/apps/desktop/src/domains/random/hooks/useRandomNote.ts
+++ b/apps/desktop/src/domains/random/hooks/useRandomNote.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+import { doc, onSnapshot, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth, db } from '@/services/firebase';
+
+const RANDOM_NOTE_ID = 'main';
+export const RANDOM_NOTE_LIMIT = 10_000;
+
+export const useRandomNote = () => {
+	const [content, setContent] = useState('');
+	const [exists, setExists] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const [user, setUser] = useState(() => auth.currentUser);
+
+	useEffect(() => {
+		const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+			setUser(firebaseUser);
+		});
+		return () => unsubscribe();
+	}, []);
+
+	useEffect(() => {
+		if (!user) {
+			setContent('');
+			setExists(false);
+			setLoading(false);
+			return;
+		}
+
+		setLoading(true);
+		const noteRef = doc(db, 'users', user.uid, 'random', RANDOM_NOTE_ID);
+		const unsubscribe = onSnapshot(
+			noteRef,
+			(snapshot) => {
+				setExists(snapshot.exists());
+				setContent(snapshot.exists() ? String(snapshot.data().content ?? '') : '');
+				setLoading(false);
+			},
+			(error) => {
+				console.error('Error fetching random note:', error);
+				setLoading(false);
+			}
+		);
+
+		return () => unsubscribe();
+	}, [user]);
+
+	const saveNote = useCallback(
+		async (nextContent: string) => {
+			if (!user) throw new Error('User not authenticated');
+			if (nextContent.length > RANDOM_NOTE_LIMIT) {
+				throw new Error(`Random note must be ${RANDOM_NOTE_LIMIT} characters or fewer.`);
+			}
+
+			const noteRef = doc(db, 'users', user.uid, 'random', RANDOM_NOTE_ID);
+			if (exists) {
+				await updateDoc(noteRef, {
+					content: nextContent,
+					updatedAt: serverTimestamp(),
+				});
+				return;
+			}
+
+			await setDoc(noteRef, {
+				content: nextContent,
+				userId: user.uid,
+				createdAt: serverTimestamp(),
+				updatedAt: serverTimestamp(),
+			});
+		},
+		[exists, user]
+	);
+
+	return { content, loading, saveNote };
+};

--- a/apps/desktop/src/domains/random/views/RandomView.tsx
+++ b/apps/desktop/src/domains/random/views/RandomView.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FiCheck, FiEdit3, FiSave } from 'react-icons/fi';
+import { Button } from '@/components/app/ui/button';
+import { Textarea } from '@/components/app/ui/textarea';
+import { useToast } from '@/components/app/ui/use-toast';
+import { PageHeader, PageShell } from '@/components/app/page-layout';
+import { useRandomNote, RANDOM_NOTE_LIMIT } from '@/domains/random/hooks/useRandomNote';
+import { cardSurface, sectionLabel } from '@/styles/marketingStyles';
+import { cn } from '@/lib/utils';
+import { getAppErrorMessage } from '@cash-flow/shared/errors';
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+const RandomView: React.FC = () => {
+	const { content, loading, saveNote } = useRandomNote();
+	const { toast } = useToast();
+	const [draft, setDraft] = useState('');
+	const [savedContent, setSavedContent] = useState('');
+	const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+	const [hasLocalChanges, setHasLocalChanges] = useState(false);
+	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const latestDraftRef = useRef('');
+
+	useEffect(() => {
+		setSavedContent(content);
+		if (!hasLocalChanges) setDraft(content);
+	}, [content, hasLocalChanges]);
+
+	useEffect(() => {
+		latestDraftRef.current = draft;
+	}, [draft]);
+
+	useEffect(() => {
+		textareaRef.current?.focus();
+	}, []);
+
+	const persistDraft = async (nextContent = draft) => {
+		if (nextContent.length > RANDOM_NOTE_LIMIT) {
+			setSaveStatus('error');
+			toast({
+				title: 'Random note is too long',
+				description: `Keep it to ${RANDOM_NOTE_LIMIT.toLocaleString()} characters or fewer.`,
+				variant: 'destructive',
+			});
+			return;
+		}
+
+		setSaveStatus('saving');
+		try {
+			await saveNote(nextContent);
+			setSavedContent(nextContent);
+			if (latestDraftRef.current === nextContent) {
+				setHasLocalChanges(false);
+				setSaveStatus('saved');
+			} else {
+				setHasLocalChanges(true);
+				setSaveStatus('idle');
+			}
+		} catch (error) {
+			setSaveStatus('error');
+			toast({
+				title: 'Random note was not saved',
+				description: getAppErrorMessage(error, { operation: 'Save random note' }),
+				variant: 'destructive',
+			});
+		}
+	};
+
+	useEffect(() => {
+		if (loading || !hasLocalChanges || draft === savedContent) return;
+
+		const timeoutId = window.setTimeout(() => {
+			void persistDraft(draft);
+		}, 900);
+
+		return () => window.clearTimeout(timeoutId);
+		// persistDraft intentionally stays out of this dependency list so typing only
+		// resets the debounce when the actual text/save inputs change.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [draft, hasLocalChanges, loading, saveNote, savedContent]);
+
+	const remainingCharacters = RANDOM_NOTE_LIMIT - draft.length;
+	const saveLabel =
+		saveStatus === 'saving'
+			? 'Saving...'
+			: saveStatus === 'saved' && !hasLocalChanges
+				? 'Saved'
+				: hasLocalChanges
+					? 'Unsaved changes'
+					: 'Ready';
+
+	return (
+		<PageShell className="flex flex-col">
+			<PageHeader
+				eyebrow="Random"
+				title="Write anything down"
+				description="A private place for brain dumps, reminders, rough thoughts, or anything that helps with mental clarity."
+			/>
+
+			<section className={cn('flex min-h-[60vh] flex-1 flex-col overflow-hidden', cardSurface)}>
+				<header className="flex flex-col gap-3 border-b border-gray-100 px-5 py-4 dark:border-gray-800 md:flex-row md:items-center md:justify-between">
+					<div>
+						<p className={sectionLabel}>Free text</p>
+						<h2 className="mt-1 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-50">
+							<FiEdit3 className="h-5 w-5 text-blue-600" />
+							Random notes
+						</h2>
+					</div>
+					<div className="flex flex-wrap items-center gap-3">
+						<span className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+							{saveStatus === 'saved' && !hasLocalChanges && <FiCheck className="h-4 w-4 text-emerald-600" />}
+							{saveLabel}
+						</span>
+						<Button
+							type="button"
+							variant="marketing"
+							onClick={() => void persistDraft()}
+							disabled={loading || saveStatus === 'saving' || draft.length > RANDOM_NOTE_LIMIT}
+						>
+							<FiSave className="mr-2 h-4 w-4" />
+							Save
+						</Button>
+					</div>
+				</header>
+
+				<div className="flex min-h-0 flex-1 flex-col gap-3 p-5">
+					<Textarea
+						ref={textareaRef}
+						value={draft}
+						onChange={(event) => {
+							setDraft(event.target.value);
+							setHasLocalChanges(true);
+							setSaveStatus('idle');
+						}}
+						disabled={loading}
+						placeholder="Write whatever is on your mind..."
+						className="min-h-[420px] flex-1 resize-none border-gray-200 bg-white/80 text-base leading-7 shadow-inner dark:border-gray-800 dark:bg-gray-950/50"
+						aria-label="Random free text note"
+					/>
+					<div className="flex flex-col gap-1 text-sm text-gray-500 dark:text-gray-400 md:flex-row md:items-center md:justify-between">
+						<p>{loading ? 'Loading your note...' : 'Autosaves after you pause typing.'}</p>
+						<p className={remainingCharacters < 0 ? 'text-destructive' : undefined}>
+							{remainingCharacters.toLocaleString()} characters remaining
+						</p>
+					</div>
+				</div>
+			</section>
+		</PageShell>
+	);
+};
+
+export default RandomView;

--- a/apps/desktop/src/pages/dashboard/Dashboard.tsx
+++ b/apps/desktop/src/pages/dashboard/Dashboard.tsx
@@ -15,6 +15,7 @@ import ReconcileForm from '@/domains/accounts/views/ReconcileForm';
 import BudgetsList from '@/domains/budgets/views/BudgetsList';
 import ReportsView from '@/domains/reports/views/ReportsView';
 import RecurringTransactionsView from '@/domains/recurring/views/RecurringTransactionsView';
+import RandomView from '@/domains/random/views/RandomView';
 import AIChatbot from '@/domains/ai/components/AIChatbot';
 import AuthModals from '@/domains/auth/components/AuthModals';
 import {
@@ -47,6 +48,7 @@ const routeToView = (pathname: string, isMobile: boolean): ViewType => {
 	if (pathname.startsWith('/dashboard/budgets')) return 'budgets';
 	if (pathname.startsWith('/dashboard/recurring')) return 'recurring';
 	if (pathname.startsWith('/dashboard/reports')) return 'reports';
+	if (pathname.startsWith('/dashboard/random')) return 'random';
 	if (pathname.startsWith('/dashboard/assistant')) return 'assistant';
 	return 'dashboard';
 };
@@ -64,6 +66,8 @@ const viewToRoute = (view: ViewType): string => {
 			return '/dashboard/recurring';
 		case 'reports':
 			return '/dashboard/reports';
+		case 'random':
+			return '/dashboard/random';
 		case 'assistant':
 			return '/dashboard/assistant';
 		default:
@@ -297,6 +301,8 @@ const Dashboard: React.FC = () => {
 				return <RecurringTransactionsView onOpenSettings={() => handleOpenSettings('filters')} />;
 			case 'reports':
 				return <ReportsView onOpenSettings={() => handleOpenSettings('filters')} />;
+			case 'random':
+				return <RandomView />;
 			case 'assistant':
 				return <AIChatbot />;
 			default:

--- a/apps/desktop/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/apps/desktop/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -51,6 +51,7 @@ jest.mock('@/pages/dashboard/components/Sidebar', () => ({
 		<>
 			<button onClick={onCreate}>Create transaction</button>
 			<button onClick={() => onViewChange('budgets')}>Open budgets</button>
+			<button onClick={() => onViewChange('random')}>Open random</button>
 		</>
 	),
 }));
@@ -128,6 +129,11 @@ jest.mock('@/domains/ai/components/AIChatbot', () => ({
 	default: () => <div>AI assistant</div>,
 }));
 
+jest.mock('@/domains/random/views/RandomView', () => ({
+	__esModule: true,
+	default: () => <div>Random notes</div>,
+}));
+
 jest.mock('@/domains/auth/components/AuthModals', () => ({
 	__esModule: true,
 	default: () => null,
@@ -187,5 +193,19 @@ describe('Dashboard', () => {
 		fireEvent.click(screen.getByRole('button', { name: 'Open budgets' }));
 		expect(screen.getByText('Budgets list')).toBeInTheDocument();
 		expect(screen.queryByText('Transaction form')).not.toBeInTheDocument();
+	});
+
+	it('navigates to random notes from the dashboard shell', () => {
+		render(
+			<MemoryRouter initialEntries={['/dashboard']}>
+				<Routes>
+					<Route path="/dashboard" element={<Dashboard />} />
+					<Route path="/dashboard/random" element={<Dashboard />} />
+				</Routes>
+			</MemoryRouter>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Open random' }));
+		expect(screen.getByText('Random notes')).toBeInTheDocument();
 	});
 });

--- a/apps/desktop/src/pages/dashboard/components/Sidebar.tsx
+++ b/apps/desktop/src/pages/dashboard/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
 	FiBarChart2,
 	FiChevronLeft,
+	FiEdit3,
 	FiGrid,
 	FiList,
 	FiMessageCircle,
@@ -54,6 +55,7 @@ const NAV_ITEMS: NavItem[] = [
 	{ id: 'budgets', label: 'Budgets', icon: FiTarget },
 	{ id: 'recurring', label: 'Recurring', icon: FiRefreshCw },
 	{ id: 'reports', label: 'Reports', icon: FiBarChart2 },
+	{ id: 'random', label: 'Random', icon: FiEdit3 },
 	{ id: 'assistant', label: 'Assistant', icon: FiMessageCircle },
 	{ id: 'mobisite', label: 'View Mobisite', icon: FiSmartphone },
 ];
@@ -176,9 +178,9 @@ const Sidebar: React.FC<SidebarProps> = ({
 					</div>
 
 					{!collapsed && (
-						<div className="border-b border-gray-200/80 p-3 dark:border-gray-800/80">
+						<div className="flex flex-1 flex-col border-b border-gray-200/80 p-3 dark:border-gray-800/80">
 							<p className={cn(sectionLabel, 'px-3 pb-2 pt-1')}>Admin</p>
-							<div className="space-y-1">
+							<div className="flex flex-1 flex-col gap-1.5">
 								{NAV_ITEMS.map(({ id, label, icon: Icon }) => {
 									const isActive =
 										id === 'history'
@@ -189,7 +191,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 											key={id}
 											onClick={() => handleViewClick(id)}
 											className={cn(
-												'flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors',
+												'flex min-h-10 w-full flex-1 items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors',
 												isActive ? navItemActive : navItemInactive
 											)}
 										>
@@ -201,8 +203,6 @@ const Sidebar: React.FC<SidebarProps> = ({
 							</div>
 						</div>
 					)}
-
-					<div className="flex-1" />
 
 					{!collapsed && (
 						<div className="border-t border-gray-200/80 p-3 dark:border-gray-800/80">

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -18,6 +18,7 @@ export type ViewType =
 	| 'transfer'
 	| 'reconcile'
 	| 'recurring'
+	| 'random'
 	| 'assistant';
 
 // Category

--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -14,6 +14,7 @@ Cash Flow is one deployed SPA. `apps/desktop/src/App.tsx` owns routing for both 
 | `/dashboard/budgets` | Desktop budget management. |
 | `/dashboard/recurring` | Desktop recurring transaction management. |
 | `/dashboard/reports` | Desktop reports. |
+| `/dashboard/random` | Desktop freeform private notes area. |
 | `/dashboard/assistant` | Gemini-powered financial assistant workspace. |
 | `/dashboard/settings` | Desktop settings modal route. |
 | `/mobisite` | Mobile capture experience. On desktop/tablet it is shown inside a mobile browser-style frame; on actual small screens it renders full-screen. |

--- a/firestore.rules
+++ b/firestore.rules
@@ -142,6 +142,15 @@ service cloud.firestore {
         optionalTimestamp(data, 'updatedAt');
     }
 
+    function validRandomNote(data, userId) {
+      return data.keys().hasOnly(['userId', 'content', 'createdAt', 'updatedAt']) &&
+        data.userId == userId &&
+        data.content is string &&
+        data.content.size() <= 10000 &&
+        data.createdAt is timestamp &&
+        optionalTimestamp(data, 'updatedAt');
+    }
+
     match /users/{userId} {
       allow read: if isOwner(userId);
       allow write: if false;
@@ -191,6 +200,15 @@ service cloud.firestore {
         allow create: if isOwner(userId) && validCategory(request.resource.data);
         allow update: if isOwner(userId) &&
           validCategory(request.resource.data) &&
+          request.resource.data.createdAt == resource.data.createdAt;
+      }
+
+      match /random/{noteId} {
+        allow read, delete: if isOwner(userId);
+        allow create: if isOwner(userId) && validRandomNote(request.resource.data, userId);
+        allow update: if isOwner(userId) &&
+          validRandomNote(request.resource.data, userId) &&
+          request.resource.data.userId == resource.data.userId &&
           request.resource.data.createdAt == resource.data.createdAt;
       }
     }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,6 +18,7 @@ export type ViewType =
 	| 'transfer'
 	| 'reconcile'
 	| 'recurring'
+	| 'random'
 	| 'assistant';
 
 // Category


### PR DESCRIPTION
## Summary 

- add a Random sidebar section and /dashboard/random route; 
- add a Firebase-backed free text workspace saved at users/{uid}/random/main;
- Update Firestore rules, route docs, and dashboard route tests; 
- adjust sidebar nav spacing so items fill the available sidebar area. 

## Testing 
- git diff --cached --check. 
Not run: npm test / TypeScript check blocked by local npm/Node setup and missing project executable bins in this WSL/Windows workspace state.