### PR TITLE
feat: improve random notes and export filters

### DIFF
--- a/apps/desktop/src/domains/random/hooks/__tests__/useRandomNote.test.ts
+++ b/apps/desktop/src/domains/random/hooks/__tests__/useRandomNote.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRandomNote, RANDOM_NOTE_MAX_COUNT } from '../useRandomNote';
+import { auth } from '@/services/firebase';
+import { addDoc, deleteDoc, onSnapshot, setDoc, updateDoc } from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+
+jest.mock('firebase/auth', () => ({
+	onAuthStateChanged: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+	addDoc: jest.fn(),
+	collection: jest.fn((...segments: string[]) => ({ type: 'collection', segments })),
+	deleteDoc: jest.fn((ref) => Promise.resolve(ref)),
+	doc: jest.fn((...segments: string[]) => ({ type: 'doc', segments })),
+	onSnapshot: jest.fn(),
+	serverTimestamp: jest.fn(() => 'server-time'),
+	setDoc: jest.fn(() => Promise.resolve()),
+	updateDoc: jest.fn(() => Promise.resolve()),
+}));
+
+const mockSnapshot = (docs: Array<{ id: string; data: Record<string, unknown> }>) => ({
+	docs: docs.map((item) => ({
+		id: item.id,
+		data: () => item.data,
+	})),
+});
+
+describe('useRandomNote', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(auth as { currentUser: unknown }).currentUser = { uid: 'user-1' };
+		(onAuthStateChanged as jest.Mock).mockImplementation((_auth, callback) => {
+			callback({ uid: 'user-1' });
+			return jest.fn();
+		});
+		(onSnapshot as jest.Mock).mockImplementation((_ref, next) => {
+			next(
+				mockSnapshot([
+					{ id: 'secondary', data: { content: 'Second note' } },
+					{ id: 'main', data: { content: 'Legacy note' } },
+				])
+			);
+			return jest.fn();
+		});
+		(addDoc as jest.Mock).mockResolvedValue({ id: 'new-note' });
+	});
+
+	it('loads the legacy main note first from the random collection', async () => {
+		const { result } = renderHook(() => useRandomNote());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.notes).toEqual([
+			{ id: 'main', content: 'Legacy note' },
+			{ id: 'secondary', content: 'Second note' },
+		]);
+	});
+
+	it('creates main as the first note and generated documents after that', async () => {
+		(onSnapshot as jest.Mock).mockImplementation((_ref, next) => {
+			next(mockSnapshot([]));
+			return jest.fn();
+		});
+		const { result } = renderHook(() => useRandomNote());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		await act(async () => {
+			await expect(result.current.addNote()).resolves.toBe('main');
+		});
+
+		expect(setDoc).toHaveBeenCalledWith(
+			expect.objectContaining({ segments: expect.arrayContaining(['random', 'main']) }),
+			expect.objectContaining({ content: '', userId: 'user-1' })
+		);
+
+		(onSnapshot as jest.Mock).mockImplementation((_ref, next) => {
+			next(mockSnapshot([{ id: 'main', data: { content: '' } }]));
+			return jest.fn();
+		});
+		const next = renderHook(() => useRandomNote());
+		await waitFor(() => expect(next.result.current.notes).toHaveLength(1));
+		await act(async () => {
+			await expect(next.result.current.addNote()).resolves.toBe('new-note');
+		});
+
+		expect(addDoc).toHaveBeenCalledWith(
+			expect.objectContaining({ type: 'collection' }),
+			expect.objectContaining({ content: '', userId: 'user-1' })
+		);
+	});
+
+	it('caps random notes at five and saves or deletes selected notes', async () => {
+		(onSnapshot as jest.Mock).mockImplementation((_ref, next) => {
+			next(
+				mockSnapshot(
+					Array.from({ length: RANDOM_NOTE_MAX_COUNT }, (_, index) => ({
+						id: index === 0 ? 'main' : `note-${index}`,
+						data: { content: `Note ${index + 1}` },
+					}))
+				)
+			);
+			return jest.fn();
+		});
+		const { result } = renderHook(() => useRandomNote());
+
+		await waitFor(() => expect(result.current.notes).toHaveLength(RANDOM_NOTE_MAX_COUNT));
+		await act(async () => {
+			await expect(result.current.addNote()).rejects.toThrow('up to 5 random notes');
+		});
+		await act(async () => {
+			await result.current.saveNote('main', 'Updated note');
+			await result.current.deleteNote('note-1');
+		});
+
+		expect(updateDoc).toHaveBeenCalledWith(
+			expect.objectContaining({ segments: expect.arrayContaining(['random', 'main']) }),
+			expect.objectContaining({ content: 'Updated note' })
+		);
+		expect(deleteDoc).toHaveBeenCalledWith(
+			expect.objectContaining({ segments: expect.arrayContaining(['random', 'note-1']) })
+		);
+	});
+});

--- a/apps/desktop/src/domains/random/hooks/useRandomNote.ts
+++ b/apps/desktop/src/domains/random/hooks/useRandomNote.ts
@@ -1,14 +1,35 @@
 import { useCallback, useEffect, useState } from 'react';
-import { doc, onSnapshot, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
+import {
+	addDoc,
+	collection,
+	deleteDoc,
+	doc,
+	onSnapshot,
+	serverTimestamp,
+	setDoc,
+	updateDoc,
+} from 'firebase/firestore';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth, db } from '@/services/firebase';
 
 const RANDOM_NOTE_ID = 'main';
 export const RANDOM_NOTE_LIMIT = 10_000;
