### PR TITLE
fix: use supported random page header props

### DIFF
--- a/apps/desktop/src/domains/random/views/RandomView.tsx
+++ b/apps/desktop/src/domains/random/views/RandomView.tsx
@@ -92,9 +92,9 @@ const RandomView: React.FC = () => {
 	return (
 		<PageShell className="flex flex-col">
 			<PageHeader
-				eyebrow="Random"
+				badge="Random"
 				title="Write anything down"
-				description="A private place for brain dumps, reminders, rough thoughts, or anything that helps with mental clarity."
+				subtitle="A private place for brain dumps, reminders, rough thoughts, or anything that helps with mental clarity."
 			/>
 
 			<section className={cn('flex min-h-[60vh] flex-1 flex-col overflow-hidden', cardSurface)}>


### PR DESCRIPTION
Fixes the Random page build error by using the supported PageHeader props: badge and subtitle instead of eyebrow and description. Testing: attempted npm run build, but local dependencies in this environment do not expose tsc ('tsc' is not recognized).