+export const RANDOM_NOTE_MAX_COUNT = 5;
+
+export interface RandomNote {
+	id: string;
+	content: string;
+}
+
+const sortRandomNotes = (notes: RandomNote[]) =>
+	[...notes].sort((a, b) => {
+		if (a.id === RANDOM_NOTE_ID) return -1;
+		if (b.id === RANDOM_NOTE_ID) return 1;
+		return a.id.localeCompare(b.id);
+	});
 
 export const useRandomNote = () => {
-	const [content, setContent] = useState('');
-	const [exists, setExists] = useState(false);
+	const [notes, setNotes] = useState<RandomNote[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [user, setUser] = useState(() => auth.currentUser);
 
@@ -21,23 +42,28 @@ export const useRandomNote = () => {
 
 	useEffect(() => {
 		if (!user) {
-			setContent('');
-			setExists(false);
+			setNotes([]);
 			setLoading(false);
 			return;
 		}
 
 		setLoading(true);
-		const noteRef = doc(db, 'users', user.uid, 'random', RANDOM_NOTE_ID);
+		const notesRef = collection(db, 'users', user.uid, 'random');
 		const unsubscribe = onSnapshot(
-			noteRef,
+			notesRef,
 			(snapshot) => {
-				setExists(snapshot.exists());
-				setContent(snapshot.exists() ? String(snapshot.data().content ?? '') : '');
+				setNotes(
+					sortRandomNotes(
+						snapshot.docs.map((note) => ({
+							id: note.id,
+							content: String(note.data().content ?? ''),
+						}))
+					)
+				);
 				setLoading(false);
 			},
 			(error) => {
-				console.error('Error fetching random note:', error);
+				console.error('Error fetching random notes:', error);
 				setLoading(false);
 			}
 		);
@@ -46,27 +72,54 @@ export const useRandomNote = () => {
 	}, [user]);
 
 	const saveNote = useCallback(
-		async (nextContent: string) => {
+		async (noteId: string, nextContent: string) => {
 			if (!user) throw new Error('User not authenticated');
 
-			const noteRef = doc(db, 'users', user.uid, 'random', RANDOM_NOTE_ID);
-			if (exists) {
-				await updateDoc(noteRef, {
-					content: nextContent,
-					updatedAt: serverTimestamp(),
-				});
-				return;
-			}
-
-			await setDoc(noteRef, {
+			const noteRef = doc(db, 'users', user.uid, 'random', noteId);
+			await updateDoc(noteRef, {
 				content: nextContent,
+				updatedAt: serverTimestamp(),
+			});
+		},
+		[user]
+	);
+
+	const addNote = useCallback(async () => {
+		if (!user) throw new Error('User not authenticated');
+		if (notes.length >= RANDOM_NOTE_MAX_COUNT) {
+			throw new Error(`You can keep up to ${RANDOM_NOTE_MAX_COUNT} random notes.`);
+		}
+
+		if (notes.length === 0) {
+			const noteRef = doc(db, 'users', user.uid, 'random', RANDOM_NOTE_ID);
+			await setDoc(noteRef, {
+				content: '',
 				userId: user.uid,
 				createdAt: serverTimestamp(),
 				updatedAt: serverTimestamp(),
 			});
+			return RANDOM_NOTE_ID;
+		}
+
+		const notesRef = collection(db, 'users', user.uid, 'random');
+		const noteRef = await addDoc(notesRef, {
+			content: '',
+			userId: user.uid,
+			createdAt: serverTimestamp(),
+			updatedAt: serverTimestamp(),
+		});
+		return noteRef.id;
+	}, [notes.length, user]);
+
+	const deleteNote = useCallback(
+		async (noteId: string) => {
+			if (!user) throw new Error('User not authenticated');
+
+			const noteRef = doc(db, 'users', user.uid, 'random', noteId);
+			await deleteDoc(noteRef);
 		},
-		[exists, user]
+		[user]
 	);
 
-	return { content, loading, saveNote };
+	return { notes, loading, saveNote, addNote, deleteNote };
 };

--- a/apps/desktop/src/domains/random/views/RandomView.tsx
+++ b/apps/desktop/src/domains/random/views/RandomView.tsx
@@ -1,38 +1,59 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { FiCheck, FiEdit3, FiSave } from 'react-icons/fi';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { FiCheck, FiEdit3, FiFileText, FiPlus, FiSave, FiTrash2 } from 'react-icons/fi';
 import { Button } from '@/components/app/ui/button';
 import { Textarea } from '@/components/app/ui/textarea';
 import { useToast } from '@/components/app/ui/use-toast';
 import { PageHeader, PageShell } from '@/components/app/page-layout';
-import { useRandomNote, RANDOM_NOTE_LIMIT } from '@/domains/random/hooks/useRandomNote';
+import {
+	RANDOM_NOTE_LIMIT,
+	RANDOM_NOTE_MAX_COUNT,
+	useRandomNote,
+} from '@/domains/random/hooks/useRandomNote';
 import { cardSurface, sectionLabel } from '@/styles/marketingStyles';
 import { cn } from '@/lib/utils';
 import { getAppErrorMessage } from '@cash-flow/shared/errors';
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+type ViewMode = 'editor' | 'markdown';
 
 const RandomView: React.FC = () => {
-	const { content, loading, saveNote } = useRandomNote();
+	const { notes, loading, saveNote, addNote, deleteNote } = useRandomNote();
 	const { toast } = useToast();
+	const [activeNoteId, setActiveNoteId] = useState('');
 	const [note, setNote] = useState({ draft: '', saved: '' });
 	const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+	const [viewMode, setViewMode] = useState<ViewMode>('editor');
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const { draft, saved } = note;
 	const hasLocalChanges = draft !== saved;
+	const activeNote = useMemo(() => notes.find((item) => item.id === activeNoteId) ?? notes[0], [activeNoteId, notes]);
 
 	useEffect(() => {
+		if (!activeNote) {
+			setActiveNoteId('');
+			setNote({ draft: '', saved: '' });
+			return;
+		}
+
+		setActiveNoteId(activeNote.id);
 		setNote((current) => ({
-			draft: current.draft === current.saved ? content : current.draft,
-			saved: content,
+			draft:
+				current.draft === current.saved || activeNote.id !== activeNoteId
+					? activeNote.content
+					: current.draft,
+			saved: activeNote.content,
 		}));
-	}, [content]);
+	}, [activeNote, activeNoteId]);
 
 	useEffect(() => {
-		textareaRef.current?.focus();
-	}, []);
+		if (viewMode === 'editor') textareaRef.current?.focus();
+	}, [activeNoteId, viewMode]);
 
 	const persistDraft = useCallback(
 		async (nextContent = draft) => {
+			if (!activeNote) return;
 			if (nextContent.length > RANDOM_NOTE_LIMIT) {
 				setSaveStatus('error');
 				toast({
@@ -45,7 +66,7 @@ const RandomView: React.FC = () => {
 
 			setSaveStatus('saving');
 			try {
-				await saveNote(nextContent);
+				await saveNote(activeNote.id, nextContent);
 				setNote((current) => ({ ...current, saved: nextContent }));
 				setSaveStatus('saved');
 			} catch (error) {
@@ -57,18 +78,48 @@ const RandomView: React.FC = () => {
 				});
 			}
 		},
-		[draft, saveNote, toast]
+		[activeNote, draft, saveNote, toast]
 	);
 
 	useEffect(() => {
-		if (loading || !hasLocalChanges) return;
+		if (loading || !activeNote || !hasLocalChanges) return;
 
 		const timeoutId = window.setTimeout(() => {
 			void persistDraft(draft);
 		}, 900);
 
 		return () => window.clearTimeout(timeoutId);
-	}, [draft, hasLocalChanges, loading, persistDraft]);
+	}, [activeNote, draft, hasLocalChanges, loading, persistDraft]);
+
+	const handleAddNote = async () => {
+		try {
+			const nextNoteId = await addNote();
+			setActiveNoteId(nextNoteId);
+			setSaveStatus('idle');
+		} catch (error) {
+			toast({
+				title: 'Random note was not created',
+				description: getAppErrorMessage(error, { operation: 'Create random note' }),
+				variant: 'destructive',
+			});
+		}
+	};
+
+	const handleDeleteNote = async () => {
+		if (!activeNote) return;
+		try {
+			await deleteNote(activeNote.id);
+			const nextNote = notes.find((item) => item.id !== activeNote.id);
+			setActiveNoteId(nextNote?.id ?? '');
+			setSaveStatus('idle');
+		} catch (error) {
+			toast({
+				title: 'Random note was not deleted',
+				description: getAppErrorMessage(error, { operation: 'Delete random note' }),
+				variant: 'destructive',
+			});
+		}
+	};
 
 	const remainingCharacters = RANDOM_NOTE_LIMIT - draft.length;
 	const saveLabel =
@@ -79,6 +130,7 @@ const RandomView: React.FC = () => {
 				: hasLocalChanges
 					? 'Unsaved changes'
 					: 'Ready';
+	const canAddNote = !loading && notes.length < RANDOM_NOTE_MAX_COUNT;
 
 	return (
 		<PageShell className="flex flex-col">
@@ -87,8 +139,8 @@ const RandomView: React.FC = () => {
 				subtitle="A private place for brain dumps, reminders, rough thoughts, or anything that helps with mental clarity."
 			/>
 
-			<section className={cn('flex min-h-[60vh] flex-1 flex-col overflow-hidden', cardSurface)}>
-				<header className="flex flex-col gap-3 border-b border-gray-100 px-5 py-4 dark:border-gray-800 md:flex-row md:items-center md:justify-between">
+			<section className={cn('overflow-visible', cardSurface)}>
+				<header className="flex flex-col gap-3 border-b border-gray-100 px-5 py-4 dark:border-gray-800 lg:flex-row lg:items-center lg:justify-between">
 					<div>
 						<p className={sectionLabel}>Free text</p>
 						<h2 className="mt-1 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-50">
@@ -97,6 +149,28 @@ const RandomView: React.FC = () => {
 						</h2>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
+						<div className="flex rounded-md border border-gray-200 p-1 dark:border-gray-800">
+							<Button
+								type="button"
+								size="sm"
+								variant={viewMode === 'editor' ? 'secondary' : 'ghost'}
+								onClick={() => setViewMode('editor')}
+								aria-pressed={viewMode === 'editor'}
+							>
+								<FiEdit3 className="h-4 w-4" />
+								Editor
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								variant={viewMode === 'markdown' ? 'secondary' : 'ghost'}
+								onClick={() => setViewMode('markdown')}
+								aria-pressed={viewMode === 'markdown'}
+							>
+								<FiFileText className="h-4 w-4" />
+								Markdown
+							</Button>
+						</div>
 						<span className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
 							{saveStatus === 'saved' && !hasLocalChanges && <FiCheck className="h-4 w-4 text-emerald-600" />}
 							{saveLabel}
@@ -105,7 +179,7 @@ const RandomView: React.FC = () => {
 							type="button"
 							variant="marketing"
 							onClick={() => void persistDraft()}
-							disabled={loading || saveStatus === 'saving' || draft.length > RANDOM_NOTE_LIMIT}
+							disabled={!activeNote || loading || saveStatus === 'saving' || draft.length > RANDOM_NOTE_LIMIT}
 						>
 							<FiSave className="mr-2 h-4 w-4" />
 							Save
@@ -113,24 +187,101 @@ const RandomView: React.FC = () => {
 					</div>
 				</header>
 
-				<div className="flex min-h-0 flex-1 flex-col gap-3 p-5">
-					<Textarea
-						ref={textareaRef}
-						value={draft}
-						onChange={(event) => {
-							setNote((current) => ({ ...current, draft: event.target.value }));
-							setSaveStatus('idle');
-						}}
-						disabled={loading}
-						placeholder="Write whatever is on your mind..."
-						className="min-h-[420px] flex-1 resize-none border-gray-200 bg-white/80 text-base leading-7 shadow-inner dark:border-gray-800 dark:bg-gray-950/50"
-						aria-label="Random free text note"
-					/>
-					<div className="flex flex-col gap-1 text-sm text-gray-500 dark:text-gray-400 md:flex-row md:items-center md:justify-between">
-						<p>{loading ? 'Loading your note...' : 'Autosaves after you pause typing.'}</p>
-						<p className={remainingCharacters < 0 ? 'text-destructive' : undefined}>
-							{remainingCharacters.toLocaleString()} characters remaining
-						</p>
+				<div className="space-y-4 p-5">
+					<div className="space-y-3">
+						{activeNote ? (
+							viewMode === 'editor' ? (
+								<Textarea
+									ref={textareaRef}
+									value={draft}
+									onChange={(event) => {
+										setNote((current) => ({ ...current, draft: event.target.value }));
+										setSaveStatus('idle');
+									}}
+									disabled={loading}
+									placeholder="Write whatever is on your mind..."
+									className="h-[55vh] min-h-[360px] max-h-[620px] resize-none border-gray-200 bg-white/80 text-base leading-7 shadow-inner dark:border-gray-800 dark:bg-gray-950/50"
+									aria-label="Random note editor"
+								/>
+							) : (
+								<div className="markdown-preview h-[55vh] min-h-[360px] max-h-[620px] overflow-y-auto rounded-md border border-gray-200 bg-white p-6 text-base leading-7 shadow-inner dark:border-gray-800 dark:bg-gray-950">
+									{draft.trim() ? (
+										<ReactMarkdown remarkPlugins={[remarkGfm]}>
+											{draft}
+										</ReactMarkdown>
+									) : (
+										<p className="text-sm text-gray-500 dark:text-gray-400">Nothing to preview yet.</p>
+									)}
+								</div>
+							)
+						) : (
+							<div className="flex h-[55vh] min-h-[360px] max-h-[620px] flex-col items-center justify-center rounded-md border border-dashed border-gray-300 bg-white/60 p-6 text-center dark:border-gray-700 dark:bg-gray-950/40">
+								<p className="text-sm font-medium text-gray-700 dark:text-gray-200">No random notes yet</p>
+								<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+									Add a note to start writing.
+								</p>
+							</div>
+						)}
+						<div className="flex flex-col gap-1 text-sm text-gray-500 dark:text-gray-400 md:flex-row md:items-center md:justify-between">
+							<p>{loading ? 'Loading your notes...' : 'Autosaves after you pause typing.'}</p>
+							<p className={remainingCharacters < 0 ? 'text-destructive' : undefined}>
+								{remainingCharacters.toLocaleString()} characters remaining
+							</p>
+						</div>
+					</div>
+
+					<div className="border-t border-gray-100 pt-4 dark:border-gray-800">
+						<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+							<p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+								{notes.length}/{RANDOM_NOTE_MAX_COUNT} notes
+							</p>
+							<div className="flex flex-wrap items-center gap-2">
+								<Button
+									type="button"
+									size="sm"
+									variant="outline"
+									onClick={() => void handleAddNote()}
+									disabled={!canAddNote}
+								>
+									<FiPlus className="h-4 w-4" />
+									Add
+								</Button>
+								{activeNote && (
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										onClick={() => void handleDeleteNote()}
+									>
+										<FiTrash2 className="h-4 w-4" />
+										Delete note
+									</Button>
+								)}
+							</div>
+						</div>
+						<div className="flex gap-2 overflow-x-auto pb-1" aria-label="Random notes">
+							{notes.map((item, index) => (
+								<button
+									key={item.id}
+									type="button"
+									onClick={() => {
+										setActiveNoteId(item.id);
+										setSaveStatus('idle');
+									}}
+									className={cn(
+										'min-w-[180px] max-w-[240px] rounded-md border px-3 py-2 text-left text-sm transition-colors',
+										item.id === activeNote?.id
+											? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-200'
+											: 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-800 dark:text-gray-300 dark:hover:bg-gray-900'
+									)}
+								>
+									<span className="block font-medium">Note {index + 1}</span>
+									<span className="block truncate text-xs opacity-75">
+										{item.content.trim() || 'Empty note'}
+									</span>
+								</button>
+							))}
+						</div>
 					</div>
 				</div>
 			</section>

--- a/apps/desktop/src/domains/random/views/__tests__/RandomView.test.tsx
+++ b/apps/desktop/src/domains/random/views/__tests__/RandomView.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RandomView from '../RandomView';
+import { RANDOM_NOTE_MAX_COUNT } from '@/domains/random/hooks/useRandomNote';
+
+const mockSaveNote = jest.fn();
+const mockAddNote = jest.fn();
+const mockDeleteNote = jest.fn();
+let mockRandomState = {
+	notes: [{ id: 'main', content: '# Legacy note' }],
+	loading: false,
+	saveNote: mockSaveNote,
+	addNote: mockAddNote,
+	deleteNote: mockDeleteNote,
+};
+
+jest.mock('@/domains/random/hooks/useRandomNote', () => ({
+	RANDOM_NOTE_LIMIT: 10_000,
+	RANDOM_NOTE_MAX_COUNT: 5,
+	useRandomNote: () => mockRandomState,
+}));
+
+jest.mock('react-markdown', () => ({
+	__esModule: true,
+	default: ({ children }: { children: string }) => {
+		const text = String(children);
+		return (
+			<div data-testid="markdown-preview">
+				{text.includes('# ') && <h1>{text.replace(/^#\s*/, '')}</h1>}
+				{text.includes('- ') && (
+					<ul>
+						<li>item</li>
+					</ul>
+				)}
+				{text.includes('`') && <p><code>code</code></p>}
+				{text.includes('|') && (
+					<table>
+						<thead><tr><th>Column</th></tr></thead>
+						<tbody><tr><td>Value</td></tr></tbody>
+					</table>
+				)}
+			</div>
+		);
+	},
+}));
+
+jest.mock('remark-gfm', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}));
+
+describe('RandomView', () => {
+	beforeEach(() => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+		mockRandomState = {
+			notes: [{ id: 'main', content: '# Legacy note' }],
+			loading: false,
+			saveNote: mockSaveNote,
+			addNote: mockAddNote,
+			deleteNote: mockDeleteNote,
+		};
+	});
+
+	it('renders legacy main note content and autosaves selected note edits', async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		render(<RandomView />);
+
+		const editor = screen.getByLabelText('Random note editor');
+		expect(editor).toHaveValue('# Legacy note');
+
+		await user.clear(editor);
+		await user.type(editor, 'Updated note');
+		await act(async () => {
+			jest.advanceTimersByTime(900);
+		});
+
+		await waitFor(() => expect(mockSaveNote).toHaveBeenCalledWith('main', 'Updated note'));
+	});
+
+	it('switches between editor and markdown preview', async () => {
+		const user = userEvent.setup();
+		render(<RandomView />);
+
+		await user.click(screen.getByRole('button', { name: /markdown/i }));
+
+		expect(screen.queryByLabelText('Random note editor')).not.toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: /legacy note/i })).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /editor/i }));
+		expect(screen.getByLabelText('Random note editor')).toBeInTheDocument();
+	});
+
+	it('renders markdown preview with document element styles', async () => {
+		const user = userEvent.setup();
+		mockRandomState = {
+			...mockRandomState,
+			notes: [{ id: 'main', content: '# Heading\n\n- item\n\n`code`\n\n| Column |\n| --- |\n| Value |' }],
+		};
+		render(<RandomView />);
+
+		await user.click(screen.getByRole('button', { name: /markdown/i }));
+
+		expect(screen.getByTestId('markdown-preview').parentElement).toHaveClass('markdown-preview');
+		expect(screen.getByRole('heading', { name: /heading/i })).toBeInTheDocument();
+		expect(screen.getByRole('list')).toBeInTheDocument();
+		expect(screen.getByText('code')).toBeInTheDocument();
+		expect(screen.getByRole('table')).toBeInTheDocument();
+	});
+
+	it('adds up to five notes and disables add at the cap', async () => {
+		const user = userEvent.setup();
+		mockRandomState = {
+			...mockRandomState,
+			notes: Array.from({ length: RANDOM_NOTE_MAX_COUNT }, (_, index) => ({
+				id: index === 0 ? 'main' : `note-${index}`,
+				content: `Note ${index + 1}`,
+			})),
+		};
+		const { rerender } = render(<RandomView />);
+
+		expect(screen.getByRole('button', { name: /add/i })).toBeDisabled();
+		expect(screen.getByText('5/5 notes')).toBeInTheDocument();
+
+		mockRandomState = {
+			...mockRandomState,
+			notes: [{ id: 'main', content: 'Only note' }],
+		};
+		rerender(<RandomView />);
+		mockAddNote.mockResolvedValue('new-note');
+		await user.click(screen.getByRole('button', { name: /add/i }));
+
+		expect(mockAddNote).toHaveBeenCalledTimes(1);
+	});
+
+	it('deletes the selected note', async () => {
+		const user = userEvent.setup();
+		render(<RandomView />);
+
+		await user.click(screen.getByRole('button', { name: /delete note/i }));
+
+		expect(mockDeleteNote).toHaveBeenCalledWith('main');
+	});
+});

--- a/apps/desktop/src/domains/recurring/views/RecurringTransactionForm.tsx
+++ b/apps/desktop/src/domains/recurring/views/RecurringTransactionForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getAppErrorMessage } from '@cash-flow/shared/errors';
-import { FiDollarSign, FiTag, FiInfo, FiSave, FiX, FiRefreshCw, FiArrowUpCircle, FiArrowDownCircle } from 'react-icons/fi';
+import { FiDollarSign, FiTag, FiInfo, FiSave, FiRefreshCw, FiArrowUpCircle, FiArrowDownCircle } from 'react-icons/fi';
 import { useTransactionsContext } from '@/domains/transactions/context/TransactionsContext';
 import { useCategoriesContext } from '@/domains/categories/context/CategoriesContext';
 import { useAccountsContext } from '@/domains/accounts/context/AccountsContext';
@@ -10,6 +10,7 @@ import { Button } from '@/components/app/ui/button';
 import { Input } from '@/components/app/ui/input';
 import { Label } from '@/components/app/ui/label';
 import { Textarea } from '@/components/app/ui/textarea';
+import { DialogDescription, DialogTitle } from '@/components/app/ui/dialog';
 import {
 	Select,
 	SelectContent,
@@ -177,24 +178,15 @@ const RecurringTransactionForm: React.FC<RecurringTransactionFormProps> = ({ onC
 			{/* Header */}
 			<div className="flex items-center justify-between border-b pb-4">
 				<div>
-					<h3 className="text-xl font-bold tracking-tight">
+					<DialogTitle className="text-xl font-bold tracking-tight">
 						{expense ? 'Edit Recurring Transaction' : 'New Recurring Transaction'}
-					</h3>
-					<p className="mt-1 text-xs text-muted-foreground">
+					</DialogTitle>
+					<DialogDescription className="mt-1 text-xs text-muted-foreground">
 						{expense
 							? 'Update your recurring transaction details'
 							: 'Set up a transaction that repeats automatically'}
-					</p>
+					</DialogDescription>
 				</div>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					onClick={onClose}
-					className="h-8 w-8 rounded-lg"
-				>
-					<FiX className="h-4 w-4" />
-				</Button>
 			</div>
 
 			<form onSubmit={handleSubmit} className="space-y-5">

--- a/apps/desktop/src/domains/recurring/views/__tests__/RecurringTransactionsView.test.tsx
+++ b/apps/desktop/src/domains/recurring/views/__tests__/RecurringTransactionsView.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import RecurringTransactionsView from '../RecurringTransactionsView';
 
 const mockDeleteRecurringTransaction = jest.fn();
+const mockAddRecurringTransaction = jest.fn();
+const mockUpdateRecurringTransaction = jest.fn();
 
 jest.mock('@/domains/transactions/context/TransactionsContext', () => ({
 	useTransactionsContext: () => ({
@@ -20,12 +23,15 @@ jest.mock('@/domains/transactions/context/TransactionsContext', () => ({
 			},
 		],
 		deleteRecurringTransaction: mockDeleteRecurringTransaction,
+		addRecurringTransaction: mockAddRecurringTransaction,
+		updateRecurringTransaction: mockUpdateRecurringTransaction,
 		recurringTransactionsLoading: false,
 	}),
 }));
 
 jest.mock('@/domains/categories/context/CategoriesContext', () => ({
 	useCategoriesContext: () => ({
+		categories: [{ value: 'home', label: 'Home', subcategories: [{ value: 'rent', label: 'Rent' }] }],
 		categoryOptions: [{ value: 'home', label: 'Home' }],
 		getCategoryPathLabel: () => 'Home / Rent',
 	}),
@@ -51,6 +57,10 @@ jest.mock('@/shared/filters/context/FilterPreferencesContext', () => ({
 	}),
 }));
 
+jest.mock('@cash-flow/shared/accounts/mainAccountPreference', () => ({
+	useMainAccountPreference: () => ({ mainAccountId: 'checking' }),
+}));
+
 describe('RecurringTransactionsView', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -74,5 +84,15 @@ describe('RecurringTransactionsView', () => {
 			'recurringTransactions.viewMode',
 			expect.any(String)
 		);
+	});
+
+	it('shows one close button in the edit recurring modal', async () => {
+		const user = userEvent.setup();
+		render(<RecurringTransactionsView />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit recurring transaction' }));
+
+		expect(screen.getByRole('heading', { name: 'Edit Recurring Transaction' })).toBeInTheDocument();
+		expect(screen.getAllByRole('button', { name: 'Close' })).toHaveLength(1);
 	});
 });

--- a/apps/desktop/src/domains/transactions/views/TransactionExportDialog.tsx
+++ b/apps/desktop/src/domains/transactions/views/TransactionExportDialog.tsx
@@ -72,6 +72,7 @@ const TransactionExportDialog: React.FC<Props> = ({ open, onOpenChange, transact
 	}), [accountIds, customEndDate, customStartDate, datePreset, selectedCategories, type]);
 	const matches = useMemo(() => filterTransactionsForExport(transactions, filters), [filters, transactions]);
 	const invalidRange = datePreset === 'custom' && Boolean(customStartDate && customEndDate && customStartDate > customEndDate);
+	const hasFilters = Boolean(accountIds.length || selectedCategories.length || type !== 'overall' || datePreset !== 'all');
 	const close = () => { onOpenChange(false); reset(); };
 
 	return (
@@ -79,7 +80,9 @@ const TransactionExportDialog: React.FC<Props> = ({ open, onOpenChange, transact
 			<DialogContent className={cn('max-h-modal overflow-y-auto sm:max-w-2xl', modalShell)}>
 				<DialogHeader>
 					<DialogTitle>Export transactions</DialogTitle>
-					<DialogDescription>Choose which transaction records to include.</DialogDescription>
+					<DialogDescription>
+						Choose optional filters for the export. Leaving a filter unset includes all values for that field.
+					</DialogDescription>
 				</DialogHeader>
 				<div className="grid gap-5 py-2 sm:grid-cols-2">
 					<div className="space-y-2">
@@ -89,14 +92,13 @@ const TransactionExportDialog: React.FC<Props> = ({ open, onOpenChange, transact
 						</select>
 					</div>
 					<div className="space-y-2">
-						<Label htmlFor="export-type">Transaction type</Label>
+						<Label htmlFor="export-type">Transaction data</Label>
 						<select id="export-type" value={type} onChange={(event) => setType(event.target.value as TransactionExportFilters['type'])} className="h-10 w-full rounded-md border bg-background px-3 text-sm">
-							<option value="overall">Overall</option><option value="income">Income</option><option value="expense">Expenses</option>
+							<option value="overall">All transaction data</option><option value="income">Income only</option><option value="expense">Expenses only</option>
 						</select>
 					</div>
 					<fieldset className="space-y-2 rounded-xl border p-3">
 						<legend className="px-1 text-sm font-medium">Accounts</legend>
-						<p className="text-xs text-muted-foreground">None selected includes all accounts.</p>
 						<div className="max-h-32 space-y-2 overflow-y-auto">
 							{accounts.map((account) => account.id && (
 								<label key={account.id} className="flex items-center gap-2 text-sm"><input type="checkbox" checked={accountIds.includes(account.id)} onChange={() => setAccountIds((current) => toggle(current, account.id!))} />{account.name}</label>
@@ -105,7 +107,6 @@ const TransactionExportDialog: React.FC<Props> = ({ open, onOpenChange, transact
 					</fieldset>
 					<fieldset className="space-y-2 rounded-xl border p-3">
 						<legend className="px-1 text-sm font-medium">Categories</legend>
-						<p className="text-xs text-muted-foreground">None selected includes all categories.</p>
 						<div className="max-h-32 space-y-2 overflow-y-auto">
 							{categories.map((category) => (
 								<label key={category.value} className="flex items-center gap-2 text-sm"><input type="checkbox" checked={selectedCategories.includes(category.value)} onChange={() => setSelectedCategories((current) => toggle(current, category.value))} />{category.label}</label>
@@ -126,7 +127,10 @@ const TransactionExportDialog: React.FC<Props> = ({ open, onOpenChange, transact
 						{invalidRange && <p className="text-sm text-destructive">Start date must be on or before end date.</p>}
 					</div>
 				</div>
-				<p aria-live="polite" className="text-sm text-muted-foreground">{matches.length} matching {matches.length === 1 ? 'transaction' : 'transactions'}</p>
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+					<p aria-live="polite" className="text-sm text-muted-foreground">{matches.length} matching {matches.length === 1 ? 'transaction' : 'transactions'}</p>
+					<Button type="button" variant="ghost" size="sm" onClick={reset} disabled={!hasFilters}>Reset filters</Button>
+				</div>
 				<DialogFooter>
 					<Button variant="outline" onClick={close}>Cancel</Button>
 					<Button disabled={matches.length === 0 || invalidRange} onClick={() => { onExport(format, matches); close(); }}>Export {format.toUpperCase()}</Button>

--- a/apps/desktop/src/domains/transactions/views/__tests__/TransactionExportDialog.test.tsx
+++ b/apps/desktop/src/domains/transactions/views/__tests__/TransactionExportDialog.test.tsx
@@ -1,6 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TransactionExportDialog from '../TransactionExportDialog';
+import { Transaction } from '@/types';
+
+const accounts = [
+	{ id: 'a', name: 'Main', type: 'debit' as const, balance: 0 },
+	{ id: 'b', name: 'Savings', type: 'savings' as const, balance: 0 },
+];
+
+const categories = [
+	{ id: 'food', value: 'food', label: 'Food', subcategories: [] },
+	{ id: 'salary', value: 'salary', label: 'Salary', subcategories: [] },
+];
+
+const transactions: Transaction[] = [
+	{ id: '1', accountId: 'a', title: 'Lunch', amount: 10, type: 'expense', category: 'food', date: new Date(2026, 5, 1) },
+	{ id: '2', accountId: 'b', title: 'Pay', amount: 100, type: 'income', category: 'salary', date: new Date(2026, 5, 30) },
+	{ id: '3', accountId: 'a', title: 'Transfer', amount: 50, type: 'transfer', category: 'transfer', date: new Date(2026, 6, 1) },
+];
 
 describe('TransactionExportDialog', () => {
 	it('filters the live count and exports the selected format', async () => {
@@ -10,18 +27,9 @@ describe('TransactionExportDialog', () => {
 			<TransactionExportDialog
 				open
 				onOpenChange={jest.fn()}
-				accounts={[
-					{ id: 'a', name: 'Main', type: 'debit', balance: 0 },
-					{ id: 'b', name: 'Savings', type: 'savings', balance: 0 },
-				]}
-				categories={[
-					{ id: 'food', value: 'food', label: 'Food', subcategories: [] },
-					{ id: 'salary', value: 'salary', label: 'Salary', subcategories: [] },
-				]}
-				transactions={[
-					{ id: '1', accountId: 'a', title: 'Lunch', amount: 10, type: 'expense', category: 'food' },
-					{ id: '2', accountId: 'b', title: 'Pay', amount: 100, type: 'income', category: 'salary' },
-				]}
+				accounts={accounts}
+				categories={categories}
+				transactions={transactions.slice(0, 2)}
 				onExport={onExport}
 			/>
 		);
@@ -32,5 +40,82 @@ describe('TransactionExportDialog', () => {
 		await user.selectOptions(screen.getByLabelText('Format'), 'json');
 		await user.click(screen.getByRole('button', { name: 'Export JSON' }));
 		expect(onExport).toHaveBeenCalledWith('json', [expect.objectContaining({ id: '1' })]);
+	});
+
+	it('exports all records when optional filters are unset', async () => {
+		const user = userEvent.setup();
+		const onExport = jest.fn();
+		render(
+			<TransactionExportDialog
+				open
+				onOpenChange={jest.fn()}
+				accounts={accounts}
+				categories={categories}
+				transactions={transactions}
+				onExport={onExport}
+			/>
+		);
+
+		expect(screen.getByText('3 matching transactions')).toBeInTheDocument();
+		expect(screen.getByText(/Leaving a filter unset includes all values/i)).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+		expect(onExport).toHaveBeenCalledWith('csv', transactions);
+	});
+
+	it('narrows matches independently by type, category, and inclusive custom dates', async () => {
+		const user = userEvent.setup();
+		render(
+			<TransactionExportDialog
+				open
+				onOpenChange={jest.fn()}
+				accounts={accounts}
+				categories={categories}
+				transactions={transactions}
+				onExport={jest.fn()}
+			/>
+		);
+
+		await user.selectOptions(screen.getByLabelText('Transaction data'), 'expense');
+		expect(screen.getByText('1 matching transaction')).toBeInTheDocument();
+
+		await user.selectOptions(screen.getByLabelText('Transaction data'), 'overall');
+		await user.click(screen.getByLabelText('Salary'));
+		expect(screen.getByText('1 matching transaction')).toBeInTheDocument();
+
+		await user.click(screen.getByLabelText('Salary'));
+		await user.selectOptions(screen.getByLabelText('Date range'), 'custom');
+		await user.type(screen.getByLabelText('Start date'), '2026-06-01');
+		await user.type(screen.getByLabelText('End date'), '2026-06-30');
+		expect(screen.getByText('2 matching transactions')).toBeInTheDocument();
+	});
+
+	it('resets filters from the reset and close actions', async () => {
+		const user = userEvent.setup();
+		const onOpenChange = jest.fn();
+		render(
+			<TransactionExportDialog
+				open
+				onOpenChange={onOpenChange}
+				accounts={accounts}
+				categories={categories}
+				transactions={transactions}
+				onExport={jest.fn()}
+			/>
+		);
+
+		await user.click(screen.getByLabelText('Main'));
+		expect(screen.getByText('2 matching transactions')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+		expect(screen.getByText('3 matching transactions')).toBeInTheDocument();
+
+		await user.click(screen.getByLabelText('Food'));
+		expect(screen.getByText('1 matching transaction')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(screen.getByText('3 matching transactions')).toBeInTheDocument();
 	});
 });

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -197,3 +197,79 @@
 	filter: invert(1);
 	opacity: 1;
 }
+
+.markdown-preview :where(h1, h2) {
+	@apply mb-3 mt-6 border-b border-gray-200 pb-2 font-semibold leading-tight text-gray-950 dark:border-gray-800 dark:text-gray-50;
+}
+
+.markdown-preview h1 {
+	@apply mt-0 text-3xl;
+}
+
+.markdown-preview h2 {
+	@apply text-2xl;
+}
+
+.markdown-preview :where(h3, h4) {
+	@apply mb-2 mt-4 font-semibold text-gray-950 dark:text-gray-50;
+}
+
+.markdown-preview h3 {
+	@apply text-xl;
+}
+
+.markdown-preview h4 {
+	@apply text-lg;
+}
+
+.markdown-preview :where(p, ul, ol, blockquote, pre, table, hr) {
+	@apply mb-4;
+}
+
+.markdown-preview :where(p, li, td) {
+	@apply text-gray-800 dark:text-gray-200;
+}
+
+.markdown-preview :where(ul, ol) {
+	@apply ml-6 space-y-1;
+}
+
+.markdown-preview ul {
+	@apply list-disc;
+}
+
+.markdown-preview ol {
+	@apply list-decimal;
+}
+
+.markdown-preview a {
+	@apply font-medium text-blue-600 underline underline-offset-2 hover:text-blue-500 dark:text-blue-300 dark:hover:text-blue-200;
+}
+
+.markdown-preview blockquote {
+	@apply border-l-4 border-gray-300 pl-4 italic text-gray-600 dark:border-gray-700 dark:text-gray-300;
+}
+
+.markdown-preview code {
+	@apply rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-100;
+}
+
+.markdown-preview pre {
+	@apply overflow-x-auto rounded-lg bg-gray-950 p-4 text-sm leading-6 text-gray-100 shadow-inner;
+}
+
+.markdown-preview pre code {
+	@apply bg-transparent p-0 text-gray-100;
+}
+
+.markdown-preview table {
+	@apply w-full border-collapse text-left text-sm;
+}
+
+.markdown-preview :where(th, td) {
+	@apply border border-gray-200 px-3 py-2 dark:border-gray-800;
+}
+
+.markdown-preview th {
+	@apply bg-gray-50 font-semibold text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
 				"react": "^19.2.5",
 				"react-dom": "^19.2.5",
 				"react-icons": "^5.6.0",
+				"react-markdown": "^10.1.0",
 				"react-router-dom": "^7.14.2",
 				"recharts": "^2.15.4",
+				"remark-gfm": "^4.0.1",
 				"tailwind-merge": "^2.6.1"
 			},
 			"devDependencies": {
@@ -4544,12 +4546,29 @@
 			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
 			"license": "MIT"
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/estree-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
 		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
@@ -4559,6 +4578,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+			"integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
 			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -4653,6 +4681,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "22.19.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -4675,7 +4718,6 @@
 			"version": "19.2.14",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -4703,6 +4745,12 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
 			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/yargs": {
@@ -5016,6 +5064,12 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+			"integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+			"license": "ISC"
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "4.7.0",
@@ -5398,6 +5452,16 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5584,6 +5648,16 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5609,6 +5683,46 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/chokidar": {
@@ -5754,6 +5868,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -6047,7 +6171,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -6073,6 +6196,19 @@
 			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
 			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"license": "MIT"
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/dedent": {
 			"version": "1.7.2",
@@ -6120,7 +6256,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -6141,6 +6276,19 @@
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
 			"license": "MIT"
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
@@ -6589,6 +6737,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-util-is-identifier-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6654,6 +6812,12 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -7179,6 +7343,46 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-to-jsx-runtime": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -7198,6 +7402,16 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/html-url-attributes": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+			"integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/http-parser-js": {
 			"version": "0.5.10",
@@ -7349,6 +7563,12 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
+		},
 		"node_modules/internmap": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -7356,6 +7576,30 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-arrayish": {
@@ -7392,6 +7636,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -7436,6 +7690,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7444,6 +7708,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -8747,6 +9023,16 @@
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8835,6 +9121,16 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"node_modules/markdown-table": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8843,6 +9139,288 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-gfm-autolink-literal": "^2.0.0",
+				"mdast-util-gfm-footnote": "^2.0.0",
+				"mdast-util-gfm-strikethrough": "^2.0.0",
+				"mdast-util-gfm-table": "^2.0.0",
+				"mdast-util-gfm-task-list-item": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-autolink-literal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"micromark-util-character": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-strikethrough": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"markdown-table": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-task-list-item": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-expression": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-jsx": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"parse-entities": "^4.0.0",
+				"stringify-entities": "^4.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdxjs-esm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -8861,6 +9439,569 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-gfm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-extension-gfm-autolink-literal": "^2.0.0",
+				"micromark-extension-gfm-footnote": "^2.0.0",
+				"micromark-extension-gfm-strikethrough": "^2.0.0",
+				"micromark-extension-gfm-table": "^2.0.0",
+				"micromark-extension-gfm-tagfilter": "^2.0.0",
+				"micromark-extension-gfm-task-list-item": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-strikethrough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-tagfilter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-task-list-item": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -8961,7 +10102,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
@@ -9170,6 +10310,31 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/parse-entities/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
 		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
@@ -9603,6 +10768,16 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
 		},
+		"node_modules/property-information": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+			"integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
@@ -9723,6 +10898,33 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "*"
+			}
+		},
+		"node_modules/react-markdown": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+			"integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"html-url-attributes": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"@types/react": ">=18",
+				"react": ">=18"
 			}
 		},
 		"node_modules/react-refresh": {
@@ -9946,6 +11148,72 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/remark-gfm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-gfm": "^3.0.0",
+				"micromark-extension-gfm": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-rehype": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+			"integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/require-directory": {
@@ -10249,6 +11517,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10307,6 +11585,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -10363,6 +11655,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
 			}
 		},
 		"node_modules/sucrase": {
@@ -10620,6 +11930,26 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/ts-api-utils": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -10819,6 +12149,93 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"license": "MIT"
 		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -10961,6 +12378,34 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/victory-vendor": {
 			"version": "36.9.2",
@@ -11369,6 +12814,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"packages/shared": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5",
 		"react-icons": "^5.6.0",
+		"react-markdown": "^10.1.0",
 		"react-router-dom": "^7.14.2",
 		"recharts": "^2.15.4",
+		"remark-gfm": "^4.0.1",
 		"tailwind-merge": "^2.6.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- Expand Random notes from one note to up to five notes with add/delete and autosave support.
- Add editor/markdown modes with a rendered markdown preview and bottom note tray layout.
- Fix the duplicate close button in the recurring transaction modal.
- Clarify optional transaction export filters and add reset behavior.

## Validation

- `npm test`
- `npm run build:desktop`
- `cd apps/desktop && npx tsc -p tsconfig.app.json`
- `git diff --check`

## Notes

- Import behavior is unchanged.
- The PR includes `react-markdown` and `remark-gfm` for markdown preview rendering.